### PR TITLE
Pip install wheel is required

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -39,7 +39,7 @@ $ sudo yum install libffi-devel
   - Create pip package
     - It will create `cortx_py_utils-1.0.0-py3-none-any.whl`
 ```bash
-$ pip install wheel
+$ pip3 install wheel
 $ python3 setup.py bdist_wheel
 ```
 

--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -39,6 +39,7 @@ $ sudo yum install libffi-devel
   - Create pip package
     - It will create `cortx_py_utils-1.0.0-py3-none-any.whl`
 ```bash
+$ pip install wheel
 $ python3 setup.py bdist_wheel
 ```
 


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

Pip install wheel added as base CentOS does not come with this pre-installed.

-----
[View rendered py-utils/README.md](https://github.com/hessio/cortx-utils/blob/patch-1/py-utils/README.md)