### PR TITLE
EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo utils)

### DIFF
--- a/c-utils/src/cortx/m0common.c
+++ b/c-utils/src/cortx/m0common.c
@@ -25,6 +25,7 @@
 #include "m0common.h"
 #include <common/log.h>
 #include <debug.h> /* dassert */
+#include "perf/tsdb.h" /*  is_engine_on */
 
 /* To be passed as argument */
 struct m0_realm     motr_uber_realm;
@@ -233,6 +234,7 @@ int init_motr(void)
 	motr_conf.mc_idx_service_id	= M0_IDX_DIX;
 	dix_conf.kc_create_meta		= false;
 	motr_conf.mc_idx_service_conf	= &dix_conf;
+	motr_conf.mc_is_addb_init	= tsdb_is_engine_on();
 
 	/* Create Motr instance */
 	rc = m0_client_init(&motr_instance, &motr_conf, true);

--- a/c-utils/src/cortx/m0kvs.c
+++ b/c-utils/src/cortx/m0kvs.c
@@ -22,6 +22,7 @@
 #include "addb2/global.h" /* global_leave */
 #include "common/log.h"
 #include <debug.h>
+#include "perf/tsdb.h"
 
 int m0kvs_reinit(void)
 {
@@ -40,6 +41,9 @@ void m0kvs_do_init(void)
 	}
 
 	log_config();
+
+	/* TODO: Create a config file parameter. */
+	tsdb_init(true, true);
 
 	rc = init_motr();
 	assert(rc == 0);

--- a/c-utils/src/include/perf/perf-counters.h
+++ b/c-utils/src/include/perf/perf-counters.h
@@ -30,6 +30,7 @@ enum perfc_subtags {
 	PERFC_EE_OP_PUSH = 0x1,
 	PERFC_EE_OP_POP = 0x2,
 	PERFC_MAP = 0xF,
+	PERFC_ACTION  = 0xA,
 };
 
 /** Creates a unique id for a function (or any other "action"). */
@@ -50,10 +51,8 @@ enum perfc_subtags {
  *	__call - Call ID (generated).
  *	__VA_ARGS_ - Optional arguments.
  */
-#define PERFC_OP_EE(__mod, __fn, __call, __ee_type, ...)			\
-	TSDB_ADD(TSDB_MK_AID(__mod, __fn), __ee_type , __call,	\
-		 __VA_ARGS__)
-
+#define PERFC_OP_EE(__mod, __fn, __call, __ee_type, ...)	\
+	TSDB_ADD(TSDB_MK_AID(__mod, __fn), __call, __ee_type, __VA_ARGS__)
 
 /* Format of mappings :
  * | <AID> | MAP | <Call ID> | <MAP-ID> | <EXTERNAL-ID> |
@@ -69,14 +68,30 @@ enum perfc_subtags {
  */
 
 #define PERFC_MAP(__mod_id, __fn, __call, __map_id, __ext_id, ...) \
-	TSDB_ADD(TSDB_MK_AID(__mod_id, __fn), PERFC_MAP,  __call, \
+	TSDB_ADD(TSDB_MK_AID(__mod_id, __fn), __call, PERFC_MAP, \
 		 __map_id, __ext_id, __VA_ARGS__)
 
+/* Format of action id and map w/ op :
+ * | <OP Tuple> | <Action tuple> |
+ * where
+ * 	OP Tuple:
+ * 		TSDB_MK_AID(__mod_id, __fn) + Call ID
+ * 		Call ID - id the particular call to AID
+ * 	Action tuple:
+ * 		TSDB_MK_AID(__mod_id, __act_tag)
+ */
+
+#define PERFC_ACTION_OP_MAP(__mod_id, __fn, __call, __act_tag, ...) \
+	TSDB_ADD(TSDB_MK_AID(__mod_id, __fn), __call, \
+	TSDB_MK_AID(__mod_id, __act_tag), PERFC_ACTION, __VA_ARGS__)
 
 /* TODO: move it into submodules */
 
 enum perfc_cfs {
-	PERFC_CFS_MKDIR,
+	PERFC_CFS_MKDIR_BEGIN,
+	PERFC_CFS_MKDIR_END,
+	PERFC_CFS_WRITE_BEGIN,
+	PERFC_CFS_WRITE_END,
 };
 
 enum perfc_nsal {


### PR DESCRIPTION
# EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo utils)

## Solution Overview
Change description:
                1) Pickup Ivan's changes from https://github.com/Seagate/cortx-posix/pull/233
                   & modify and update according to the proposed changes in EOS-12313 (https://jts.seagate.com/browse/EOS-8892)
                2) Introduce new performance counters and action maps as described in EOS-12313
                3) Update kvsfs_write2 to use the new performance counters## Checklist

- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Associated commit info from private branch EOS-12313
        commit af8519b05cbe006bd075346fdfffef01d334f437
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Thu Sep 10 17:06:37 2020 -0600

        EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo utils)

        List of added/modified/deleted files:
                modified:   c-utils/src/cortx/m0common.c
                modified:   c-utils/src/cortx/m0kvs.c
                modified:   c-utils/src/include/operation.h
                modified:   c-utils/src/include/perf/perf-counters.h

        Change description:
                1) Pickup Ivan's changes from https://github.com/Seagate/cortx-posix/pull/233
                        & modify and update according to the proposed changes in EOS-12313
                2) Introduce new performance counters and action maps as described in EOS-12313
                3) Update kvsfs_write2 to use the new performance counters

        Unit test (on LABVM):
                With ENABLE_TSDB_ADDB on, single node nfs IO (write) test and verify TSDB traces using m0addb2dump
                Compile and run UT with and without ENABLE_TSDB_ADDB

    O/P:
    * 2020-09-10-17:05:22.308899982            24001 ?               5?, ?               b?
    * 2020-09-10-17:05:22.308915847            24001 ?               5?, ?           24002?, ?               a?, ?               1?, ?               0?
    * 2020-09-10-17:05:22.317921816            24001 ?               5?, ?           24003?, ?               a?, ?               0?, ?               0?
    * 2020-09-10-17:05:22.317944557            24001 ?               5?, ?               e?
    * 2020-09-10-17:05:22.746529797            24001 ?               e?, ?               b?
    * 2020-09-10-17:05:22.746546233            24001 ?               e?, ?           24002?, ?               a?, ?               1?, ?               0?
    * 2020-09-10-17:05:22.756376965            24001 ?               e?, ?           24003?, ?               a?, ?               0?, ?               0?
    * 2020-09-10-17:05:22.756401295            24001 ?               e?, ?               e?
