### PR TITLE
EOS-13013 reverted primary to master in py-utils

### DIFF
--- a/py-utils/docs/ha/ha_script/pcs.sh.sample
+++ b/py-utils/docs/ha/ha_script/pcs.sh.sample
@@ -27,7 +27,7 @@ pcs -f cortxcluster_cfg resource create RabbitMQ systemd:rabbitmq-server  meta f
 pcs -f cortxcluster_cfg resource clone RabbitMQ clone-max=2 clone-node-max=1 
 
 pcs -f cortxcluster_cfg resource create Sspl systemd:sspl  meta failure-timeout=10s op monitor timeout=10s interval=10s op start timeout=10s op stop timeout=10s
-pcs -f cortxcluster_cfg resource clone Sspl clone-max=2 clone-node-max=1 primary-max=1 primary-node-max=1 
+pcs -f cortxcluster_cfg resource clone Sspl clone-max=2 clone-node-max=1 master-max=1 master-node-max=1 
 
 pcs -f cortxcluster_cfg resource create Statsd systemd:stats  meta failure-timeout=10s op monitor timeout=10s interval=10s op start timeout=10s op stop timeout=10s
 pcs -f cortxcluster_cfg resource clone Statsd clone-max=2 clone-node-max=1 

--- a/py-utils/docs/ha/ha_script/pcs.sh.sample
+++ b/py-utils/docs/ha/ha_script/pcs.sh.sample
@@ -27,6 +27,7 @@ pcs -f cortxcluster_cfg resource create RabbitMQ systemd:rabbitmq-server  meta f
 pcs -f cortxcluster_cfg resource clone RabbitMQ clone-max=2 clone-node-max=1 
 
 pcs -f cortxcluster_cfg resource create Sspl systemd:sspl  meta failure-timeout=10s op monitor timeout=10s interval=10s op start timeout=10s op stop timeout=10s
+# created ticket for pcs https://bugs.clusterlabs.org/show_bug.cgi?id=5437
 pcs -f cortxcluster_cfg resource clone Sspl clone-max=2 clone-node-max=1 master-max=1 master-node-max=1 
 
 pcs -f cortxcluster_cfg resource create Statsd systemd:stats  meta failure-timeout=10s op monitor timeout=10s interval=10s op start timeout=10s op stop timeout=10s

--- a/py-utils/src/utils/ha/hac/generate.py
+++ b/py-utils/src/utils/ha/hac/generate.py
@@ -149,9 +149,9 @@ class PCSGenerator(Generator):
             "pcs -f $cluster_cfg resource clone $resource "+
             "clone-max=$clone_max clone-node-max=$clone_node_max $param")
         self._primary_secondary = Template("echo $$pcs_status | grep -q $resource || "+
-            "pcs -f $cluster_cfg resource primary $primary "+
+            "pcs -f $cluster_cfg resource master $primary "+
             "$resource clone-max=$clone_max clone-node-max=$clone_node_max "+
-            "primary-max=$primary_max primary-node-max=$primary_node_max $param")
+            "master-max=$primary_max master-node-max=$primary_node_max $param")
         self._location = Template("echo $$pcs_location | grep -q $resource || "+
             "pcs -f $cluster_cfg constraint location $resource prefers $node=$score")
         self._order = Template("echo $$pcs_status | grep -q 'start $res1 then start $res2' || "+

--- a/py-utils/src/utils/ha/hac/generate.py
+++ b/py-utils/src/utils/ha/hac/generate.py
@@ -148,6 +148,9 @@ class PCSGenerator(Generator):
         self._active_active = Template("echo $$pcs_status | grep -q $resource || "+
             "pcs -f $cluster_cfg resource clone $resource "+
             "clone-max=$clone_max clone-node-max=$clone_node_max $param")
+        """
+        Created ticket for pcs https://bugs.clusterlabs.org/show_bug.cgi?id=5437
+        """
         self._primary_secondary = Template("echo $$pcs_status | grep -q $resource || "+
             "pcs -f $cluster_cfg resource master $primary "+
             "$resource clone-max=$clone_max clone-node-max=$clone_node_max "+


### PR DESCRIPTION
## Problem Statement
<pre>
Cannot change pcs command line parameter master to primary
</pre>
## Unit testing on RPM done
<pre>
Not done
</pre>
## Problem Description
<pre>
Found problem in review, https://github.com/Seagate/cortx-py-utils/commit/c85243149959178189bb7a681c4b812497e64e8c#r42512233
</pre>
## Solution
<pre>
Reverted pcs parameter back to master which was changed to primary.
</pre>
## Unit Test Cases
<pre>
NA
</pre>






Signed-off-by: Naval Patel <naval.patel@seagate.com>