### PR TITLE
EOS-16423: S3 Mini-provisioner: Validations in post_install

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -106,3 +106,21 @@ try:
 except CipherInvalidToken:
     print('Key is wrong')
 ```
+### Utility
+#### Validator
+The validator modules can be used to perform checks and validate a wide range of things. For example, if a certain service is running, certain packages are installed or not, examine network connectivity etc.
+
+```python
+from cortx.utils.validator.v_pkg import PkgV
+try:
+	PkgV().validate('rpms', ["lvm2-2.02.186-7.el7", "openldap-server"])
+except Exception as e:
+	print("one or more pkgs are not installed on this machine")
+
+try:
+	PkgV().validate('rpms', ["lvm2-2.02.186-7.el7", "openldap-server"], "remote_hostname")
+except Exception as e:
+	print("one or more pkgs are not installed on that remote machine")
+```
+Note that the optional hostname usage will cause ssh connection to remote host, and the ssh must be set up without password beforehand otherwise operation will fail.
+```

--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -108,19 +108,36 @@ except CipherInvalidToken:
 ```
 ### Utility
 #### Validator
-The validator modules can be used to perform checks and validate a wide range of things. For example, if a certain service is running, certain packages are installed or not, examine network connectivity etc.
+The validator modules can be used to perform checks and validate a wide range of things. For example, if a certain service is running, certain packages are installed or not, examine network connectivity etc. For the remote checks, there is an optional hostname usage which will cause ssh connection to remote host, and the ssh must be set up without password beforehand otherwise operation will fail.
 
+  - Package validator: Currently two types of package validators are supported. One for checking rpm packages and the other one for pip3 packages. These APIs can be used to check if certain packages are installed on a remote host as well.
+
+    -- To check if rpm packages are installed, use command "rpms", and pass a list of package names.
 ```python
 from cortx.utils.validator.v_pkg import PkgV
 try:
 	PkgV().validate('rpms', ["lvm2-2.02.186-7.el7", "openldap-server"])
 except Exception as e:
 	print("one or more pkgs are not installed on this machine")
