### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-utils using git-dir

### DIFF
--- a/c-utils/scripts/build.sh
+++ b/c-utils/scripts/build.sh
@@ -28,9 +28,9 @@ CORTX_UTILS_VERSION=${CORTX_UTILS_VERSION:-"$(cat $CORTX_UTILS_SOURCE_ROOT/VERSI
 
 
 # Select CORTX-UTILS Build Version.
-# Superproject: derived from cortx-utils version.
-# Local: taken from git rev.
-CORTX_UTILS_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of UTILS repo
+GIT_DIR="$CORTX_UTILS_SOURCE_ROOT/../.git"
+CORTX_UTILS_BUILD_VERSION="$(git --git-dir "$GIT_DIR" rev-parse --short HEAD)"
 
 ###############################################################################
 # Local variables


### PR DESCRIPTION
## Problem Statement:

https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-dsal

## Problem Description:

The previous solution only worked for git version higher than 1.8.5.
This solution works for git version 1.8.3. However, this solution is a bit tricky as we need to specify the `.git` explicitly.

When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.

```
git --git-dir <path_to_git_repo>/.git rev-parse --short HEAD
```

## Tests
Before fix:
```
cortx-utils-debuginfo-1.0.0-1c32ae1.el7.x86_64.rpm
cortx-utils-devel-1.0.0-1c32ae1.el7.x86_64.rpm
cortx-utils-1.0.0-1c32ae1.el7.x86_64.rpm
```
After fix:
```
cortx-utils-debuginfo-1.0.0-02f2655.el7.x86_64.rpm
cortx-utils-devel-1.0.0-02f2655.el7.x86_64.rpm
cortx-utils-1.0.0-02f2655.el7.x86_64.rpm
```
## Companion PRs
https://github.com/Seagate/cortx-nsal/pull/7