### PR TITLE
EOS-15347: Removing debug log level and adding required paramiko version

### DIFF
--- a/py-utils/requirements.txt
+++ b/py-utils/requirements.txt
@@ -12,4 +12,4 @@ argparse==1.4.0
 confluent-kafka==1.5.0
 python-crontab==2.5.1
 elasticsearch==6.8.1
-paramiko==2.7.2
+paramiko==2.7.1


### PR DESCRIPTION
[root@smc5-m11 utils]# **python3 -m unittest -v cortx/test/test_ssh_connection.py**
test_command_execution_ok (cortx.test.test_ssh_connection.TestSSHChannel)
Check if command is executed successfully ... Creating mailbox file: File exists
ok
test_connection_ok (cortx.test.test_ssh_connection.TestSSHChannel)
Check if ssh connection is alive ... Creating mailbox file: File exists
ok
test_reconnect_ok (cortx.test.test_ssh_connection.TestSSHChannel)
Check ssh re-connect after disconnection caller ... Creating mailbox file: File exists
ok
test_recv_file (cortx.test.test_ssh_connection.TestSSHChannel) ... Creating mailbox file: File exists
ok
test_send_file (cortx.test.test_ssh_connection.TestSSHChannel) ... Creating mailbox file: File exists
ok

----------------------------------------------------------------------
Ran 5 tests in 29.262s

OK