### PR TITLE
EOS-15071: Add support for enclosure controller accessibility validator

### DIFF
--- a/py-utils/src/utils/validator/v_controller.py
+++ b/py-utils/src/utils/validator/v_controller.py
@@ -24,7 +24,7 @@ from cortx.utils.validator.error import VError
 
 
 class ControllerV:
-    """Controller related validations."""
+    """ Controller related validations. """
 
     def __init__(self):
         self.version_cmd = "show versions"
@@ -62,7 +62,7 @@ class ControllerV:
                 errno.EINVAL, f"Action parameter '{v_type}' is not supported. Refer usage.")
 
     def validate_controller_accessibility(self, ip, username, password):
-        """Check contoller console is accessible to node."""
+        """ Check contoller console is accessible to node. """
         # Check if ssh connection is successful
         try:
             session = SSHChannel(host=ip, username=username, password=password)
@@ -82,7 +82,8 @@ class ControllerV:
             raise VError(errno.EINVAL, msg)
 
     def validate_firmware(self, ip, username, password, mc_expected):
-        """Check expected contoller bundle version found
+        """
+        Check expected contoller bundle version found
         mc_expected: string or list of expected version(s).
         """
         try:

--- a/py-utils/src/utils/validator/v_controller.py
+++ b/py-utils/src/utils/validator/v_controller.py
@@ -62,8 +62,7 @@ class ControllerV:
                 errno.EINVAL, f"Action parameter '{v_type}' is not supported. Refer usage.")
 
     def validate_controller_accessibility(self, ip, username, password):
-        """Check contoller console is accessible to node
-        """
+        """Check contoller console is accessible to node."""
         # Check if ssh connection is successful
         try:
             session = SSHChannel(host=ip, username=username, password=password)
@@ -84,7 +83,7 @@ class ControllerV:
 
     def validate_firmware(self, ip, username, password, mc_expected):
         """Check expected contoller bundle version found
