### PR TITLE
EOS-13985:Implement nfs_req.py and hist.py <utils repo>

### DIFF
--- a/c-utils/src/addb/plugin.c
+++ b/c-utils/src/addb/plugin.c
@@ -344,7 +344,8 @@ static struct m0_addb2__id_intrp gs_curr_ids[] = {
             &decode_perfc_function_tags,
             &decode_perfc_entry_type,
             &hex, // operation id
-            &decode_perfc_entity_attrs
+            &decode_perfc_entity_attrs,
+            &hex // attribute val
         }
     },
     {
@@ -353,8 +354,10 @@ static struct m0_addb2__id_intrp gs_curr_ids[] = {
         {
             &decode_perfc_function_tags,
             &decode_perfc_entry_type,
+            &hex, // map name
             &hex, // operation id
-            &hex // mapping with opertation id
+            &hex, // mapping with origin operation id
+            &hex // mapping with caller operation id
         }
     },
 

--- a/c-utils/src/test/perf/perf-manual-test.c
+++ b/c-utils/src/test/perf/perf-manual-test.c
@@ -244,7 +244,7 @@ void perfc_run_manual_test(void)
 	tsdb_set_rt_state(true);
 	PERFC_STATE_V2(TSDB_MOD_UT, PFT_UT_A, opid, PES_GEN_INIT);
 	PERFC_ATTR_V2(TSDB_MOD_UT, PFT_UT_A, opid, PEA_UT_A_ARG_1, 0xAB);
-	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid+1, opid, 0xAB);
+	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid+1, opid, 0xAB, 0xDD);
 	tsdb_fini();
 }
 


### PR DESCRIPTION
# EOS-13985:Implement nfs_req.py and hist.py <cortxfs repo>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
            commit 65c25247aef3e380d092441a87647894ebdf773e
            Author: pratyush-seagate <pratyush.k.khan@seagate.com>
            Date:   Mon Oct 12 17:23:50 2020 -0600

            EOS-13985:Implement nfs_req.py and hist.py <Part 1, utils repo>
            List of modified files:
                modified:   c-utils/src/addb/plugin.c
                modified:   c-utils/src/include/perf/perf-counters.h
                modified:   c-utils/src/test/perf/perf-manual-test.c
            Change description:
                This repo's change is to track the operation id of immediate callers in map performance counters which will be used by addb2db_cortxfs.py. Thi
            Unit test:
                    Run NFS READ IO test, generate DB from addb2db_cortxfs.py, use that DB to generate a png file which shows call graph constructed from that
            TODO: Implement timeline and histogram tools
            The generate graph image along with DB file and raw dump files are saved at: /home/751521/JIRA/EOS-13985
                    [root@ssc-vm-c-0040 /]# python3 /root/cortxfs_req.py -d ./cortxfs_perfc_demo_decoded_1.db 0x537B -o graph
                    Creating cortxfs performance call graphs for fsal_op_id 21371, from db file ./cortxfs_perfc_demo_decoded_1.db, o/p graph png file graph
                    Graph render completed
