### PR TITLE
EOS-17370: cortx-utils: Stop using "--format=legacy" with pip3 in v_pkg.py due to incompatibility issues with newer pip3 versions

### DIFF
--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -70,7 +70,7 @@ class PkgV:
 			if host != None:
 				result = self.__search_pkg(f"ssh {host} rpm -qa")
 			else:
-				result = self.__search_pkg(f"rpm -qa")
+				result = self.__search_pkg("rpm -qa")
 			if result.find(f"{pkg}") == -1:
 				raise VError(errno.EINVAL,
 					     "rpm pkg: %s not found" % pkg)
@@ -82,7 +82,7 @@ class PkgV:
 			if host != None:
 				result = self.__search_pkg(f"ssh {host} pip3 list")
 			else:
-				result = self.__search_pkg(f"pip3 list")
+				result = self.__search_pkg("pip3 list")
 			if result.find(f"{pkg}") == -1:
 				raise VError(errno.EINVAL,
 					     "pip3 pkg: %s not found" % pkg)

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -35,9 +35,10 @@ class PkgV:
 				     "cmd: %s failed with error code: %d"
 				     %(cmd, retcode))
 		if stderr:
-			raise VError(errno.EINVAL,
-				     "cmd: %s failed with stderr: %s"
-				     %(cmd, stderr))
+			if "WARNING:" not in stderr.decode("utf-8"):
+				raise VError(errno.EINVAL,
+					     "cmd: %s failed with stderr: %s"
+					     %(cmd, stderr))
 		# To calm down codacy.
 		return stdout.decode("utf-8")
 
@@ -79,9 +80,9 @@ class PkgV:
 
 		for pkg in pkgs:
 			if host != None:
-				result = self.__search_pkg(f"ssh {host} pip3 list --format=legacy")
+				result = self.__search_pkg(f"ssh {host} pip3 list")
 			else:
-				result = self.__search_pkg(f"pip3 list --format=legacy")
+				result = self.__search_pkg(f"pip3 list")
 			if result.find(f"{pkg}") == -1:
 				raise VError(errno.EINVAL,
 					     "pip3 pkg: %s not found" % pkg)


### PR DESCRIPTION
commit 6889387c9ecca06b17a981ca4091622f8460f8d5
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Feb 8 05:24:42 2021 -0700

        EOS-17370: cortx-utils: Stop using "--format=legacy" with pip3 in v_pkg.py due to incompatibility issues with newer pip3 versions
        Description: Recent pre-merge mini-provisioner jobs require pip3 to be updated to 21.0.1 from 9.0.3. This breaks the existing use of pip3 in validator framework API while using "pip3 list – format=legacy". The "-- form
        modified:   py-utils/src/utils/validator/v_pkg.py

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
