### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-utils

### DIFF
--- a/c-utils/scripts/build.sh
+++ b/c-utils/scripts/build.sh
@@ -28,9 +28,8 @@ CORTX_UTILS_VERSION=${CORTX_UTILS_VERSION:-"$(cat $CORTX_UTILS_SOURCE_ROOT/VERSI
 
 
 # Select CORTX-UTILS Build Version.
-# Superproject: derived from cortx-utils version.
-# Local: taken from git rev.
-CORTX_UTILS_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of cortx-utils repo.
+CORTX_UTILS_BUILD_VERSION=$(git -C $CORTX_UTILS_SOURCE_ROOT rev-parse --short HEAD)
 
 ###############################################################################
 # Local variables


### PR DESCRIPTION
## Problem Statement:
https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-utils

## Problem Description:
When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.
```
git -C <path_to_git_repo> rev-parse --short HEAD
```

## Tests
before fix:
```
cortx-utils-debuginfo-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-utils-devel-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-utils-1.0.0-7e45dd6.el7.x86_64.rpm
```
after fix:
```
cortx-utils-debuginfo-1.0.0-fbf65b9.el7.x86_64.rpm
cortx-utils-devel-1.0.0-fbf65b9.el7.x86_64.rpm
cortx-utils-1.0.0-fbf65b9.el7.x86_64.rpm
```
## Companion PRs
https://github.com/Seagate/cortx-nsal/pull/5
https://github.com/Seagate/cortx-dsal/pull/11
https://github.com/Seagate/cortx-fs/pull/7
https://github.com/Seagate/cortx-fs-ganesha/pull/11