### PR TITLE
EOS-17528:cortx-utils: In pkg validator dont check stderr if stdout is non-zero for pip3 pkgs

### DIFF
--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -32,14 +32,8 @@ class PkgV:
 		stdout, stderr, retcode = handler.run()
 		if retcode != 0:
 			raise VError(errno.EINVAL,
-				     "cmd: %s failed with error code: %d"
-				     %(cmd, retcode))
-		if stderr:
-			if "WARNING:" not in stderr.decode("utf-8"):
-				raise VError(errno.EINVAL,
-					     "cmd: %s failed with stderr: %s"
-					     %(cmd, stderr))
-		# To calm down codacy.
+				     "cmd: %s failed with error code: %d, stderr: %s"
+				     %(cmd, retcode, stderr))
 		return stdout.decode("utf-8")
 
 	def validate(self, v_type: str, args: list, host: str = None):


### PR DESCRIPTION
commit 584b78e5610e6a01cd0852f295bac9881acc7035
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Thu Feb 11 00:15:07 2021 -0700

        EOS-17528:cortx-utils: In pkg validator dont check stderr if stdout is non-zero for pip3 pkgs
        Description: In pkg validator dont check stderr if stdout is non-zero for pip3 pkgs
        modified:   py-utils/src/utils/validator/v_pkg.py
        test:
                # python3 test/validator/test_pkg_validator.py
                ....
                ----------------------------------------------------------------------
                Ran 4 tests in 5.176s

                OK

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