-
-try:
-	PkgV().validate('rpms', ["lvm2-2.02.186-7.el7", "openldap-server"], "remote_hostname")
-except Exception as e:
-	print("one or more pkgs are not installed on that remote machine")
 ```
-Note that the optional hostname usage will cause ssh connection to remote host, and the ssh must be set up without password beforehand otherwise operation will fail.
+Note The second example below shows how to check if packages are installed on a remote host specified by "remote_hostname".
+```python
+	PkgV().validate('rpms', ["lvm2-2.02.186-7.el7", "openldap-server"], "remote_hostname")
+```
+    -- To check if pip3 packages are installed, use command "pip3", and pass a list of package names.
+```python
+	PkgV().validate('pip3', ["toml", "salt"])
+	PkgV().validate('pip3', ["toml", "salt"], "remote_hostname") # for checking remote pip3 packages
+```
+  - Service validator: This can be used to check if certain services are running on this host or on a remote host. Use command "isrunning" to check, pass a list of name of services which needs to be checked.
+```python
+from cortx.utils.validator.v_service import ServiceV
+try:
+	ServiceV().validate('isrunning', ["rabbitmq-server", "sshd"])
+except Exception as e:
+	print("one or more services are not running on this machine")
+```
+Note The second example below shows how to check if gievn services are running on a remote host specified by "remote_hostname".
+```python
+	ServiceV().validate('isrunning', ["rabbitmq-server", "sshd"], "remote_hostname")
 ```

--- a/py-utils/src/utils/validator/commands.py
+++ b/py-utils/src/utils/validator/commands.py
@@ -168,3 +168,37 @@ class ControllerVCommand(VCommand):
         """Validate controller status."""
 
         self._controller.validate(self.v_type, self.args)
+
+class PkgVCommand(VCommand):
+    """Pkg check related commands."""
+
+    name = "Pkg"
+
+    def __init__(self, args):
+        super(PkgVCommand, self).__init__(args)
+
+        from v_pkg import PkgV
+
+        self._pkg = PkgV()
+
+    def process(self):
+        """Validate pkg status."""
+
+        self._pkg.validate(self.v_type, self.args)
+
+class ServiceVCommand(VCommand):
+    """Service check related commands."""
+
+    name = "Service"
+
+    def __init__(self, args):
+        super(ServiceVCommand, self).__init__(args)
+
+        from v_service import ServiceV
+
+        self._service = ServiceV()
+
+    def process(self):
+        """Validate service status."""
+
+        self._service.validate(self.v_type, self.args)

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -39,7 +39,7 @@ class PkgV:
 				     "cmd: %s failed with stderr: %s"
 				     %(cmd, stderr))
 		# To calm down codacy.
-		stdout = stdout
+		return stdout.decode("utf-8")
 
 	def validate(self, v_type: str, args: list, host: str = None):
 		"""
@@ -67,15 +67,21 @@ class PkgV:
 
 		for pkg in pkgs:
 			if host != None:
-				self.__search_pkg(f"ssh {host} rpm -qa | grep {pkg}")
+				result = self.__search_pkg(f"ssh {host} rpm -qa")
 			else:
-				self.__search_pkg(f"rpm -qa | grep {pkg}")
+				result = self.__search_pkg(f"rpm -qa")
+			if result.find(f"{pkg}") == -1:
+				raise VError(errno.EINVAL,
+					     "rpm pkg: %s not found" % pkg)
 
 	def validate_pip3s(self, host, pkgs):
 		"""Check if pip3 pkg is installed."""
 
 		for pkg in pkgs:
 			if host != None:
-				self.__search_pkg(f"ssh {host} pip3 list --format=legacy | grep {pkg}")
+				result = self.__search_pkg(f"ssh {host} pip3 list --format=legacy")
 			else:
-				self.__search_pkg(f"pip3 list --format=legacy {pkg}")
+				result = self.__search_pkg(f"pip3 list --format=legacy")
+			if result.find(f"{pkg}") == -1:
+				raise VError(errno.EINVAL,
+					     "pip3 pkg: %s not found" % pkg)

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -35,6 +35,8 @@ class PkgV:
 			raise VError(errno.EINVAL,
 				     "cmd: %s failed with stderr: %s"
 				     %(cmd, stderr))
+		# To calm down codacy.
+		stdout = stdout
 
 	def validate(self, v_type: str, args: list, host: str = None):
 		"""

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -1,0 +1,71 @@
+#!/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import errno
+from cortx.utils.validator.error import VError
+from cortx.utils.process import SimpleProcess
+
+def search_pkg(cmd):
+	# print(f"Running {cmd}")
+	handler = SimpleProcess(cmd)
+	stdout, stderr, retcode = handler.run()
+	if retcode != 0:
+		raise VError(errno.EINVAL,
+			     "cmd: %s failed with error code: %d"
+			     %(cmd, retcode))
+	if stderr:
+		raise VError(errno.EINVAL,
+			     "cmd: %s failed with stderr: %s"
+			     %(cmd, stderr))
+
+class PkgV:
+	"""Pkg related validations."""
+
+	def validate(self, v_type: str, args: list, host: str = None):
+		"""
+		Process rpm validations.
+		Usage (arguments to be provided):
+		1. pkg validate_rpms host (optional) [packagenames]
+		2. pkg validate_pip3s host (optional) [pip3 packagenames]
+		"""
+
+		if v_type == "validate_rpms":
+			return self.validate_rpms(host, args)
+		elif v_type == "validate_pip3s":
+			return self.validate_pip3s(host, args)
+		else:
+			raise VError(errno.EINVAL,
+				     "Action parameter %s not supported" % v_type)
+
+	def validate_rpms(self, host, pkgs):
+		"""Check if rpm pkg is installed."""
+
+		for pkg in pkgs:
+			if host != None:
+				search_pkg(f"ssh {host} rpm -qa | grep {pkg}")
+			else:
+				search_pkg(f"rpm -qa | grep {pkg}")
+
+	def validate_pip3s(self, host, pkgs):
+		"""Check if pip3 pkg is installed."""
+
+		for pkg in pkgs:
+			if host != None:
+				search_pkg(f"ssh {host} pip3 list --format=legacy | grep {pkg}")
+			else:
+				search_pkg(f"pip3 list --format=legacy {pkg}")

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -20,21 +20,21 @@ import errno
 from cortx.utils.validator.error import VError
 from cortx.utils.process import SimpleProcess
 
-def search_pkg(cmd):
-	# print(f"Running {cmd}")
-	handler = SimpleProcess(cmd)
-	stdout, stderr, retcode = handler.run()
-	if retcode != 0:
-		raise VError(errno.EINVAL,
-			     "cmd: %s failed with error code: %d"
-			     %(cmd, retcode))
-	if stderr:
-		raise VError(errno.EINVAL,
-			     "cmd: %s failed with stderr: %s"
-			     %(cmd, stderr))
-
 class PkgV:
 	"""Pkg related validations."""
+
+	def __search_pkg(self, cmd):
+		# print(f"Running {cmd}")
+		handler = SimpleProcess(cmd)
+		stdout, stderr, retcode = handler.run()
+		if retcode != 0:
+			raise VError(errno.EINVAL,
+				     "cmd: %s failed with error code: %d"
+				     %(cmd, retcode))
+		if stderr:
+			raise VError(errno.EINVAL,
+				     "cmd: %s failed with stderr: %s"
+				     %(cmd, stderr))
 
 	def validate(self, v_type: str, args: list, host: str = None):
 		"""
@@ -44,9 +44,9 @@ class PkgV:
 		2. pkg validate_pip3s host (optional) [pip3 packagenames]
 		"""
 
-		if v_type == "validate_rpms":
+		if v_type == "rpms":
 			return self.validate_rpms(host, args)
-		elif v_type == "validate_pip3s":
+		elif v_type == "pip3s":
 			return self.validate_pip3s(host, args)
 		else:
 			raise VError(errno.EINVAL,
@@ -57,15 +57,15 @@ class PkgV:
 
 		for pkg in pkgs:
 			if host != None:
-				search_pkg(f"ssh {host} rpm -qa | grep {pkg}")
+				self.__search_pkg(f"ssh {host} rpm -qa | grep {pkg}")
 			else:
-				search_pkg(f"rpm -qa | grep {pkg}")
+				self.__search_pkg(f"rpm -qa | grep {pkg}")
 
 	def validate_pip3s(self, host, pkgs):
 		"""Check if pip3 pkg is installed."""
 
 		for pkg in pkgs:
 			if host != None:
-				search_pkg(f"ssh {host} pip3 list --format=legacy | grep {pkg}")
+				self.__search_pkg(f"ssh {host} pip3 list --format=legacy | grep {pkg}")
 			else:
-				search_pkg(f"pip3 list --format=legacy {pkg}")
+				self.__search_pkg(f"pip3 list --format=legacy {pkg}")

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -16,9 +16,12 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+import os
+import pwd
 import errno
 from cortx.utils.validator.error import VError
 from cortx.utils.process import SimpleProcess
+from cortx.utils.validator.v_network import NetworkV
 
 class PkgV:
 	"""Pkg related validations."""
@@ -45,6 +48,11 @@ class PkgV:
 		1. pkg validate_rpms host (optional) [packagenames]
 		2. pkg validate_pip3s host (optional) [pip3 packagenames]
 		"""
+
+		# Ensure we can perform passwordless ssh and there are no prompts
+		if host:
+			NetworkV().validate('passwordless',
+				[pwd.getpwuid(os.getuid()).pw_name, host])
 
 		if v_type == "rpms":
 			return self.validate_rpms(host, args)

--- a/py-utils/src/utils/validator/v_service.py
+++ b/py-utils/src/utils/validator/v_service.py
@@ -1,0 +1,57 @@
+#!/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import errno
+from cortx.utils.validator.error import VError
+from cortx.utils.process import SimpleProcess
+
+class ServiceV:
+	"""Service related validations."""
+
+	def validate(self, v_type: str, args: list, host: str = None):
+		"""
+		Process service validations.
+		Usage (arguments to be provided):
+		1. service isrunning host (optional) [servicenames]
+		"""
+
+		if v_type == "isrunning":
+			return self.validate_services(host, args)
+		else:
+			raise VError(errno.EINVAL,
+				     "Action parameter %s not supported" % v_type)
+
+	def validate_services(self, host, services):
+		"""Check if services are running."""
+
+		for service in services:
+			if host != None:
+				cmd = f"ssh {host} systemctl status {service}"
+			else:
+				cmd = f"systemctl status {service}"
+			# print(f"Running {cmd}")
+			handler = SimpleProcess(cmd)
+			stdout, stderr, retcode = handler.run()
+			if retcode != 0:
+				raise VError(errno.EINVAL,
+					     "cmd: %s failed with error code: %d"
+					     %(cmd, retcode))
+			if stderr:
+				raise VError(errno.EINVAL,
+					     "cmd: %s failed with stderr: %s"
+					     %(cmd, stderr))

--- a/py-utils/src/utils/validator/v_service.py
+++ b/py-utils/src/utils/validator/v_service.py
@@ -16,9 +16,12 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+import os
+import pwd
 import errno
 from cortx.utils.validator.error import VError
 from cortx.utils.process import SimpleProcess
+from cortx.utils.validator.v_network import NetworkV
 
 class ServiceV:
 	"""Service related validations."""
@@ -29,6 +32,11 @@ class ServiceV:
 		Usage (arguments to be provided):
 		1. service isrunning host (optional) [servicenames]
 		"""
+
+		# Ensure we can perform passwordless ssh and there are no prompts
+		if host:
+			NetworkV().validate('passwordless',
+				[pwd.getpwuid(os.getuid()).pw_name, host])
 
 		if v_type == "isrunning":
 			return self.validate_services(host, args)

--- a/py-utils/src/utils/validator/v_service.py
+++ b/py-utils/src/utils/validator/v_service.py
@@ -55,3 +55,5 @@ class ServiceV:
 				raise VError(errno.EINVAL,
 					     "cmd: %s failed with stderr: %s"
 					     %(cmd, stderr))
+			# To calm down codacy.
+			stdout = stdout

--- a/py-utils/src/utils/validator/validate.py
+++ b/py-utils/src/utils/validator/validate.py
@@ -42,7 +42,9 @@ class ValidatorCommandFactory:
                         "\t[storage lvms <node-1> <...>]\n"
                         "\t[elasticsearch service <host> <port>]\n"
                         "\t[bmc accessible <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
-                        "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n")
+                        "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
+                        "\t[pkg <packagenames> <host>]\n"
+                        "\t[service <servicenames> <host>]\n")
         sys.stderr.write(usage_string)
 
     @staticmethod

--- a/py-utils/test/validator/test_pkg_validator.py
+++ b/py-utils/test/validator/test_pkg_validator.py
@@ -27,27 +27,27 @@ class TestRpmValidator(unittest.TestCase):
 	def test_rpm_installed(self):
 		"""Check if rpm pkg installed."""
 
-		PkgV().validate('validate_rpms', self.pkg)
+		PkgV().validate('rpms', self.pkg)
 
 	def test_pip3_installed(self):
 		"""Check if pip3 pkg installed."""
 
 		try:
 			pkg = ["toml", "salt"]
-			PkgV().validate('validate_pip3s', [pkg])
+			PkgV().validate('pip3s', [pkg])
 		except Exception as e:
 			self.fail("{}".format(e))
 
 	def test_remote_rpm_installed(self):
 		"""Check if rpm pkg installed."""
 
-		PkgV().validate('validate_rpms', self.pkg, self.host)
+		PkgV().validate('rpms', self.pkg, self.host)
 
 	def test_remote_pip3_installed(self):
 		"""Check if pip3 pkg installed."""
 
 		pkg = "toml"
-		PkgV().validate('validate_pip3s', [pkg], self.host)
+		PkgV().validate('pip3s', [pkg], self.host)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py-utils/test/validator/test_pkg_validator.py
+++ b/py-utils/test/validator/test_pkg_validator.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import unittest
+from cortx.utils.validator.v_pkg import PkgV
+
+class TestRpmValidator(unittest.TestCase):
+	"""Test rpm related validations."""
+	pkg = ["lvm2-2.02.186-7.el7", "openldap-server"]
+	host = "localhost"
+
+	def test_rpm_installed(self):
+		"""Check if rpm pkg installed."""
+
+		PkgV().validate('validate_rpms', self.pkg)
+
+	def test_pip3_installed(self):
+		"""Check if pip3 pkg installed."""
+
+		try:
+			pkg = ["toml", "salt"]
+			PkgV().validate('validate_pip3s', [pkg])
+		except Exception as e:
+			self.fail("{}".format(e))
+
+	def test_remote_rpm_installed(self):
+		"""Check if rpm pkg installed."""
+
+		PkgV().validate('validate_rpms', self.pkg, self.host)
+
+	def test_remote_pip3_installed(self):
+		"""Check if pip3 pkg installed."""
+
+		pkg = "toml"
+		PkgV().validate('validate_pip3s', [pkg], self.host)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py-utils/test/validator/test_pkg_validator.py
+++ b/py-utils/test/validator/test_pkg_validator.py
@@ -34,7 +34,7 @@ class TestRpmValidator(unittest.TestCase):
 
 		try:
 			pkg = ["toml", "salt"]
-			PkgV().validate('pip3s', [pkg])
+			PkgV().validate('pip3s', pkg)
 		except Exception as e:
 			self.fail("{}".format(e))
 
@@ -46,8 +46,8 @@ class TestRpmValidator(unittest.TestCase):
 	def test_remote_pip3_installed(self):
 		"""Check if pip3 pkg installed."""
 
-		pkg = "toml"
-		PkgV().validate('pip3s', [pkg], self.host)
+		pkg = ["toml"]
+		PkgV().validate('pip3s', pkg, self.host)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py-utils/test/validator/test_service_validator.py
+++ b/py-utils/test/validator/test_service_validator.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import unittest
+from cortx.utils.validator.v_service import ServiceV
+
+class TestServiceValidator(unittest.TestCase):
+	"""Test service related validations."""
+	services = ["rabbitmq-server", "sshd"]
+	host = "localhost"
+
+	def test_service_running(self):
+		"""Check if services are running."""
+
+		ServiceV().validate('isrunning', self.services)
+
+	def test_remote_service_running(self):
+		"""Check if services are running."""
+
+		ServiceV().validate('isrunning', self.services, self.host)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
commit 125555be232337ef9c2ebac20d26ad26c158b69c
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Wed Jan 20 08:36:43 2021 -0700

        EOS-16423: S3 Mini-provisioner: Validations in post_install
        Change description:
                Add new validator APIs to check if services are running and if rpm or pip3 packages are installed on local or remote host
        Files edited/added:
                modified:   src/utils/validator/commands.py
                new file:   src/utils/validator/v_pkg.py
                new file:   src/utils/validator/v_service.py
                modified:   src/utils/validator/validate.py
                new file:   test/validator/test_pkg_validator.py
                new file:   test/validator/test_service_validator.py
        Testing done:
                Used newly created unit tests to verify the new APIs. used test_pkg_validator.py and test_service_validator.py
                        > pip3 uninstall dist/cortx_py_utils-1.0.0-py3-none-any.whl -y;  rm -rf dist/* ;  python3 setup.py bdist_wheel && pip3 install dist/

                        Successfully installed cortx-py-utils-1.0.0
                        .Password:
                        .Password:
                        Password:
                        ..
                        ----------------------------------------------------------------------
                        Ran 4 tests in 13.438s

                        OK
                        Password:
                        Password:
                        ..
                        ----------------------------------------------------------------------
                        Ran 2 tests in 4.679s

                        OK

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