-            mc_expected: string or list of expected version(s)
+        mc_expected: string or list of expected version(s).
         """
         try:
             session = SSHChannel(host=ip, username=username, password=password)

--- a/py-utils/src/utils/validator/v_controller.py
+++ b/py-utils/src/utils/validator/v_controller.py
@@ -1,0 +1,118 @@
+#!/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import errno
+import traceback
+
+from cortx.utils import const
+from cortx.utils.ssh import SSHSession
+from cortx.utils.process import SimpleProcess
+from cortx.utils.validator.error import VError
+from cortx.utils.security.cipher import Cipher
+
+
+class ControllerV:
+    """Controller related validations."""
+
+    def __init__(self):
+        self.version_cmd = "show versions"
+        self.success_msg = "Command completed successfully"
+
+    def validate(self, v_type, args):
+        """
+        Process controller validations.
+        Usage (arguments to be provided):
+        1. controller accessible <ip> <username> <password>
+        2. controller firmware <ip> <username> <password> <mc_version>
+        """
+
+        if not isinstance(args, list):
+            raise VError(errno.EINVAL, f"Invalid parameters {args}")
+
+        if v_type == "accessible":
+            if len(args) < 3:
+                raise VError(errno.EINVAL, f"Insufficient parameters. {args}")
+
+            if len(args) > 3:
+                raise VError(errno.EINVAL,
+                        f"Too many parameters '{args}' for 'Controller accessible'. Refer usage.")
+            self.validate_controller_accessibility(args[0], args[1], args[2])
+        elif v_type == "firmware":
+            if len(args) < 4:
+                raise VError(errno.EINVAL, f"Insufficient parameters. {args}")
+
+            if len(args) > 4:
+                raise VError(errno.EINVAL,
+                        f"Too many parameters '{args}' for 'Controller firmware'. Refer usage.")
+            self.validate_firmware(args[0], args[1], args[2], args[3])
+        else:
+            raise VError(
+                errno.EINVAL, f"Action parameter '{v_type}' is not supported. Refer usage.")
+
+    def validate_controller_accessibility(self, ip, username, password):
+        """Check contoller console is accessible to node
+        """
+        # Check if ssh connection is successful
+        try:
+            session = SSHSession(host=ip, username=username, password=password)
+            session.disconnect()
+        except:
+            sshError = traceback.format_exc()
+            raise VError(
+                errno.EINVAL, f"Failed to create ssh connection to {ip}, '{sshError}'")
+
+        # ping controller IP
+        cmd = f"ping -c 1 -W 1 {ip}"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        if rc != 0:
+            msg = f"Ping failed for IP '{ip}'. Command: '{cmd}', Return Code: '{rc}'."
+            msg += stderr.decode("utf-8").replace('\r','').replace('\n','')
+            raise VError(errno.EINVAL, msg)
+
+    def validate_firmware(self, ip, username, password, mc_expected):
+        """Check expected contoller bundle version found
+            mc_expected: string or list of expected version(s)
+        """
+        try:
+            session = SSHSession(host=ip, username=username, password=password)
+        except:
+            sshError = traceback.format_exc()
+            raise VError(
+                errno.EINVAL, f"Failed to create ssh connection to {ip}, '{sshError}'")
+
+        # check firmware version command execution on MC
+        stdin, stdout, stderr = session.exec_command(self.version_cmd)
+        cmd_output = stdout.read().decode()
+        cmd_error = stderr.read().decode()
+        if self.success_msg not in cmd_output:
+            raise VError(
+                errno.EINVAL, f"Command failure on controller, '{self.version_cmd}'")
+
+        # check expected bundle version is found on MC
+        _supported = False
+        if mc_expected:
+            if isinstance(mc_expected, list):
+                _supported = any(ver for ver in mc_expected if ver in cmd_output)
+            else:
+                _supported = True if mc_expected in cmd_output else False
+
+        if not _supported:
+            raise VError(errno.EINVAL, f"Unsupported firmware version found on {ip}.\
+                Expected controller bundle version(s): {mc_expected}")
+
+        session.disconnect()

--- a/py-utils/src/utils/validator/validate.py
+++ b/py-utils/src/utils/validator/validate.py
@@ -43,6 +43,8 @@ class ValidatorCommandFactory:
                         "\t[elasticsearch service <host> <port>]\n"
                         "\t[bmc accessible <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
                         "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
+                        "\t[controller accessible <ip> <username> <password>]\n"
+                        "\t[controller firmware <ip> <username> <password> <mc_version>]\n
                         "\t[pkg <packagenames> <host>]\n"
                         "\t[service <servicenames> <host>]\n"
                         "\t[path <type:path> <host>]\n")

--- a/py-utils/src/utils/validator/validate.py
+++ b/py-utils/src/utils/validator/validate.py
@@ -44,7 +44,7 @@ class ValidatorCommandFactory:
                         "\t[bmc accessible <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
                         "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
                         "\t[controller accessible <ip> <username> <password>]\n"
-                        "\t[controller firmware <ip> <username> <password> <mc_version>]\n
+                        "\t[controller firmware <ip> <username> <password> <mc_version>]\n"
                         "\t[pkg <packagenames> <host>]\n"
                         "\t[service <servicenames> <host>]\n"
                         "\t[path <type:path> <host>]\n")

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import unittest
+import sys
+import os
+import errno
+import unittest
+import salt.client
+
+from cortx.utils import const
+from cortx.utils.validator.error import VError
+from cortx.utils.security.cipher import Cipher
+from cortx.utils.validator.v_controller import ControllerV
+
+utils_root = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.append(utils_root)
+
+
+class TestControllerV(unittest.TestCase):
+    """Test storage contoller related validations"""
+
+    def setUp(self):
+        """Get primary and secondary MC of storage controller"""
+        self.cluster_id = self.fetch_salt_data('grains.get', const.CLUSTER_ID)
+        self.enclosure_data = self.fetch_salt_data('pillar.get', const.STORAGE_ENCLOSURE)
+        self.primary_mc = self.enclosure_data['controller']['primary_mc']['ip']
+        self.secondary_mc = self.enclosure_data['controller']['secondary_mc']['ip']
+
+        self.cntrlr_validator = ControllerV()
+
+    @staticmethod
+    def fetch_salt_data(func, arg):
+        """Get value for any required key from salt"""
+        result = salt.client.Caller().function(func, arg)
+        if not result:
+            raise VError(errno.EINVAL, "No result found in salt for '%s'" % arg)
+        return result
+
+    def __fetch_username_password_from_salt(self):
+        """Get valid username and password from salt"""
+        username = self.enclosure_data['controller']['user']
+        secret = self.enclosure_data['controller']['secret']
+        key = Cipher.generate_key(self.cluster_id, const.STORAGE_ENCLOSURE)
+        password = Cipher.decrypt(key, secret.encode('ascii')).decode()
+        return username, password
+
+    def test_accessibility_ok(self):
+        """ Check primary & secondary controller are reachable """
+        user, passwd = self.__fetch_username_password_from_salt()
+        self.cntrlr_validator.validate("accessible", [self.primary_mc, user, passwd])
+        self.cntrlr_validator.validate("accessible", [self.secondary_mc, user, passwd])
+
+    def test_firmware_version_ok(self):
+        """ Check controller bundle version """
+        user, passwd = self.__fetch_username_password_from_salt()
+        mc_expected = ["GN265", "GN280"]
+        self.cntrlr_validator.validate("firmware", [self.primary_mc, user, passwd, mc_expected])
+        self.cntrlr_validator.validate("firmware", [self.secondary_mc, user, passwd, mc_expected])
+
+    def test_accessibility_no_args_error(self):
+        """ Check 'accessible' validation type for no arguments """
+        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', [])
+
+    def test_incorrect_vtype(self):
+        """ Check incorrect validation type """
+        self.assertRaises(VError, self.cntrlr_validator.validate, 'dummy', [])
+
+    def test_accessibility_auth_error(self):
+        """ Check 'accessible' validation type for invalid user access"""
+        invalid_data = [self.primary_mc, "tester007", "Tester!007"]
+        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
+
+    def test_accessibility_conn_error(self):
+        """ Check 'accessible' validation type for invalid ip"""
+        invalid_data = ["10.256.256.10", "tester007", "Tester!007"]
+        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
+
+    def test_unsupported_bundle(self):
+        """ Check 'accessible' validation for an unsupported bundle version of controller"""
+        user, passwd = self.__fetch_username_password_from_salt()
+        mc_expected = ["GN000", "280GN"]
+        self.assertRaises(VError, self.cntrlr_validator.validate, "firmware",\
+            [self.primary_mc, user, passwd, mc_expected])
+
+    def test_web_service(self):
+        # TODO: validate web service availability
+        pass
+
+    def tearDown(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -30,48 +30,53 @@ sys.path.append(utils_root)
 
 
 class TestControllerV(unittest.TestCase):
-    """ Test storage controller related validations. """
+    """ Test storage controller related validations """
 
     IP = ""
     USERNAME = ""
     PASSWD = ""
 
     def setUp(self):
-        """ Initialize controller validator. """
+        """ Initialize controller validator """
         self.cntrlr_validator = ControllerV()
 
     def test_accessibility_ok(self):
-        """ Check primary & secondary controller are reachable. """
-        self.cntrlr_validator.validate("accessible", [self.IP, self.USERNAME, self.PASSWD])
+        """ Check primary & secondary controller are reachable """
+        self.cntrlr_validator.validate(
+            "accessible", [self.IP, self.USERNAME, self.PASSWD])
 
     def test_firmware_version_ok(self):
-        """ Check controller bundle version. """
+        """ Check controller bundle version """
         mc_expected = ["GN265", "GN280"]
-        self.cntrlr_validator.validate("firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
+        self.cntrlr_validator.validate(
+            "firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_accessibility_no_args_error(self):
-        """ Check 'accessible' validation type for no arguments. """
-        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', [])
+        """ Check 'accessible' validation type for no arguments """
+        self.assertRaises(
+            VError, self.cntrlr_validator.validate, 'accessible', [])
 
     def test_incorrect_vtype(self):
-        """ Check incorrect validation type. """
+        """ Check incorrect validation type """
         self.assertRaises(VError, self.cntrlr_validator.validate, 'dummy', [])
 
     def test_accessibility_auth_error(self):
-        """ Check 'accessible' validation type for invalid user access. """
+        """ Check 'accessible' validation type for invalid user access """
         invalid_data = [self.IP, "tester007", "Tester!007"]
-        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
+        self.assertRaises(VError, self.cntrlr_validator.validate,
+                          'accessible', invalid_data)
 
     def test_accessibility_conn_error(self):
-        """ Check 'accessible' validation type for invalid ip. """
+        """ Check 'accessible' validation type for invalid ip """
         invalid_data = ["10.256.256.10", "tester007", "Tester!007"]
-        self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
+        self.assertRaises(VError, self.cntrlr_validator.validate,
+                          'accessible', invalid_data)
 
     def test_unsupported_bundle(self):
-        """ Check 'accessible' validation for an unsupported bundle version of controller. """
+        """ Check 'accessible' validation for an unsupported bundle version of controller """
         mc_expected = ["GN000", "280GN"]
-        self.assertRaises(VError, self.cntrlr_validator.validate, "firmware",\
-            [self.IP, self.USERNAME, self.PASSWD, mc_expected])
+        self.assertRaises(VError, self.cntrlr_validator.validate, "firmware", [
+                          self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_web_service(self):
         # TODO: validate web service availability
@@ -83,7 +88,8 @@ class TestControllerV(unittest.TestCase):
 
 if __name__ == '__main__':
     if len(sys.argv[1:]) < 3:
-        raise Exception("Insufficient arguments. Test requires <ip> <username> <password>")
+        raise Exception(
+            "Insufficient arguments. Test requires <ip> <username> <password>")
     TestControllerV.PASSWD = sys.argv.pop()
     TestControllerV.USERNAME = sys.argv.pop()
     TestControllerV.IP = sys.argv.pop()

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -30,45 +30,45 @@ sys.path.append(utils_root)
 
 
 class TestControllerV(unittest.TestCase):
-    """Test storage controller related validations."""
+    """ Test storage controller related validations. """
 
     IP = ""
     USERNAME = ""
     PASSWD = ""
 
     def setUp(self):
-        """Initialize controller validator."""
+        """ Initialize controller validator. """
         self.cntrlr_validator = ControllerV()
 
     def test_accessibility_ok(self):
-        """Check primary & secondary controller are reachable."""
+        """ Check primary & secondary controller are reachable. """
         self.cntrlr_validator.validate("accessible", [self.IP, self.USERNAME, self.PASSWD])
 
     def test_firmware_version_ok(self):
-        """Check controller bundle version."""
+        """ Check controller bundle version. """
         mc_expected = ["GN265", "GN280"]
         self.cntrlr_validator.validate("firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_accessibility_no_args_error(self):
-        """Check 'accessible' validation type for no arguments."""
+        """ Check 'accessible' validation type for no arguments. """
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', [])
 
     def test_incorrect_vtype(self):
-        """Check incorrect validation type."""
+        """ Check incorrect validation type. """
         self.assertRaises(VError, self.cntrlr_validator.validate, 'dummy', [])
 
     def test_accessibility_auth_error(self):
-        """Check 'accessible' validation type for invalid user access."""
+        """ Check 'accessible' validation type for invalid user access. """
         invalid_data = [self.IP, "tester007", "Tester!007"]
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
 
     def test_accessibility_conn_error(self):
-        """Check 'accessible' validation type for invalid ip."""
+        """ Check 'accessible' validation type for invalid ip. """
         invalid_data = ["10.256.256.10", "tester007", "Tester!007"]
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
 
     def test_unsupported_bundle(self):
-        """Check 'accessible' validation for an unsupported bundle version of controller."""
+        """ Check 'accessible' validation for an unsupported bundle version of controller. """
         mc_expected = ["GN000", "280GN"]
         self.assertRaises(VError, self.cntrlr_validator.validate, "firmware",\
             [self.IP, self.USERNAME, self.PASSWD, mc_expected])

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -30,45 +30,45 @@ sys.path.append(utils_root)
 
 
 class TestControllerV(unittest.TestCase):
-    """Test storage contoller related validations"""
+    """Test storage controller related validations."""
 
     IP = ""
     USERNAME = ""
     PASSWD = ""
 
     def setUp(self):
-        """Initialize controller validator"""
+        """Initialize controller validator."""
         self.cntrlr_validator = ControllerV()
 
     def test_accessibility_ok(self):
-        """ Check primary & secondary controller are reachable """
+        """Check primary & secondary controller are reachable."""
         self.cntrlr_validator.validate("accessible", [self.IP, self.USERNAME, self.PASSWD])
 
     def test_firmware_version_ok(self):
-        """ Check controller bundle version """
+        """Check controller bundle version."""
         mc_expected = ["GN265", "GN280"]
         self.cntrlr_validator.validate("firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_accessibility_no_args_error(self):
-        """ Check 'accessible' validation type for no arguments """
+        """Check 'accessible' validation type for no arguments."""
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', [])
 
     def test_incorrect_vtype(self):
-        """ Check incorrect validation type """
+        """Check incorrect validation type."""
         self.assertRaises(VError, self.cntrlr_validator.validate, 'dummy', [])
 
     def test_accessibility_auth_error(self):
-        """ Check 'accessible' validation type for invalid user access"""
+        """Check 'accessible' validation type for invalid user access."""
         invalid_data = [self.IP, "tester007", "Tester!007"]
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
 
     def test_accessibility_conn_error(self):
-        """ Check 'accessible' validation type for invalid ip"""
+        """Check 'accessible' validation type for invalid ip."""
         invalid_data = ["10.256.256.10", "tester007", "Tester!007"]
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
 
     def test_unsupported_bundle(self):
-        """ Check 'accessible' validation for an unsupported bundle version of controller"""
+        """Check 'accessible' validation for an unsupported bundle version of controller."""
         mc_expected = ["GN000", "280GN"]
         self.assertRaises(VError, self.cntrlr_validator.validate, "firmware",\
             [self.IP, self.USERNAME, self.PASSWD, mc_expected])

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -16,7 +16,6 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-import unittest
 import sys
 import os
 import errno

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -20,12 +20,10 @@ import sys
 import os
 import errno
 import unittest
-import salt.client
 
 from cortx.utils import const
-from cortx.utils.validator.error import VError
-from cortx.utils.security.cipher import Cipher
 from cortx.utils.validator.v_controller import ControllerV
+from cortx.utils.validator.error import VError
 
 utils_root = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.append(utils_root)
@@ -34,43 +32,22 @@ sys.path.append(utils_root)
 class TestControllerV(unittest.TestCase):
     """Test storage contoller related validations"""
 
+    IP = ""
+    USERNAME = ""
+    PASSWD = ""
+
     def setUp(self):
-        """Get primary and secondary MC of storage controller"""
-        self.cluster_id = self.fetch_salt_data('grains.get', const.CLUSTER_ID)
-        self.enclosure_data = self.fetch_salt_data('pillar.get', const.STORAGE_ENCLOSURE)
-        self.primary_mc = self.enclosure_data['controller']['primary_mc']['ip']
-        self.secondary_mc = self.enclosure_data['controller']['secondary_mc']['ip']
-
+        """Initialize controller validator"""
         self.cntrlr_validator = ControllerV()
-
-    @staticmethod
-    def fetch_salt_data(func, arg):
-        """Get value for any required key from salt"""
-        result = salt.client.Caller().function(func, arg)
-        if not result:
-            raise VError(errno.EINVAL, "No result found in salt for '%s'" % arg)
-        return result
-
-    def __fetch_username_password_from_salt(self):
-        """Get valid username and password from salt"""
-        username = self.enclosure_data['controller']['user']
-        secret = self.enclosure_data['controller']['secret']
-        key = Cipher.generate_key(self.cluster_id, const.STORAGE_ENCLOSURE)
-        password = Cipher.decrypt(key, secret.encode('ascii')).decode()
-        return username, password
 
     def test_accessibility_ok(self):
         """ Check primary & secondary controller are reachable """
-        user, passwd = self.__fetch_username_password_from_salt()
-        self.cntrlr_validator.validate("accessible", [self.primary_mc, user, passwd])
-        self.cntrlr_validator.validate("accessible", [self.secondary_mc, user, passwd])
+        self.cntrlr_validator.validate("accessible", [self.IP, self.USERNAME, self.PASSWD])
 
     def test_firmware_version_ok(self):
         """ Check controller bundle version """
-        user, passwd = self.__fetch_username_password_from_salt()
         mc_expected = ["GN265", "GN280"]
-        self.cntrlr_validator.validate("firmware", [self.primary_mc, user, passwd, mc_expected])
-        self.cntrlr_validator.validate("firmware", [self.secondary_mc, user, passwd, mc_expected])
+        self.cntrlr_validator.validate("firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_accessibility_no_args_error(self):
         """ Check 'accessible' validation type for no arguments """
@@ -82,7 +59,7 @@ class TestControllerV(unittest.TestCase):
 
     def test_accessibility_auth_error(self):
         """ Check 'accessible' validation type for invalid user access"""
-        invalid_data = [self.primary_mc, "tester007", "Tester!007"]
+        invalid_data = [self.IP, "tester007", "Tester!007"]
         self.assertRaises(VError, self.cntrlr_validator.validate, 'accessible', invalid_data)
 
     def test_accessibility_conn_error(self):
@@ -92,10 +69,9 @@ class TestControllerV(unittest.TestCase):
 
     def test_unsupported_bundle(self):
         """ Check 'accessible' validation for an unsupported bundle version of controller"""
-        user, passwd = self.__fetch_username_password_from_salt()
         mc_expected = ["GN000", "280GN"]
         self.assertRaises(VError, self.cntrlr_validator.validate, "firmware",\
-            [self.primary_mc, user, passwd, mc_expected])
+            [self.IP, self.USERNAME, self.PASSWD, mc_expected])
 
     def test_web_service(self):
         # TODO: validate web service availability
@@ -106,4 +82,10 @@ class TestControllerV(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    if len(sys.argv[1:]) < 3:
+        raise Exception("Insufficient arguments. Test requires <ip> <username> <password>")
+    TestControllerV.PASSWD = sys.argv.pop()
+    TestControllerV.USERNAME = sys.argv.pop()
+    TestControllerV.IP = sys.argv.pop()
+
     unittest.main()


### PR DESCRIPTION
[root@sm35-r5 utils]# python3 cortx/test/validator/test_controller_validator.py 10.0.0.2 manage 'testpass'
........
----------------------------------------------------------------------
Ran 8 tests in 18.612s

OK