### PR TITLE
Fix python dependency for numpy

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -56,6 +56,8 @@ $ pip3 install cortx_py_utils-1.0.0-py3-none-any.whl
 ```
 
   - Installation with RPM package
+Note : The rpm package installation will not install any dependent python packages.
+Please refer to WIKI (https://github.com/Seagate/cortx-utils/wiki/%22cortx-py-utils%22-single-node-manual-provisioning)
 ```bash
 $ cd dist;
 $ yum install -y cortx-py-utils-1.0.0-1.noarch.rpm

--- a/py-utils/requirements.txt
+++ b/py-utils/requirements.txt
@@ -7,6 +7,7 @@ cryptography==3.2
 PyYAML==5.1.2
 configparser==4.0.2
 networkx==2.4
+numpy==1.19.5
 matplotlib==3.1.3
 argparse==1.4.0
 confluent-kafka==1.5.0

--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -31,6 +31,12 @@ with open('LICENSE', 'r') as lf:
 with open('README.md', 'r') as rf:
     long_description = rf.read()
 
+def get_install_requirements() -> List:
+    install_requires = []
+    with open('requirements.txt') as r:
+        install_requires = [line.strip() for line in r]
+    return install_requires
+
 setup(name='cortx-py-utils',
       version='1.0.0',
       url='https://github.com/Seagate/cortx-py-utils',
@@ -72,4 +78,5 @@ setup(name='cortx-py-utils',
                      ('/opt/seagate/cortx/utils/conf', ['requirements.txt'])],
       long_description=long_description,
       zip_safe=False,
-      python_requires='>=3.6.8')
+      python_requires='>=3.6',
+      install_requires=get_install_requirements())


### PR DESCRIPTION
While installing cortx-py-utils, latest numpy package gets installed.
But the latest numpy (1.20 version) needs python 3.7. Hence explicitly
adding lower version (1.19.5) in requirements.txt. Required python
packages installation is handled for "pip".
"rpm" installation do not installs the dependent python packages.
Updated README mentioning the same.

-----
[View rendered py-utils/README.md](https://github.com/sachinpunadikar/cortx-utils/blob/fixpypackages/py-utils/README.md)