### PR TITLE
Problem: no validator for io-stack is available

### DIFF
--- a/py-utils/src/utils/validator/commands.py
+++ b/py-utils/src/utils/validator/commands.py
@@ -17,6 +17,8 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import errno
+from .error import VError
+from .v_ha import HaStatusV
 
 
 class VCommand:
@@ -150,3 +152,24 @@ class ElasticsearchVCommand(VCommand):
         """Validate elasticsearch status."""
 
         self._elasticsearch.validate(self.v_type, self.args)
+
+
+class HaStatusVCommand(VCommand):
+    """HA Status related commands."""
+
+    name = "ha"
+
+    def __init__(self, args):
+        super().__init__(args)
+        self._validator = HaStatusV()
+
+    def process(self):
+        """Validate HA status."""
+
+        v_type = self._v_type
+        if v_type == 'io-stack':
+            self._validator.validate_io_stack_sane()
+        else:
+            raise VError(
+                errno.EINVAL, "Invalid v_type given: {v_type}. "
+                "Supported values: [io-stack]")

--- a/py-utils/src/utils/validator/v_ha.py
+++ b/py-utils/src/utils/validator/v_ha.py
@@ -1,0 +1,85 @@
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import errno
+import re
+from typing import List, NamedTuple, Optional
+
+from cortx.utils.process import SimpleProcess
+from cortx.utils.validator.error import VError
+
+
+class ServiceInfo(NamedTuple):
+    """Structure for storing service status"""
+    status: str
+    name: str
+
+
+class HaStatusV:
+    """HA related validations."""
+
+    def validate_io_stack_sane(self):
+        """
+        Ensures that there is no anomaly in Cortx IO stack.
+        """
+
+        self._ensure_hctl_available()
+        status_str = self._get_hctl_status()
+        services = self._extract_service_info(status_str)
+
+        if not services:
+            raise VError(
+                errno.EINVAL, "No services could be seen in hctl "
+                "status output. Either the cluster is not configured or "
+                "the output was not understood. In any case, the cluster "
+                "doesn't look sane.")
+        io_service_names = {'m0_client', 'ioservice'}
+        data_services = [
+            srv for srv in services if srv.name in io_service_names
+        ]
+        if any(srv.status == 'unknown' for srv in data_services):
+            raise VError(
+                errno.EINVAL,
+                f"Some of IO services don't look sane: {data_services}")
+
+    def _extract_service_info(self, raw_text: str) -> List[ServiceInfo]:
+        result = []
+        for line in raw_text.splitlines():
+            # match line as follows:
+            #     [started]  hax        0x7200000000000001:0x6  ...
+            match = re.match(r'[\s]+\[([^\]]*)\]\s+([^\s]+).*$', line)
+            if not match:
+                continue
+            (status, name) = (match.group(1), match.group(2))
+            result.append(ServiceInfo(name=name, status=status))
+        return result
+
+    def _ensure_hctl_available(self) -> None:
+        self._execute(['hctl', '--help'],
+                      'Failed to invoke hctl. Is Hare component installed?')
+
+    def _get_hctl_status(self) -> str:
+        return self._execute(['hctl', 'status'])
+
+    def _execute(self,
+                 args: List[str],
+                 error_text: Optional[str] = None) -> str:
+        out, err, exitcode = SimpleProcess(args).run()
+        out = out.decode("utf-8")
+        err = err.decode("utf-8")
+        error_text = error_text or err
+        if exitcode:
+            raise VError(errno.EINVAL, error_text)
+        return out

--- a/py-utils/src/utils/validator/validate.py
+++ b/py-utils/src/utils/validator/validate.py
@@ -40,7 +40,9 @@ class ValidatorCommandFactory:
                         "\t[storage lvms <node-1> <...>]\n"
                         "\t[elasticsearch service <host> <port>]\n"
                         "\t[bmc accessible <node1> <node2> <...>]\n"
-                        "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n")
+                        "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
+                        "\t[ha io-stack]\n"
+                        )
         sys.stderr.write(usage_string)
 
     @staticmethod

