### PR TITLE
EOS-13238 : Changes made for contentious term hack

### DIFF
--- a/c-utils/src/cortx/m0common.c
+++ b/c-utils/src/cortx/m0common.c
@@ -128,7 +128,7 @@ int m0init(struct collection_item *cfg_items)
 
 	/* Important note:
 	 * The autoshun key should be registered before
-	 * initializing M0. The autoshun-key hack relies on
+	 * initializing M0. The autoshun-key (a temporary workaround) relies on
 	 * the internal representation of POSIX TLS in the glibc.
 	 */
 	(void) pthread_once(&autoshun_key_init_once, autoshun_key_init);


### PR DESCRIPTION
Hack changed to Temporary Fix

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

### Unit Testing

> sudo ./scripts/test.sh
>  --
>  --
> Configuration Completed
> Clean indexes prepared
> NSAL Unit tests
> NS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Iterator test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 2
> Tests passed = 2
> Tests failed = 0
> 
> KVTree test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 17
> Tests passed = 17
> Tests failed = 0
> 
> CORTXFS Unit tests
> Endpoint ops Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
> Total tests  = 4
> Tests passed = 4
> Tests failed = 0
> 
> FS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Directory tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 12
> Tests passed = 12
> Tests failed = 0
> 
> File creation tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Link Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 6
> Tests passed = 6
> Tests failed = 0
> 
> Rename tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Attribute Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Xattr file Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
> Total tests  = 9
> Tests passed = 9
> Tests failed = 0
> 
> Xattr dir Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
> Total tests  = 9
> Tests passed = 9
> Tests failed = 0
> 
> IO tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 6
> Tests passed = 6
> Tests failed = 0
> 
> 