### PR TITLE
Add python36-toml dependency

### DIFF
--- a/c-utils/build/cortx-utils.spec-in.cmake
+++ b/c-utils/build/cortx-utils.spec-in.cmake
@@ -12,6 +12,7 @@ Group: Development/Libraries
 Source: %{sourcename}.tar.gz
 BuildRequires: cmake gcc
 #BuildRequires: @RPM_DEVEL_REQUIRES@
+Requires: python36-toml
 Provides: %{name} = %{version}-%{release}
 
 # CORTX UTILS library paths


### PR DESCRIPTION
Add dependency for https://pypi.org/project/toml/ using python36-toml.rpm from EPEL repo.

Signed-off-by: Yashodhan Pise yashodhan.pise@seagate.com