--- a/py-utils/test/validator/test_ha_status.py
+++ b/py-utils/test/validator/test_ha_status.py
@@ -1,0 +1,176 @@
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import unittest
+from unittest.mock import MagicMock
+
+from cortx.utils.validator.v_ha import HaStatusV, ServiceInfo
+from cortx.utils.validator.error import VError
+
+
+def service(name, status):
+    return ServiceInfo(name=name, status=status)
+
+
+def empty():
+    return
+
+
+class TestHaValidator(unittest.TestCase):
+    """Test HA Status-related validations."""
+    def test_services_found(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+    [started]  hax        0x7200000000000001:0x6   192.168.6.214@tcp:12345:1:1
+    [started]  confd      0x7200000000000001:0x9   192.168.6.214@tcp:12345:2:1
+    [started]  ioservice  0x7200000000000001:0xc   192.168.6.214@tcp:12345:2:2
+    [unknown]  m0_client  0x7200000000000001:0x28  192.168.6.214@tcp:12345:4:1
+    [unknown]  m0_client  0x7200000000000001:0x2b  192.168.6.214@tcp:12345:4:2
+        '''
+
+        result = validator._extract_service_info(status)
+        self.assertEqual(len(result), 5)
+        s = service
+        self.assertEqual(result, [
+            s('hax', 'started'),
+            s('confd', 'started'),
+            s('ioservice', 'started'),
+            s('m0_client', 'unknown'),
+            s('m0_client', 'unknown')
+        ])
+
+    def test_validator_works_when_all_started(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+    [started]  hax        0x7200000000000001:0x6   192.168.6.214@tcp:12345:1:1
+    [started]  confd      0x7200000000000001:0x9   192.168.6.214@tcp:12345:2:1
+    [started]  ioservice  0x7200000000000001:0xc   192.168.6.214@tcp:12345:2:2
+    [started]  m0_client  0x7200000000000001:0x28  192.168.6.214@tcp:12345:4:1
+    [started]  m0_client  0x7200000000000001:0x2b  192.168.6.214@tcp:12345:4:2
+        '''
+
+        validator._ensure_hctl_available = MagicMock(side_effect=empty)
+        validator._get_hctl_status = MagicMock(side_effect=[status])
+
+        # No exception is thrown
+        validator.validate_io_stack_sane()
+
+    def test_validator_works_when_all_io_started(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+    [unknown]  hax        0x7200000000000001:0x6   192.168.6.214@tcp:12345:1:1
+    [unknown]  confd      0x7200000000000001:0x9   192.168.6.214@tcp:12345:2:1
+    [started]  ioservice  0x7200000000000001:0xc   192.168.6.214@tcp:12345:2:2
+    [started]  m0_client  0x7200000000000001:0x28  192.168.6.214@tcp:12345:4:1
+    [started]  m0_client  0x7200000000000001:0x2b  192.168.6.214@tcp:12345:4:2
+        '''
+
+        validator._ensure_hctl_available = MagicMock(side_effect=empty)
+        validator._get_hctl_status = MagicMock(side_effect=[status])
+
+        # No exception is thrown
+        validator.validate_io_stack_sane()
+
+    def test_validator_fails_when_io_unknown(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+    [unknown]  hax        0x7200000000000001:0x6   192.168.6.214@tcp:12345:1:1
+    [unknown]  confd      0x7200000000000001:0x9   192.168.6.214@tcp:12345:2:1
+    [started]  ioservice  0x7200000000000001:0xc   192.168.6.214@tcp:12345:2:2
+    [started]  m0_client  0x7200000000000001:0x28  192.168.6.214@tcp:12345:4:1
+    [unknown]  m0_client  0x7200000000000001:0x2b  192.168.6.214@tcp:12345:4:2
+        '''
+
+        validator._ensure_hctl_available = MagicMock(side_effect=empty)
+        validator._get_hctl_status = MagicMock(side_effect=[status])
+
+        with self.assertRaises(VError):
+            validator.validate_io_stack_sane()
+
+    def test_validator_fails_when_no_services_found(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+        '''
+
+        validator._ensure_hctl_available = MagicMock(side_effect=empty)
+        validator._get_hctl_status = MagicMock(side_effect=[status])
+
+        with self.assertRaises(VError):
+            validator.validate_io_stack_sane()
+
+    def test_validator_fails_when_status_not_understood(self):
+        validator = HaStatusV()
+        status = '''
+Data pool:
+    # fid name
+    0x6f00000000000001:0x2e 'the pool'
+Profile:
+    # fid name: pool(s)
+    0x7000000000000001:0x4e 'default': 'the pool' None None
+Services:
+    localhost  (RC)
+    BROKENunknown]  hax        0x7200000000000001:0x6   192.168.6.214@tcp:12345:1:1
+    BROKENunknown]  confd      0x7200000000000001:0x9   192.168.6.214@tcp:12345:2:1
+    BROKENstarted]  ioservice  0x7200000000000001:0xc   192.168.6.214@tcp:12345:2:2
+    BROKENstarted]  m0_client  0x7200000000000001:0x28  192.168.6.214@tcp:12345:4:1
+    BROKENunknown]  m0_client  0x7200000000000001:0x2b  192.168.6.214@tcp:12345:4:2
+        '''
+
+        validator._ensure_hctl_available = MagicMock(side_effect=empty)
+        validator._get_hctl_status = MagicMock(side_effect=[status])
+
+        with self.assertRaises(VError):
+            validator.validate_io_stack_sane()


### PR DESCRIPTION
Solution: implement validator as follows, implement unit tests.

```
./validate.py ha io-stack
```

Unit tests implemented:
```
python -m unittest -v test/validator/test_ha_status.py
test_services_found (test.validator.test_ha_status.TestHaValidator) ... ok
test_validator_fails_when_io_unknown (test.validator.test_ha_status.TestHaValidator) ... ok
test_validator_fails_when_no_services_found (test.validator.test_ha_status.TestHaValidator) ... ok
test_validator_fails_when_status_not_understood (test.validator.test_ha_status.TestHaValidator) ... ok
test_validator_works_when_all_io_started (test.validator.test_ha_status.TestHaValidator) ... ok
test_validator_works_when_all_started (test.validator.test_ha_status.TestHaValidator) ... ok
```
