### PR TITLE
EOS-15281 :Use m0_log via log_write facility.

### DIFF
--- a/c-utils/src/include/common/log.h
+++ b/c-utils/src/include/common/log.h
@@ -35,6 +35,7 @@ typedef enum {
     LEVEL_INFO,
     LEVEL_TRACE,
     LEVEL_DEBUG,
+    LEVEL_TEST,
 } log_level_t;
 
 #define log_fatal(...) LOG(LEVEL_FATAL, ##__VA_ARGS__)
@@ -44,6 +45,7 @@ typedef enum {
 #define log_trace(...) LOG(LEVEL_TRACE, ##__VA_ARGS__)
 
 #define log_debug(...) LOG(LEVEL_DEBUG, ##__VA_ARGS__)
+#define log_test(...) LOG(LEVEL_TEST, ##__VA_ARGS__)
 
 /**
  * Returns the log level string in log_level_t type

--- a/c-utils/src/include/m0log.h
+++ b/c-utils/src/include/m0log.h
@@ -1,0 +1,18 @@
+#ifndef TEST_M0LOG_H
+#define TEST_M0LOG_H
+
+#include <stdarg.h>
+#include <stdio.h>
+
+extern const int m0trace_common1;
+
+int test_m0log_setup(void);
+void m0log_fini(void);
+
+void test_m0log_common1_setup(const void* p);
+
+void my_funct1(void);
+
+int decoder (const void* p, char *ifile, char *ofile);
+
+#endif /* TEST_M0LOG_H */

--- a/c-utils/src/log/CMakeLists.txt
+++ b/c-utils/src/log/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 2.6.3)
+include_directories(include)
+include_directories("/usr/include/motr")
+
+set(MOTR_CFLAGS "-g -D_REENTRANT -D_GNU_SOURCE -DM0_INTERNAL='' -DM0_EXTERN=extern ")
+set(MOTR_CFLAGS "${MOTR_CFLAGS} -Wall -Werror -Wno-attributes -Wno-unused-but-set-variable ")
+set(MOTR_CFLAGS "${MOTR_CFLAGS} -I/usr/include/motr")
+
+set_source_files_properties(log.c PROPERTIES COMPILE_FLAGS  "${CMAKE_C_FLAGS} ${MOTR_CFLAGS}")
+set_source_files_properties(m0log.c PROPERTIES COMPILE_FLAGS  "${CMAKE_C_FLAGS} ${MOTR_CFLAGS}")
+
 
 SET(LOG_UTILS_SRCS
 	log.c
+	m0log.c
 )
 
 add_library(utils-log OBJECT

--- a/c-utils/src/log/log.c
+++ b/c-utils/src/log/log.c
@@ -82,16 +82,18 @@ int log_write(log_level_t level, const char *fmt, ...)
 {
 	int rc = 0, len;
 	va_list args;
+	va_list args1;
 	time_t curr_time;
 	int pid = getpid();
-	//char *str;
-	//char *tmp;
+	char str[10000];
 
 	/*if (level > log_level) {
 		goto out;
 	}*/
 
 	va_start(args, fmt);
+	va_copy(args1, args);
+
 	curr_time = time(NULL);
 	fprintf(log_fp, "%10lld [%5d] ", (long long)curr_time, pid);
 	len = vfprintf(log_fp, fmt, args);
@@ -100,17 +102,14 @@ int log_write(log_level_t level, const char *fmt, ...)
 	}
 
 	fflush(log_fp);
+	va_end(args);
 
 	if (level == LEVEL_TEST) {
-		//str = (char *) malloc(sizeof(char) * (len+1));
-		//vsprintf(str, fmt, args);
-		//tmp = m0_strdup(str);
-		//M0_LOG(M0_DEBUG, "%s\n", (char *)tmp);
-		M0_LOG(M0_DEBUG, "TEST TEST TEST\n");
-		//free(str);
+		vsnprintf(str, sizeof(str), fmt, args1);
+		M0_LOG(M0_DEBUG, "%s\n", (char *)str);
 	}
 
-	va_end(args);
+	va_end(args1);
 
 //out:
 	return rc;

--- a/c-utils/src/log/log.c
+++ b/c-utils/src/log/log.c
@@ -26,8 +26,16 @@
 #include "common/log.h"
 #include <string.h>
 
+#include <stdlib.h>
+#include "lib/trace.h"
+
+
+#include "lib/string.h"            /* m0_strdup */
+#include "lib/user_space/types.h"  /* bool */
+
+
 static FILE *log_fp = NULL;
-static log_level_t log_level = LEVEL_INFO;
+static log_level_t log_level = LEVEL_TEST;
 
 const static struct {
 	log_level_t log_level;
@@ -38,7 +46,8 @@ const static struct {
 	{ LEVEL_WARN, "LEVEL_WARN"},
 	{ LEVEL_INFO, "LEVEL_INFO"},
 	{ LEVEL_TRACE, "LEVEL_TRACE"},
-	{ LEVEL_DEBUG, "LEVEL_DEBUG"}
+	{ LEVEL_DEBUG, "LEVEL_DEBUG"},
+	{ LEVEL_TEST, "LEVEL_TEST"}
 };
 
 log_level_t log_level_no(const char *log_level)
@@ -75,10 +84,12 @@ int log_write(log_level_t level, const char *fmt, ...)
 	va_list args;
 	time_t curr_time;
 	int pid = getpid();
+	//char *str;
+	//char *tmp;
 
-	if (level > log_level) {
+	/*if (level > log_level) {
 		goto out;
-	}
+	}*/
 
 	va_start(args, fmt);
 	curr_time = time(NULL);
@@ -90,7 +101,21 @@ int log_write(log_level_t level, const char *fmt, ...)
 
 	fflush(log_fp);
 
-out:
+	if (level == LEVEL_TEST) {
+		//str = (char *) malloc(sizeof(char) * (len+1));
+		//vsprintf(str, fmt, args);
+		printf("\n**************************************************************\n");
+		printf("TEST TEST TEST \n");
+
+		//tmp = m0_strdup(str);
+		//M0_LOG(M0_DEBUG, "%s\n", (char *)tmp);
+		M0_LOG(M0_DEBUG, "I am here, so happy. Tommorow is Diwali\n");
+		//free(str);
+	}
+
+	va_end(args);
+
+//out:
 	return rc;
 }
 

--- a/c-utils/src/log/log.c
+++ b/c-utils/src/log/log.c
@@ -104,12 +104,9 @@ int log_write(log_level_t level, const char *fmt, ...)
 	if (level == LEVEL_TEST) {
 		//str = (char *) malloc(sizeof(char) * (len+1));
 		//vsprintf(str, fmt, args);
-		printf("\n**************************************************************\n");
-		printf("TEST TEST TEST \n");
-
 		//tmp = m0_strdup(str);
 		//M0_LOG(M0_DEBUG, "%s\n", (char *)tmp);
-		M0_LOG(M0_DEBUG, "I am here, so happy. Tommorow is Diwali\n");
+		M0_LOG(M0_DEBUG, "TEST TEST TEST\n");
 		//free(str);
 	}
 

--- a/c-utils/src/log/m0log.c
+++ b/c-utils/src/log/m0log.c
@@ -1,0 +1,121 @@
+#include <stdarg.h>
+#include <sysexits.h>   /* EX_* exit codes (EX_OSERR, EX_SOFTWARE) */
+#include "lib/uuid.h"              /* m0_node_uuid_string_set */
+
+#include "module/instance.h"       /* m0 */
+#include "motr/init.h"             /* m0_init */
+#include "lib/uuid.h"              /* m0_node_uuid_string_set */
+#include "lib/getopts.h"           /* M0_GETOPTS */
+#include "lib/thread.h"            /* LAMBDA */
+#include "lib/string.h"            /* m0_strdup */
+#include "lib/user_space/types.h"  /* bool */
+#include "lib/user_space/trace.h"  /* m0_trace_parse */
+#include "lib/misc.h"              /* ARRAY_SIZE */
+#include "lib/trace.h"
+
+#include "m0log.h"
+
+int m0_trace_magic_sym_extra_addr_add(const void *addr);
+
+/* file for magical symbol file */
+const int  m0trace_common1 = 2811;
+
+
+int test_m0log_setup(void)
+{
+
+	m0_trace_init();
+
+	int rc = 0;
+
+        rc = m0_trace_set_immediate_mask("all");
+        if (rc) {
+                printf("Failed to set mask, rc = %d", rc);
+                goto out;
+        }
+        rc = m0_trace_set_print_context("full");
+        if (rc) {
+                printf("Failed to set print context, rc = %d", rc);
+                goto out;
+        }
+        rc = m0_trace_set_level("debug");
+        if (rc) {
+                printf("Failed to set trace level, rc = %d", rc);
+                goto out;
+        }
+        m0_trace_set_mmapped_buffer(true);
+out:
+        return rc;
+}
+
+void test_m0log_common1_setup(const void* p)
+{
+	int rc = 0;
+        rc = m0_trace_magic_sym_extra_addr_add(p);
+}
+
+void m0log_fini(void)
+{
+	m0_trace_fini();
+}
+
+
+void my_funct1(void)
+{
+        M0_LOG(M0_DEBUG, "\n In my_funct1");
+}
+
+#define DEFAULT_M0MOTR_KO_IMG_PATH  "/var/log/motr/m0motr_ko.img"
+
+int decoder (const void* p, char *ifile, char *ofile)
+{
+
+	const char *m0motr_ko_path        = DEFAULT_M0MOTR_KO_IMG_PATH;
+	enum m0_trace_parse_flags flags   = M0_TRACE_PARSE_DEFAULT_FLAGS;
+	FILE       *input_file;
+	FILE       *output_file;
+	int         rc=0;
+	const void *magic_symbols[1];
+	static struct m0 instance;
+
+	m0_trace_set_mmapped_buffer(false);
+	m0_node_uuid_string_set(NULL);
+
+	rc = m0_init(&instance);
+	if (rc != 0)
+		return rc;
+
+	const char *input_file_name =  m0_strdup(ifile);
+	const char *output_file_name = m0_strdup(ofile);
+
+	input_file = fopen(input_file_name, "r");
+	if (input_file == NULL) {
+		printf("Failed to open input file '%s'", input_file_name);
+		rc = EX_NOINPUT;
+		goto out;
+	}
+
+	output_file = fopen(output_file_name, "w");
+	if (output_file == NULL) {
+		printf("Failed to open output file '%s'", output_file_name);
+		rc = EX_NOINPUT;
+		goto out;
+	}
+
+	magic_symbols[0] = p;
+
+	rc = m0_trace_parse(input_file, output_file, m0motr_ko_path, flags,
+			magic_symbols, 1);
+	if (rc != 0) {
+		printf("Error occurred while parsing input trace data");
+		rc = EX_SOFTWARE;
+	}
+
+out:
+	m0_fini();
+	fclose(output_file);
+	fclose(input_file);
+
+	return rc;
+}
+

--- a/c-utils/src/test/management/CMakeLists.txt
+++ b/c-utils/src/test/management/CMakeLists.txt
@@ -10,5 +10,6 @@ add_executable(md5hash-test
 target_link_libraries(md5hash-test
 	ssl
 	crypto
+	motr
 	)
 


### PR DESCRIPTION
EOS-15281 :Use m0_log via log_write facility.
Utils code changes - new function calls added to utils to register
different modules
with m0trace utility. A decoder() written which will decode the m0trace
file generated.
New log_write level LEVEL_TEST introduced which will be used by
registered module.
Calling m0_log from log_write.

Signed-off-by: Shipra <shipra.gupta@seagate.com>