### PR TITLE
EOS-12314: [Spike] Design TLS-based context propagation for Operation API

### DIFF
--- a/c-utils/src/common/perfc.c
+++ b/c-utils/src/common/perfc.c
@@ -19,4 +19,4 @@
  
 #include "perf/tsdb.h"
 
-uint64_t perfc_id_gen = 0;
+uint64_t perfc_id_gen = 1;

--- a/c-utils/src/include/operation.h
+++ b/c-utils/src/include/operation.h
@@ -336,7 +336,7 @@ static inline struct opcall *opstack_caller(struct opstack *opstack)
  */
 enum tsdb_modules {
 	/* A list of well-known modules */
-	TSDB_MOD_FSUSER,
+	TSDB_MOD_FSUSER = 1,
 	TSDB_MOD_UT,
 	TSDB_MOD_LAST = TSDB_MOD_UT,
 


### PR DESCRIPTION
# EOS-12314: [Spike] Design TLS-based context propagation for Operation API

## Solution Overview
Change description:
               Introduce new TLS based performance counters and associated APIs as described in EOS-13398 and in the HLD's appendix section

## Note: This is based on the previous changes on branch EOS-13398 which is still under review, hence this merge request is posted against the private branch EOS-13398 instead of main, once the changes for EOS-13398 are merged to main, this can also be merged to main.

- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Associated commit info from private branch EOS-12314
        commit d58cd8336170d215cdc7303d07fb60a0d7555968
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Wed Sep 23 03:43:41 2020 -0600

        EOS-12314: [Spike] Design TLS-based context propagation for Operation API

            List of added/modified/deleted files:
                    modified:   c-utils/src/include/perf/perf-counters.h
                modified:   c-utils/src/common/perfc.c
                modified:   c-utils/src/include/operation.h

            Change description:
                    Introduce new TLS based performance counters and associated APIs as described in EOS-13398 and in the HLD's appendix section

            Unit test (on LABVM):
                    Compile and run UT with and without ENABLE_TSDB_ADDB
                    erf. unit test with changes integrated from read handler (EOS-8896)
