### PR TITLE
EOS-16847-ConfStore-load config traceback change

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -61,5 +61,6 @@ class ConfCache:
 
     def delete(self, key: str):
         """ Delets a given key from the config """
-        self._data.delete(key)
+        result = self._data.delete(key)
         self._dirty = True
+        return result

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -70,9 +70,12 @@ class ConfCli:
     def delete(args):
         """ Delete given set of keys from the config """
         key_list = args.args[0].split(';')
+        is_deleted = []
         for key in key_list:
-            Conf.delete(ConfCli._index, key)
-        Conf.save(ConfCli._index)
+            status = Conf.delete(ConfCli._index, key)
+            is_deleted.append(status)
+        if any(is_deleted):
+            Conf.save(ConfCli._index)
 
 
 class GetCmd:

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -130,7 +130,7 @@ class ConfStore:
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index)
 
-        self._cache[index].delete(key)
+        return self._cache[index].delete(key)
 
     def copy(self, src_index: str, dst_index: str, key_list: list = None):
         """
@@ -189,7 +189,7 @@ class Conf:
     @staticmethod
     def delete(index: str, key: str):
         """ Deletes a given key from the config """
-        Conf._conf.delete(index, key)
+        return Conf._conf.delete(index, key)
 
     @staticmethod
     def copy(src_index: str, dst_index: str, key_list: list = None):

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -156,15 +156,17 @@ class KvPayload:
             if not isinstance(data[k[0]], list):
                 raise KvError(errno.EINVAL, "Invalid key %s", key)
             if index >= len(data[k[0]]):
-                return
+                return None
             if len(k) == 1:
                 del data[k[0]][index]
+                return True
             else:
                 self._delete(k[1], data[k[0]][index])
             return
 
         if len(k) == 1:
             del data[k[0]]
+            return True
         else:
             self._delete(k[1], data[k[0]])
 

--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -46,9 +46,9 @@ class JsonKvStore(KvStore):
         with open(self._store_path, 'r') as f:
             try:
                 data = json.load(f)
-
-            except JSONDecodeError:
-                pass
+            except JSONDecodeError as jerr:
+                raise KvError(errno.EINVAL, "Invalid JSON format %s",
+                                   jerr.__str__())
         return KvPayload(data, self._delim)
 
     def dump(self, data) -> None:
@@ -71,7 +71,12 @@ class YamlKvStore(KvStore):
     def load(self) -> KvPayload:
         """ Reads from the file """
         with open(self._store_path, 'r') as f:
-            return KvPayload(yaml.safe_load(f), self._delim)
+            try:
+                data = yaml.safe_load(f)
+            except Exception as yerr:
+                raise KvError(errno.EINVAL, "Invalid YAML format %s",
+                                   yerr.__str__())
+        return KvPayload(data, self._delim)
 
     def dump(self, data) -> None:
         with open(self._store_path, 'w') as f:
@@ -92,7 +97,12 @@ class TomlKvStore(KvStore):
     def load(self) -> KvPayload:
         """ Reads from the file """
         with open(self._store_path, 'r') as f:
-            return KvPayload(toml.load(f, dict), self._delim)
+            try:
+                data = toml.load(f, dict)
+            except Exception as terr:
+                raise KvError(errno.EINVAL, "Invalid TOML format %s",
+                                   terr.__str__())
+        return KvPayload(data, self._delim)
 
     def dump(self, data) -> None:
         """ Saves data onto the file """
@@ -149,7 +159,11 @@ class IniKvStore(KvStore):
 
     def load(self) -> IniKvPayload:
         """ Reads from the file """
-        self._config.read(self._store_path)
+        try:
+            self._config.read(self._store_path)
+        except Exception as err:
+            raise KvError(errno.EINVAL, "Invalid INI format %s",
+                               err.__str__())
         return IniKvPayload(self._config, self._delim)
 
     def dump(self, data) -> None:

--- a/py-utils/test/test_message_bus/test_purge.py
+++ b/py-utils/test/test_message_bus/test_purge.py
@@ -39,9 +39,10 @@ class TestMessage(unittest.TestCase):
         producer.send(messages)
         producer.send(messages)
         producer.delete()
+        producer.send(messages)
 
     def test_receive(self):
-        """Test Receive Message."""
+        """ Test Receive Message. """
         consumer = MessageConsumer(TestMessage.message_bus, \
             consumer_id='sspl_sensors', consumer_group='sspl', \
             message_type=['Sel'], auto_ack=False, offset='latest')
@@ -55,7 +56,7 @@ class TestMessage(unittest.TestCase):
                 self.assertIsNotNone(message, "Message not found")
                 consumer.ack()
             except Exception as e:
-                self.assertEqual(count, 0)
+                self.assertEqual(count, 10)
                 break
 
 


### PR DESCRIPTION
Cli traceback for file load and cli delete will same only if key is deleted

Conf CLI:
now deleting non existing key won't do conf.save(). (Check if really requires to save the file then call the conf.save)

Conf load
now loading file with wrong protocol is restricted with a traceback as stated below

JSON:
conf json:///tmp/bug_test.toml get test
error(22): Invalid JSON format Expecting value: line 1 column 1 (char 0)

YAML:
conf yaml:///tmp/bug_test.toml get test
error(22): Invalid YAML format expected '', but found '['
in "/tmp/bug_test.toml", line 17, column 1

TOML:
conf toml:///tmp/file1.json get test
error(22): Invalid TOML format Found invalid character in key name: '}'. Try quoting the key name. (line 1 column 2 char 1)

INI:
conf ini:///tmp/bug_test.toml get test
error(22): Invalid INI format File contains no section headers.
file: '/tmp/bug_test.toml', line: 5
'title = "TOML Example"\n'

Signed-off-by: surya <k.suryakumar1024@gmail.com>