### PR TITLE
EOS-8896: NFS ADDB: NFS-only tracepoints for READ (patch for repo utils)

### DIFF
--- a/c-utils/src/include/perf/perf-counters.h
+++ b/c-utils/src/include/perf/perf-counters.h
@@ -88,10 +88,21 @@ enum perfc_subtags {
 /* TODO: move it into submodules */
 
 enum perfc_cfs {
+	PERFC_CFS_START, /** valid counters must be greater than this value */
 	PERFC_CFS_MKDIR_BEGIN,
 	PERFC_CFS_MKDIR_END,
 	PERFC_CFS_WRITE_BEGIN,
 	PERFC_CFS_WRITE_END,
+	PERFC_CFS_READ_BEGIN,
+	PERFC_CFS_READ_END,
+	PERFC_CFS_OPEN_BEGIN,
+	PERFC_CFS_OPEN_END,
+	PERFC_CFS_LOOKUP_BEGIN,
+	PERFC_CFS_LOOKUP_END,
+	PERFC_CFS_READDIR_BEGIN,
+	PERFC_CFS_READDIR_END,
+	/** TODO: Add future counters here */
+	PERFC_CFS_END /** valid counters must be less than this value  */
 };
 
 enum perfc_nsal {


### PR DESCRIPTION
# EOS-8896: NFS ADDB: NFS-only tracepoints for READ (patch for repo utils)

## Solution Overview
Change description:
               Add nfs action performance counters for: read, mkdir, lookup, readdir and open

## Note: This is based on the previous changes on branch EOS-12313, this change can be merged to dev only after EOS-12313's changes are merged to dev.

- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Associated commit info from private branch EOS-8896
         commit ccc09ec9de61ca217cfeb8e549b01efcf9eb252f
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Mon Sep 14 15:03:50 2020 -0600

        EOS-8896: NFS ADDB: NFS-only tracepoints for READ (patch for repo utils)

        List of added/modified/deleted files:
                modified:   c-utils/src/include/perf/perf-counters.h

        Change description:
                Add nfs action performance counters for: read, mkdir, lookup, readdir and open

        Unit test (on LABVM):
                With ENABLE_TSDB_ADDB on, single node nfs IO test and verify TSDB traces using m0addb2dump
                Compile and run UT with and without ENABLE_TSDB_ADDB
                Note: For less frequent NFS transactions, looks like addb does not record tsdb traces
        O/P:
    * 2020-09-14-14:59:32.520382065            24006 ?               5?, ?               b?
    * 2020-09-14-14:59:32.520392823            24006 ?               5?, ?           24009?, ?               a?
    * 2020-09-14-14:59:32.521576159            24006 ?               5?, ?           2400a?, ?               a?, ?               2?, ?fffffffffffffffe?
    * 2020-09-14-14:59:32.521599573            24006 ?               5?, ?               e?
    * 2020-09-14-14:59:32.521608027            24003 ?               6?, ?               b?
    * 2020-09-14-14:59:32.521624541            24003 ?               6?, ?           24007?, ?               a?, ?              42?, ?               1?, ?ffffffffff
    * 2020-09-14-14:59:32.549762565            24003 ?               6?, ?           24008?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:32.549769974            24003 ?               6?, ?               e?
    * 2020-09-14-14:59:32.752092904            24001 ?               e?, ?               b?
    * 2020-09-14-14:59:32.752109545            24001 ?               e?, ?           24003?, ?               a?, ?               1?, ?               0?, ?
    * 2020-09-14-14:59:32.763000306            24001 ?               e?, ?           24004?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:32.763024790            24001 ?               e?, ?               e?
    * 2020-09-14-14:59:33.055746901            24006 ?              1b?, ?               b?
    * 2020-09-14-14:59:33.055754236            24006 ?              1b?, ?           24009?, ?               a?
    * 2020-09-14-14:59:33.056941622            24006 ?              1b?, ?           2400a?, ?               a?, ?               2?, ?fffffffffffffffe?
    * 2020-09-14-14:59:33.056963203            24006 ?              1b?, ?               e?
    * 2020-09-14-14:59:33.059241362            24003 ?              1c?, ?               b?
    * 2020-09-14-14:59:33.059273851            24003 ?              1c?, ?           24007?, ?               a?, ?              42?, ?               1?, ?
    * 2020-09-14-14:59:33.081606351            24003 ?              1c?, ?           24008?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:33.081613351            24003 ?              1c?, ?               e?
    * 2020-09-14-14:59:33.622803295            24001 ?              32?, ?               b?
    * 2020-09-14-14:59:33.622820700            24001 ?              32?, ?           24003?, ?               a?, ?               1?, ?               0?, ?
    * 2020-09-14-14:59:33.633842549            24001 ?              32?, ?           24004?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:33.633875155            24001 ?              32?, ?               e?
    * 2020-09-14-14:59:34.113216214            24002 ?              3e?, ?               b?
    * 2020-09-14-14:59:34.113233267            24002 ?              3e?, ?           24005?, ?               a?, ?               0?, ?               1?, ?
    * 2020-09-14-14:59:34.147894729            24002 ?              3e?, ?           24006?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:34.148114138            24002 ?              3e?, ?               e?
    * 2020-09-14-14:59:34.300827585            24006 ?              51?, ?               b?
    * 2020-09-14-14:59:34.300835030            24006 ?              51?, ?           24009?, ?               a?
    * 2020-09-14-14:59:34.302834913            24006 ?              51?, ?           2400a?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:34.302842541            24006 ?              51?, ?               e?
    * 2020-09-14-14:59:34.302857128            24003 ?              52?, ?               b?
    * 2020-09-14-14:59:34.302872435            24003 ?              52?, ?           24007?, ?               a?, ?               1?, ?               0?, ?
    * 2020-09-14-14:59:34.303856133            24003 ?              52?, ?           24008?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:34.303878190            24003 ?              52?, ?               e?
    * 2020-09-14-14:59:34.373624383            24002 ?              5b?, ?               b?
    * 2020-09-14-14:59:34.373648252            24002 ?              5b?, ?           24005?, ?               a?, ?               0?, ?               1?, ?
    * 2020-09-14-14:59:34.379810818            24002 ?              5b?, ?           24006?, ?               a?, ?               0?, ?               0?
    * 2020-09-14-14:59:34.379858738            24002 ?              5b?, ?               e?
