### PR TITLE
EOS-13996:ADDB:Profiling for all I/O operations (utils repo)

### DIFF
--- a/c-utils/src/test/perf/perf-manual-test.c
+++ b/c-utils/src/test/perf/perf-manual-test.c
@@ -242,9 +242,9 @@ void perfc_run_manual_test(void)
 
 	(void) tsdb_init(true, true);
 	tsdb_set_rt_state(true);
-	PERFC_STATE_V2(TSDB_MOD_UT, PFT_UT_A, opid, PES_GEN_INIT);
-	PERFC_ATTR_V2(TSDB_MOD_UT, PFT_UT_A, opid, PEA_UT_A_ARG_1, 0xAB);
-	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, opid+1, opid, 0xAB, 0xDD);
+	PERFC_STATE_V2(TSDB_MOD_UT, PFT_UT_A, 0, opid, PES_GEN_INIT);
+	PERFC_ATTR_V2(TSDB_MOD_UT, PFT_UT_A, 0, opid, PEA_UT_A_ARG_1, 0xAB);
+	PERFC_MAP_V2(TSDB_MOD_UT, PFT_UT_A, 0, opid+1, opid, 0xAB, 0xDD);
 	tsdb_fini();
 }
 


### PR DESCRIPTION
#  EOS-13996:ADDB:Profiling for all I/O operations (utils repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit de4a233b42d996e91eb072eb9e9b82d0abbf3b55
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Oct 27 16:10:25 2020 -0600

            EOS-13996:ADDB:Profiling for all I/O operations (utils repo)

            List of modified files:
                modified:   c-utils/src/addb/plugin.c
                modified:   c-utils/src/include/perf/perf-counters.h
                modified:   c-utils/src/test/perf/perf-manual-test.c
            Change description:
                Support for a tag to identify submodules based on function tags
                Write attr fixes
                Unit test:
                    histogram generation