### PR TITLE
EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo utils)

### DIFF
--- a/c-utils/src/common/perfc.c
+++ b/c-utils/src/common/perfc.c
@@ -20,3 +20,5 @@
 #include "perf/perf-counters.h"
 
 uint64_t perfc_id_gen = PERFC_INVALID_ID;
+
+pthread_key_t perfc_tls_key;

--- a/c-utils/src/test/perf/perf-manual-test.c
+++ b/c-utils/src/test/perf/perf-manual-test.c
@@ -244,7 +244,7 @@ void perfc_run_manual_test(void)
 	tsdb_set_rt_state(true);
 	PERFC_STATE_V2(TSDB_MOD_UT, PFT_UT_A, opid, PES_GEN_INIT);
 	PERFC_ATTR_V2(TSDB_MOD_UT, PFT_UT_A, opid, PEA_UT_A_ARG_1, 0xAB);
-	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid, 0xAB);
+	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid+1, opid, 0xAB);
 	tsdb_fini();
 }
 


### PR DESCRIPTION
# EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo utils)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
        commit d3ebfc398554cf556220f9deb8fec60ee3e0d8b7
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Tue Sep 29 02:12:50 2020 -0600

        EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo utils)
        List of modified files:
                modified:   c-utils/src/common/perfc.c
                modified:   c-utils/src/include/perf/perf-counters.h
                modified:   c-utils/src/test/perf/perf-manual-test.c
        Change description:
                Add new performance counters and integrate them further with other modules using newly added APIs
                Addb APIs integration for read path
        Unit test:
                Compilation with and without ENABLE_TSDB_ADDB flag
                Addb unit test while integrated with read handler
                Regular UTs (both with and without ENABLE_TSDB_ADDB flag)
        addb dump o/p from read handler after integration:
        * 2020-09-29-17:27:47.484505618            210ab ?               1?, ?               1?, ?            5035?, ?               1?
        * 2020-09-29-17:27:47.484506598            210cd ?               1?, ?               2?, ?            5035?, ?               5?, ?               0?
        * 2020-09-29-17:27:47.484507284            210cd ?               1?, ?               2?, ?            5035?, ?               6?, ?               1?
        * 2020-09-29-17:27:47.484508075            210cd ?               1?, ?               2?, ?            5035?, ?               7?, ?            1000?
        * 2020-09-29-17:27:47.484524037            210ab ?               4?, ?               1?, ?            5036?, ?               1?
        * 2020-09-29-17:27:47.484524850            210ef ?               4?, ?               3?, ?               6?, ?            5036?, ?            5035?
        * 2020-09-29-17:27:47.484525701            210cd ?               4?, ?               2?, ?            5036?, ?               a?, ?            1000?
        * 2020-09-29-17:27:47.484526538            210cd ?               4?, ?               2?, ?            5036?, ?               b?, ?               0?
        * 2020-09-29-17:27:47.484528239            210ab ?               2?, ?               1?, ?            5037?, ?               1?
        * 2020-09-29-17:27:47.484528994            210ef ?               2?, ?               3?, ?              10?, ?            5037?, ?            5035?
        * 2020-09-29-17:27:47.484529869            210cd ?               2?, ?               2?, ?            5037?, ?              10?, ?              12?
        * 2020-09-29-17:27:47.484531526            210cd ?               2?, ?               2?, ?            5037?, ?              11?, ?               0?
        * 2020-09-29-17:27:47.484532228            210ab ?               2?, ?               1?, ?            5037?, ?               2?
        * 2020-09-29-17:27:47.484533046            210ab ?               3?, ?               1?, ?            5038?, ?               1?
        * 2020-09-29-17:27:47.484533789            210ef ?               3?, ?               3?, ?              10?, ?            5038?, ?            5035?
        * 2020-09-29-17:27:47.484534649            210cd ?               3?, ?               2?, ?            5038?, ?              17?, ?              12?
        * 2020-09-29-17:27:47.484535507            210cd ?               3?, ?               2?, ?            5038?, ?              18?, ?               0?
        * 2020-09-29-17:27:47.487947750            210cd ?               3?, ?               2?, ?            5038?, ?              19?, ?               0?
        * 2020-09-29-17:27:47.487948775            210ab ?               3?, ?               1?, ?            5038?, ?               2?
