### PR TITLE
KV split = only for first occurrence 

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -41,7 +41,7 @@ class ConfCli:
         kv_list = args.args[0].split(';')
         for kv in kv_list:
             try:
-                key, val = kv.split('=')
+                key, val = kv.split('=',1)
             except:
                raise ConfError(errno.EINVAL, "Invalid KV pair %s", kv)
             Conf.set(ConfCli._index, key, val)


### PR DESCRIPTION
Problem with set key with '=' in value:  openldap>root>secret=gAAAAABgK5ydEKyUaCk5W6epdPNC39c3e6HHhieeyKd3_j4is502l79yR1_vdh4dSYYfvepbjMFQAP2esnlzbNSSkEPSA3udeQ==

```
[root@ssc-vm-1409 ~]# conf json:///root/provisioner_cluster.json set "openldap>root>secret=$ENCPW"
error(22): Invalid KV pair openldap>root>secret=gAAAAABgK5ydEKyUaCk5W6epdPNC39c3e6HHhieeyKd3_j4is502l79yR1_vdh4dSYYfvepbjMFQAP2esnlzbNSSkEPSA3udeQ==

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cli.py", line 44, in set
    key, val = kv.split('=')
ValueError: too many values to unpack (expected 2)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cli.py", line 149, in main
    out = args.func(args)
  File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cli.py", line 46, in set
    raise ConfError(errno.EINVAL, "Invalid KV pair %s", kv)
cortx.utils.conf_store.error.ConfError: error(22): Invalid KV pair openldap>root>secret=gAAAAABgK5ydEKyUaCk5W6epdPNC39c3e6HHhieeyKd3_j4is502l79yR1_vdh4dSYYfvepbjMFQAP2esnlzbNSSkEPSA3udeQ==

```
Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>