### PR TITLE
PoC changes for EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (utils repo) 

### DIFF
--- a/c-utils/src/include/cortx/helpers.h
+++ b/c-utils/src/include/cortx/helpers.h
@@ -58,6 +58,17 @@ struct m0kvs_key_iter {
 	bool initialized;
 };
 
+struct m0kvs_key_iter_v1 {
+	struct m0_bufvec key;
+	struct m0_bufvec val;
+	struct m0_op *op;
+	struct m0_idx *index;
+	int32_t *rcs;
+	bool initialized;
+	int16_t rcs_len;
+	int16_t  idx_to_read;
+};
+
 typedef bool (*get_list_cb)(char *k, void *arg);
 
 int m0init(struct collection_item *cfg_items);
@@ -129,6 +140,11 @@ int m0kvs_key_iter_find(const void* prefix, size_t prefix_len,
 
 /* Find the next record and set iter to it. */
 int m0kvs_key_iter_next(struct m0kvs_key_iter *priv);
+
+int m0kvs_key_iter_find_v1(const void* prefix, size_t prefix_len,
+			   struct m0kvs_key_iter_v1 *priv, int batch_size);
+void m0kvs_key_iter_get_kv_v1(struct m0kvs_key_iter_v1 *priv, void **key,
+			      size_t *klen, void **val, size_t *vlen);
 
 /**
  * Get pointer to key data.


### PR DESCRIPTION
#  EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (utils repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT
This PoC change does not affect existing production code. The newly introduced readdir v1's UT is work in progress.


## Commit Message
commit 3edc0d8aa1fadaddb5f9133db1ef0ea876b62b90
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Thu Dec 3 15:32:38 2020 +0000

            PoC changes for EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (utils repo)
            KV iterator with batching
            UT changes for readdir test
        modified:   c-utils/src/cortx/m0kvs.c
        modified:   c-utils/src/include/cortx/helpers.h

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
