### PR TITLE
EOS-14340: cortx-py-utils rpm installation does not install dependencies

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -25,7 +25,7 @@ python3 setup.py bdist_wheel
 ```
 setup.py is also able to build RPMs. Run
 ```bash
-python3 setup.py bdist_rpm
+python3.6 setup.py bdist_rpm --post-install utils-post-install --pre-uninstall utils-pre-uninstall
 ```
 ## Installation
 Use pip and the wheel file to install the package. E.g.

--- a/py-utils/requirements.txt
+++ b/py-utils/requirements.txt
@@ -1,0 +1,14 @@
+aiohttp==3.6.1
+elasticsearch-dsl==6.4.0
+python-consul==1.1.0
+schematics==2.1.0
+toml==0.10.0
+cryptography==2.8
+PyYAML==5.1.2
+configparser==4.0.2
+networkx==2.4
+matplotlib==3.1.3
+argparse==1.4.0
+confluent-kafka==1.5.0
+python-crontab==2.5.1
+elasticsearch==6.8.1

--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+from typing import List
 from setuptools import setup
 
 SPEC_DIR = "src/utils/ha/hac/specs/"
@@ -29,6 +30,12 @@ with open('LICENSE', 'r') as lf:
 
 with open('README.md', 'r') as rf:
     long_description = rf.read()
+
+def get_install_requirements() -> List:
+    install_requires = []
+    with open('requirements.txt') as r:
+        install_requires = [line.strip() for line in r]
+    return install_requires
 
 setup(name='cortx-py-utils',
       version='1.0.0',
@@ -60,12 +67,9 @@ setup(name='cortx-py-utils',
         ]
       },
       data_files = [ ('/var/lib/cortx/ha/specs', specs),
-                     ('/var/lib/cortx/ha', ['src/utils/ha/hac/args.yaml', 'src/utils/ha/hac/re_build.sh'])],
+                     ('/var/lib/cortx/ha', ['src/utils/ha/hac/args.yaml', 'src/utils/ha/hac/re_build.sh']),
+                     ('/opt/seagate/cortx/utils/conf', ['requirements.txt'])],
       long_description=long_description,
       zip_safe=False,
       python_requires='>=3.6.8',
-      install_requires=['cryptography==2.8', 'schematics==2.1.0', 'toml==0.10.0',
-                        'PyYAML==5.1.2', 'configparser==4.0.2', 'networkx==2.4',
-                        'matplotlib==3.1.3', 'argparse==1.4.0',
-                        'confluent-kafka==1.5.0', 'python-crontab==2.5.1','elasticsearch==6.8.1',
-                        'elasticsearch-dsl==6.4.0','python-consul==1.1.0', 'aiohttp==3.6.1'])
+      install_requires=get_install_requirements())

--- a/py-utils/utils-post-install
+++ b/py-utils/utils-post-install
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PYTHON=python3.6 
+POST_INSTALL_REQUIREMENTS=/opt/seagate/cortx/utils/conf/requirements.txt
+
+sudo $PYTHON -m pip install -r $POST_INSTALL_REQUIREMENTS

--- a/py-utils/utils-pre-uninstall
+++ b/py-utils/utils-pre-uninstall
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PYTHON=python3.6 
+POST_INSTALL_REQUIREMENTS=/opt/seagate/cortx/utils/conf/requirements.txt
+
+sudo $PYTHON -m pip uninstall --yes -r $POST_INSTALL_REQUIREMENTS


### PR DESCRIPTION
Following packages are required by cortx-py-utils but are not installed as part of
the rpm installation. Components using cortx-py-utils fail due to these
dependencies and require to handle them separately.
```
aiohttp==3.6.1
elasticsearch-dsl==6.4.0
python-consul==1.1.0
schematics==2.1.0
toml==0.10.0
```
Solutions:
- Add  a post install script to install the dependencies.
  This script can be specified to setup.py bdist_rpm command
  as follows,
```
   python3.6 setup.py bdist_rpm --post-install utils-post-install
