### PR TITLE
EOS-13934 : Addition of CORS http header in response.

### DIFF
--- a/c-utils/src/management/request-handler.c
+++ b/c-utils/src/management/request-handler.c
@@ -168,6 +168,11 @@ void request_send_response(struct request *request,
 	struct json_object *json_resp_obj = NULL;
 
 	http = request->http;
+         
+	/* Set CORS Header  */
+	request_set_out_header(request,
+			       "Access-Control-Allow-Origin",
+			       "*");
 
 	if (request->err_code != 0) {
 		/**


### PR DESCRIPTION
Added "Access-Control-Allow-Origin" header in the http response.

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

Testing done : 

Positive Tests
> LIST fs API
> bash-4.2$ curl -v -X GET "http://localhost:8081/fs" -H  "accept: application/json"
> About to connect() to localhost port 8081 (#0)
> Trying 127.0.0.1...
> Connected to localhost (127.0.0.1) port 8081 (#0)
> GET /fs HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8081
> accept: application/json
>
> HTTP/1.1 200 OK
> Access-Control-Allow-Origin: *
> Content-Type: application/json
> Accept: application/json
> Content-Length: 284
>
> Connection #0 to host localhost left intact
> [ { "fs-name": "fs1", "fs-options": null, "endpoint-options": { "proto": "nfs", "secType": "sys", "Filesystem_id": "192.1", "client": "1", > "clients": "*", "Squash": "no_root_squash", "access_type": "RW", "protocols": "4", "pnfs_enabled": "false", "data_server":  >"10.230.246.225" } } ]
>
> CREATE fs API
>bash-4.2$ curl -v -X PUT "http://localhost:8081/fs" -H  "accept: */*" -H  "Content-Type: application/json" -d " 
>{\"name\":\"testFS\"}"
> About to connect() to localhost port 8081 (#0)
>   Trying 127.0.0.1...
> Connected to localhost (127.0.0.1) port 8081 (#0)
> PUT /fs HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8081
> accept: */*
> Content-Type: application/json
> Content-Length: 17
>
> upload completely sent off: 17 out of 17 bytes
> HTTP/1.1 201 Created
> Access-Control-Allow-Origin: *
> Content-Length:
> Content-Length: 0
> Content-Type: text/plain
>
> Connection #0 to host localhost left intact
>
> DELETE fs API
>bash-4.2$ curl -v -X DELETE "http://localhost:8081/fs/testFS" -H  "accept: */*"
> About to connect() to localhost port 8081 (#0)
>   Trying 127.0.0.1...
> Connected to localhost (127.0.0.1) port 8081 (#0)
> DELETE /fs/testFS HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8081
> accept: */*
>
> HTTP/1.1 200 OK
> Access-Control-Allow-Origin: *
> Content-Length:
> Content-Length: 0
> Content-Type: text/plain
>
> Connection #0 to host localhost left intact

Negative Tests also performed noting just one below :
> DELETE fs API
> bash-4.2$ curl -v -X DELETE "http://localhost:8081/fs/testfs" -H  "accept: */*"
> About to connect() to localhost port 8081 (#0)
>   Trying 127.0.0.1...
> Connected to localhost (127.0.0.1) port 8081 (#0)
> DELETE /fs/testfs HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8081
> accept: */*
>
> HTTP/1.1 404 Not Found
> Access-Control-Allow-Origin: *
> Content-Type: application/json
> Accept: application/json
> Content-Length: 11
>
> Connection #0 to host localhost left intact
