### PR TITLE
Install required packages as pre-install step

### DIFF
--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -31,12 +31,6 @@ with open('LICENSE', 'r') as lf:
 with open('README.md', 'r') as rf:
     long_description = rf.read()
 
-def get_install_requirements() -> List:
-    install_requires = []
-    with open('requirements.txt') as r:
-        install_requires = [line.strip() for line in r]
-    return install_requires
-
 setup(name='cortx-py-utils',
       version='1.0.0',
       url='https://github.com/Seagate/cortx-py-utils',
@@ -79,5 +73,4 @@ setup(name='cortx-py-utils',
                      ('/opt/seagate/cortx/utils/conf', ['requirements.txt'])],
       long_description=long_description,
       zip_safe=False,
-      python_requires='>=3.6.8',
-      install_requires=get_install_requirements())
+      python_requires='>=3.6.8')

--- a/py-utils/utils-pre-install
+++ b/py-utils/utils-pre-install
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+PIP=pip3
+
+# Remember to update "requirements.txt" if below list is updated
+
+PACKAGE_LIST="aiohttp==3.6.1
+ elasticsearch-dsl==6.4.0
+ python-consul==1.1.0
+ schematics==2.1.0
+ toml==0.10.0
+ cryptography==3.2
+ PyYAML==5.1.2
+ configparser==4.0.2
+ networkx==2.4
+ matplotlib==3.1.3
+ argparse==1.4.0
+ confluent-kafka==1.5.0
+ python-crontab==2.5.1
+ elasticsearch==6.8.1
+ paramiko==2.7.1"
+
+sudo $PIP install  $PACKAGE_LIST
+


### PR DESCRIPTION
"cortx-py-utils" depends on various python packages. Current method
to install these packages was to install them as post-install step.
This was leading to erroneous state of "cortx-py-utils" installation.
Corrected this, and now these packages will get installed as
pre-install step.