### PR TITLE
stats_connection_fix: Fix http request issue

### DIFF
--- a/statsd-utils/statsd-elasticsearch-backend-0.4.2/lib/elasticsearch.js
+++ b/statsd-utils/statsd-elasticsearch-backend-0.4.2/lib/elasticsearch.js
@@ -199,7 +199,7 @@ function setData(listData, statsdIndex, renderKV, prev_index) {
         }
         req = http.request(reqOpts, function (res) {
         }).on('error', function (err) {
-          lg.log('error', 'Error with HTTP request, no stats flushed.');
+          lg.log('warning', 'Elasticsearch-Statsd connection failed, No stats flushed.');
         });
         req.end();
 
@@ -213,7 +213,7 @@ function setData(listData, statsdIndex, renderKV, prev_index) {
         };
         settings_req = http.request(settingsOptions, function(res) {
         }).on('error', function (err) {
-          lg.log('error', 'Error with HTTP request, no stats flushed.');
+          lg.log('warning', 'Elasticsearch-Statsd connection failed, No stats flushed.');
         });
         settings_req.write(settings_payload);
         settings_req.end();
@@ -246,7 +246,7 @@ function setData(listData, statsdIndex, renderKV, prev_index) {
       }
     });
   }).on('error', function (err) {
-    lg.log('error', 'Error with HTTP request, no stats flushed.');
+    lg.log('warning', 'Elasticsearch-Statsd connection failed, No stats flushed.');
   });
   if (debug) {
     lg.log('ES payload:');

--- a/statsd-utils/statsd-elasticsearch-backend-0.4.2/lib/elasticsearch.js
+++ b/statsd-utils/statsd-elasticsearch-backend-0.4.2/lib/elasticsearch.js
@@ -119,7 +119,7 @@ var flush_stats = function elastic_flush(ts, metrics) {
     es_bulk_insert(array_counts, array_timers, array_timer_data, array_gauges);
   }
   catch (e) {
-    lg.log("warning Connection to elasticsearch is failed.");
+    lg.log("warning","Connection to elasticsearch is failed.");
   }
 
   if (debug) {


### PR DESCRIPTION

## Problem Statement
<pre>
  <code>
Elasticsearch statsd connection fails
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
req = http.request(reqOpts, function (res) { });
Here, request error not handled causing Elasticsearch to restart.
  </code>
</pre>
## Solution
<pre>
  <code>
req = http.request(reqOpts, function (res) { });
Handled error for connection request
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Tested on vm with es - statsd connecton.
  </code>
</pre>
