### PR TITLE
Handle upgrade of cortx-py-utils package

### DIFF
--- a/py-utils/utils-pre-uninstall
+++ b/py-utils/utils-pre-uninstall
@@ -3,4 +3,11 @@
 PIP=pip3.6 
 POST_INSTALL_REQUIREMENTS=/opt/seagate/cortx/utils/conf/requirements.txt
 
-sudo $PIP uninstall --yes -r $POST_INSTALL_REQUIREMENTS
+# rpm utility passes additional parameter to indicate whether it is a fresh
+# install, un-install or upgrade. For this script un-install or upgrade are
+# the valid scenarios. 0 means un-install and 1 means upgrade.
+# Remove required packages only when uninstall
+if [ $1 == 0 ]
+then
+    sudo $PIP uninstall --yes -r $POST_INSTALL_REQUIREMENTS
+fi


### PR DESCRIPTION
While upgrading the cortx-py-utils package, as part of pre-uninstall
phase, all required packages were getting removed. This is not
expected in upgrade scenarios.
Made corrections in pre-uninstall script.