```
  Built rpm can then be installed along with dependencies,

```
[root@ssc-vm-c-0552 py-utils]# rpm -ivh dist/cortx-py-utils-1.0.0-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:cortx-py-utils-1.0.0-1           ################################# [100%]
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting aiohttp==3.6.1
  Downloading https://files.pythonhosted.org/packages/e0/cb/5fa1d7722488995358d6092a7d2ccceb9011ab78842ccd336fbb5ec0d878/aiohttp-3.6.1-cp36-cp36m-manylinux1_x86_64.whl (1.2MB)
    100% |████████████████████████████████| 1.2MB 711kB/s
Requirement already satisfied: async-timeout<4.0,>=3.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: idna-ssl>=1.0; python_version < "3.7" in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: typing-extensions>=3.6.5; python_version < "3.7" in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: chardet<4.0,>=2.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: yarl<2.0,>=1.0 in /usr/local/lib64/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: multidict<5.0,>=4.5 in /usr/local/lib64/python3.6/site-packages (from aiohttp==3.6.1)
Requirement already satisfied: idna>=2.0 in /usr/local/lib/python3.6/site-packages (from idna-ssl>=1.0; python_version < "3.7"->aiohttp==3.6.1)
Installing collected packages: aiohttp
  Found existing installation: aiohttp 3.6.2
    Uninstalling aiohttp-3.6.2:
      Successfully uninstalled aiohttp-3.6.2
Successfully installed aiohttp-3.6.1
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting elasticsearch-dsl==6.4.0
  Downloading https://files.pythonhosted.org/packages/4f/73/580e648ab72a19c26c815931ce2b2dda67454f557e72ce7ae90fd3b7887d/elasticsearch_dsl-6.4.0-py2.py3-none-any.whl (49kB)
    100% |████████████████████████████████| 51kB 1.0MB/s
Collecting elasticsearch<7.0.0,>=6.0.0 (from elasticsearch-dsl==6.4.0)
  Downloading https://files.pythonhosted.org/packages/78/1b/498aa74c244c5c9d578c1a1a2f16b0db61ac178ec4f1a33d3785f86a052d/elasticsearch-6.8.1-py2.py3-none-any.whl (75kB)
    100% |████████████████████████████████| 81kB 2.6MB/s
Requirement already satisfied: python-dateutil in /usr/local/lib/python3.6/site-packages (from elasticsearch-dsl==6.4.0)
Requirement already satisfied: six in /usr/lib64/python3.6/site-packages (from elasticsearch-dsl==6.4.0)
Requirement already satisfied: urllib3>=1.21.1 in /usr/local/lib/python3.6/site-packages (from elasticsearch<7.0.0,>=6.0.0->elasticsearch-dsl==6.4.0)
Installing collected packages: elasticsearch, elasticsearch-dsl
  Found existing installation: elasticsearch 7.9.1
    Uninstalling elasticsearch-7.9.1:
      Successfully uninstalled elasticsearch-7.9.1
  Found existing installation: elasticsearch-dsl 7.3.0
    Uninstalling elasticsearch-dsl-7.3.0:
      Successfully uninstalled elasticsearch-dsl-7.3.0
Successfully installed elasticsearch-6.8.1 elasticsearch-dsl-6.4.0
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Requirement already satisfied: python-consul==1.1.0 in /usr/local/lib/python3.6/site-packages
Requirement already satisfied: six>=1.4 in /usr/lib64/python3.6/site-packages (from python-consul==1.1.0)
Requirement already satisfied: requests>=2.0 in /usr/local/lib/python3.6/site-packages (from python-consul==1.1.0)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/site-packages (from requests>=2.0->python-consul==1.1.0)
Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/site-packages (from requests>=2.0->python-consul==1.1.0)
Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/site-packages (from requests>=2.0->python-consul==1.1.0)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/site-packages (from requests>=2.0->python-consul==1.1.0)
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Requirement already satisfied: schematics==2.1.0 in /usr/local/lib/python3.6/site-packages
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting toml==0.10.0
  Downloading https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl
Installing collected packages: toml
  Found existing installation: toml 0.10.1
    Uninstalling toml-0.10.1:
      Successfully uninstalled toml-0.10.1
Successfully installed toml-0.10.0
```