### PR TITLE
Problem: cortx-py-utils installation fails

### DIFF
--- a/py-utils/utils-post-install
+++ b/py-utils/utils-post-install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTHON=python3.6 
+PIP=pip3.6 
 POST_INSTALL_REQUIREMENTS=/opt/seagate/cortx/utils/conf/requirements.txt
 
-sudo $PYTHON -m pip install -r $POST_INSTALL_REQUIREMENTS
+sudo $PIP install -r $POST_INSTALL_REQUIREMENTS

--- a/py-utils/utils-pre-uninstall
+++ b/py-utils/utils-pre-uninstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTHON=python3.6 
+PIP=pip3.6 
 POST_INSTALL_REQUIREMENTS=/opt/seagate/cortx/utils/conf/requirements.txt
 
-sudo $PYTHON -m pip uninstall --yes -r $POST_INSTALL_REQUIREMENTS
+sudo $PIP uninstall --yes -r $POST_INSTALL_REQUIREMENTS


### PR DESCRIPTION
As part of the cortx-py-utils installation its related python dependencies are
installed as well. These dependencies are presently installed using command
`python -m pip install -r requirements.txt` but using `python` requires python-devel
package during installation to build setup.py for one of the modules `yarl`.
python-devel being not present as part of the overall product installation,
cortx-py-utils installation fails.

Solution:
This dependency on python-devel can be avoided by not using `python -m` but
directly using `pip3.6 install -r requirements.txt` to install required python
modules.

Signed-off-by: Mandar Sawant <mandar.sawant@seagate.com>