### PR TITLE
EOS-13398: Re-structure Cortx-FS perfr counters format - v2

### DIFF
--- a/c-utils/src/common/CMakeLists.txt
+++ b/c-utils/src/common/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.6.3)
 SET(COMMON_UTILS_SRCS
 	utils.c
 	str.c
+	perfc.c
 )
 
 add_library(utils-common OBJECT

--- a/c-utils/src/common/perfc.c
+++ b/c-utils/src/common/perfc.c
@@ -1,0 +1,22 @@
+/*
+ * Filename:	perfc.c
+ * Description:	This module implements performance counters based on TSDB.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+ 
+#include "perf/perf-counters.h"
+
+uint64_t perfc_id_gen = PERFC_INVALID_ID;

--- a/c-utils/src/cortx/m0common.c
+++ b/c-utils/src/cortx/m0common.c
@@ -25,6 +25,7 @@
 #include "m0common.h"
 #include <common/log.h>
 #include <debug.h> /* dassert */
+#include "perf/tsdb.h" /* is_engine_on */
 
 /* To be passed as argument */
 struct m0_realm     motr_uber_realm;
@@ -233,6 +234,7 @@ int init_motr(void)
 	motr_conf.mc_idx_service_id	= M0_IDX_DIX;
 	dix_conf.kc_create_meta		= false;
 	motr_conf.mc_idx_service_conf	= &dix_conf;
+	motr_conf.mc_is_addb_init	= tsdb_is_engine_on();
 
 	/* Create Motr instance */
 	rc = m0_client_init(&motr_instance, &motr_conf, true);

--- a/c-utils/src/cortx/m0kvs.c
+++ b/c-utils/src/cortx/m0kvs.c
@@ -22,6 +22,7 @@
 #include "addb2/global.h" /* global_leave */
 #include "common/log.h"
 #include <debug.h>
+#include "perf/tsdb.h"
 
 int m0kvs_reinit(void)
 {
@@ -40,6 +41,9 @@ void m0kvs_do_init(void)
 	}
 
 	log_config();
+
+	/*  TODO: Create a config file parameter. */
+	tsdb_init(true, true);
 
 	rc = init_motr();
 	assert(rc == 0);

--- a/c-utils/src/include/operation.h
+++ b/c-utils/src/include/operation.h
@@ -336,11 +336,7 @@ static inline struct opcall *opstack_caller(struct opstack *opstack)
  */
 enum tsdb_modules {
 	/* A list of well-known modules */
-	TSDB_MOD_UTILS = 0,
-	TSDB_MOD_DSAL,
-	TSDB_MOD_NSAL,
-	TSDB_MOD_FS,
-	TSDB_MOD_FSUSER,
+	TSDB_MOD_FSUSER = 1,
 	TSDB_MOD_UT,
 	TSDB_MOD_LAST = TSDB_MOD_UT,
 

--- a/c-utils/src/test/perf/perf-manual-test.c
+++ b/c-utils/src/test/perf/perf-manual-test.c
@@ -25,6 +25,8 @@
 #include "operation.h"
 #include <assert.h>
 
+uint64_t perfc_id_gen = PERFC_INVALID_ID;
+
 static
 void tsdb_run_manual_test(void)
 {
@@ -212,11 +214,48 @@ void opcall_run_manual_test(void)
 	}
 }
 
+static
+void perfc_run_manual_test(void)
+{
+	uint64_t opid = perf_id_gen();
+
+	enum perfc_function_tags {
+		PFT_START,
+		PFT_UT_A,
+		PFT_UT_B,
+		PFT_END
+	};
+
+	enum perfc_entity_attrs {
+		PEA_START,
+		PEA_UT_A_ARG_1,
+		PEA_UT_B_ARG_2,
+		PEA_END
+	};
+
+	enum perfc_entity_maps {
+		PEM_START,
+		PEM_UT_A_TO_B,
+		PEM_UT_B_TO_A,
+		PEM_END
+	};
+
+	(void) tsdb_init(true, true);
+	tsdb_set_rt_state(true);
+	PERFC_STATE_V2(TSDB_MOD_UT, PFT_UT_A, opid, PES_GEN_INIT);
+	PERFC_ATTR_V2(TSDB_MOD_UT, PFT_UT_A, opid, PEA_UT_A_ARG_1, 0xAB);
+	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid, 0xAB);
+	tsdb_fini();
+}
+
+
 int main(void)
 {
 	printf("TSDB manual tests:\n");
 	tsdb_run_manual_test();
 	printf("OPCALL manual tests :\n");
 	opcall_run_manual_test();
+	printf("Performance counters V2 tests :\n");
+	perfc_run_manual_test();
 	return 0;
 }


### PR DESCRIPTION
# EOS-13398: Re-structure Cortx-FS perfr counters format - v2

## Solution Overview
Introduce new performance counters and action maps as described in EOS-13398 and in the HLD's appendix section and update unit test
               
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Associated commit info from private branch EOS-13398
        commit 0afb4d0ac4f683b209584c0cdd26cabba715aa4d
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Tue Sep 22 17:05:44 2020 -0600

        EOS-13398: Re-structure Cortx-FS perfr counters format - v2

        List of added/modified/deleted files:
                modified:   c-utils/src/common/CMakeLists.txt
                new file:   c-utils/src/common/perfc.c
                modified:   c-utils/src/cortx/m0common.c
                modified:   c-utils/src/cortx/m0kvs.c
                modified:   c-utils/src/include/operation.h
                modified:   c-utils/src/include/perf/perf-counters.h
                modified:   c-utils/src/test/perf/perf-manual-test.c

        Change description:
                Introduce new performance counters and action maps as described in EOS-13398 and in the HLD's appendix section and update unit test

        Unit test (on LABVM):
                Compile and run UT with and without ENABLE_TSDB_ADDB
                    perf. unit test o/p:
                        Performance counters V2 tests :
                        TSDB::add: ID=20ab, 1, 1, 1, 1;
                        TSDB::add: ID=20cd, 1, 2, 1, 1, ab;
                        TSDB::add: ID=20ef, 1, 3, 1, ab;
