### PR TITLE
Fix ElasticSearch connection to localhost ignoring configuration

### DIFF
--- a/py-utils/src/utils/data/db/db_provider.py
+++ b/py-utils/src/utils/data/db/db_provider.py
@@ -24,6 +24,7 @@ from schematics import Model
 from schematics.types import DictType, StringType, ListType, ModelType, IntType
 
 from cortx.utils.data.access import BaseModel
+from cortx.utils.log import Log
 from cortx.utils.errors import MalformedConfigurationError, DataAccessInternalError, DataAccessError
 from cortx.utils.data.access import AbstractDataBaseProvider
 
@@ -146,6 +147,7 @@ class AsyncDataBase:
         self._model = model
         self._model_settings = model_config.config.get(model_config.database)
         self._db_config = db_config.databases.get(model_config.database)
+        Log.info(f'Connect to DB {self._db_config.config.host}:{self._db_config.config.port}')
         self._database_status = ServiceStatus.NOT_CREATED
         self._database_module = getattr(db_module, self._db_config.import_path)
         self._database = None

--- a/py-utils/src/utils/product_features/unsupported_features.py
+++ b/py-utils/src/utils/product_features/unsupported_features.py
@@ -20,6 +20,7 @@ from cortx.utils.data.access import Query
 from cortx.utils.data.access.filters import Compare, And
 from cortx.utils.data.db.db_provider import DataBaseProvider, GeneralConfig
 from cortx.utils import const
+from cortx.utils.ha.hac import const as constha
 from cortx.utils.log import Log
 from cortx.utils.schema import database
 from cortx.utils.schema.payload import Json
@@ -28,7 +29,12 @@ from cortx.utils.product_features.model import UnsupportedFeaturesModel
 class UnsupportedFeaturesDB:
     def __init__(self) -> None:
         """Init load consul db for storing key in db."""
-        conf = GeneralConfig(database.DATABASE)
+        if os.path.exists(os.path.join(constha.CONF_PATH, constha.HA_DATABADE_SCHEMA)):
+            schema = Json(os.path.join(constha.CONF_PATH,
+                          constha.HA_DATABADE_SCHEMA)).load()
+            conf = GeneralConfig(schema)
+        else:
+            conf = GeneralConfig(database.DATABASE)
         self.storage = DataBaseProvider(conf)
 
     async def store_unsupported_feature(self, component_name, feature_name):


### PR DESCRIPTION
unsupported_features.py always took hard-coded db configuration even if the configuration file was available:
added the condition to handle this case.
