### PR TITLE
Fix python package dependency issue

### DIFF
--- a/py-utils/src/utils/setup/msg_bus_test.py
+++ b/py-utils/src/utils/setup/msg_bus_test.py
@@ -16,8 +16,6 @@
 
 import errno
 import time
-from cortx.utils.message_bus import MessageBus, MessageConsumer, MessageProducer
-from cortx.utils.conf_store import Conf
 from cortx.utils.setup import SetupError
 from cortx.utils.process import SimpleProcess
 
@@ -25,12 +23,14 @@ class MessageBusTest:
     """ Represents Message Bus Test methods """
 
     def __init__(self):
+        from cortx.utils.message_bus import MessageBus, MessageConsumer, MessageProducer
+        from cortx.utils.conf_store import Conf
         Conf.load("index", "json:///etc/cortx/message_bus.conf")
         self._server = Conf.get("index",'message_broker>cluster[0]>server')
         self._msg_bus = MessageBus()
         # Create a test topic
         cmd = "/opt/kafka/bin/kafka-topics.sh --create" + \
-              " --topic my_test --bootstrap-server " + self._server + ":9092"
+              " --topic mytest --bootstrap-server " + self._server + ":9092"
         try:
             cmd_proc = SimpleProcess(cmd)
             res_op, res_err, res_rc = cmd_proc.run()
@@ -44,7 +44,7 @@ class MessageBusTest:
     def __del__(self):
         # Delete the test topic
         cmd = "/opt/kafka/bin/kafka-topics.sh --delete" + \
-              " --topic my_test --bootstrap-server " + self._server + ":9092"
+              " --topic mytest --bootstrap-server " + self._server + ":9092"
         try:
             cmd_proc = SimpleProcess(cmd)
             res_op, res_err, res_rc = cmd_proc.run()
@@ -57,16 +57,18 @@ class MessageBusTest:
 
     def send_msg(self, message):
         """ Sends a  message """
+        from cortx.utils.message_bus import MessageBus, MessageConsumer, MessageProducer
         producer = MessageProducer(self._msg_bus, producer_id='setup', \
-            message_type='my_test', method='sync')
+            message_type='mytest', method='sync')
         producer.send(message)
         time.sleep(1)
 
 
     def receive_msg(self):
         """ Receives a message """
+        from cortx.utils.message_bus import MessageBus, MessageConsumer, MessageProducer
         consumer = MessageConsumer(self._msg_bus, consumer_id='setup', \
-            consumer_group='provisioner', message_type=['my_test'], auto_ack=False, \
+            consumer_group='provisioner', message_type=['mytest'], auto_ack=False, \
             offset='earliest')
         while True:
             try:


### PR DESCRIPTION
Just after installing cortx-py-utils rpm, all other required
python packages are not installed. Hence need to move the "import"
functionality to methods in the class MessageBusTest.