### PR TITLE
Support version string argument for cortx-py-utils

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -43,9 +43,10 @@ $ python3 setup.py bdist_wheel
 ```
 
   - Create RPM Package
-    - It will create `cortx-py-utils-1.0.0-1.noarch.rpm`
+It will create `cortx-py-utils-1.0.0-1.noarch.rpm` by default. One can change the version by passing extra `--version=<version_string>` parameter.
+Below command passes version string as 2.0.0, which creates `cortx-py-utils-2.0.0-1.noarch.rpm`
 ```bash
-$ python3.6 setup.py bdist_rpm --post-install utils-post-install --post-uninstall utils-post-uninstall
+$ python3.6 setup.py bdist_rpm --version=2.0.0 --post-install utils-post-install --post-uninstall utils-post-uninstall
 ```
 
 ## Installation

--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -18,6 +18,14 @@ import sys
 from typing import List
 from setuptools import setup
 
+# Get the version string from command line
+utils_version = "1.0.0"    #default version
+for argument in sys.argv:
+    if argument.startswith("--version"):
+        utils_version = argument.split("=")[1]
+        # remove the argument as it is not recognized argument for setup
+        sys.argv.remove(argument)
+
 SPEC_DIR = "src/utils/ha/hac/specs/"
 _ROOT = os.path.abspath(os.path.dirname(__file__)) + "/" + SPEC_DIR
 specs = []
@@ -31,15 +39,15 @@ with open('LICENSE', 'r') as lf:
 with open('README.md', 'r') as rf:
     long_description = rf.read()
 
-def get_install_requirements() -> List:
+def get_install_requirements() -> list:
     install_requires = []
     with open('requirements.txt') as r:
         install_requires = [line.strip() for line in r]
     return install_requires
 
 setup(name='cortx-py-utils',
-      version='1.0.0',
-      url='https://github.com/Seagate/cortx-py-utils',
+      version=utils_version,
+      url='https://github.com/Seagate/cortx-utils/py-utils',
       license='Seagate',
       author='Alexander Voronov',
       author_email='alexander.voronov@seagate.com',


### PR DESCRIPTION
A provision made, so that build command accepts version string, so that
rpm has the required version.

Signed-off-by: Sachin Punadikar <sachin.punadikar@seagate.com>

-----
[View rendered py-utils/README.md](https://github.com/sachinpunadikar/cortx-utils/blob/version_support/py-utils/README.md)