### PR TITLE
ConfStore CLI: kv_delim -d optional argument changes with testcases

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -38,10 +38,11 @@ class ConfCli:
     @staticmethod
     def set(args):
         """ Set Key Value """
+        kv_delim = '=' if args.kv_delim == None else args.kv_delim
         kv_list = args.args[0].split(';')
         for kv in kv_list:
             try:
-                key, val = kv.split('=')
+                key, val = kv.split(kv_delim, 1)
             except:
                raise ConfError(errno.EINVAL, "Invalid KV pair %s", kv)
             Conf.set(ConfCli._index, key, val)
@@ -109,6 +110,8 @@ class SetCmd:
             "Example command:\n"
             "# conf json:///tmp/csm.conf set 'k1>k2=v1;k3=1'\n\n")
         s_parser.set_defaults(func=ConfCli.set)
+        s_parser.add_argument('-d', dest='kv_delim', 
+            help="Delimiter for k=v (default is '=')")
         s_parser.add_argument('args', nargs='+', default=[], help='args')
 
 

--- a/py-utils/src/utils/validator/v_controller.py
+++ b/py-utils/src/utils/validator/v_controller.py
@@ -1,0 +1,123 @@
+#!/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import errno
+import traceback
+
+from cortx.utils.ssh import SSHChannel
+from cortx.utils.process import SimpleProcess
+from cortx.utils.validator.error import VError
+
+
+class ControllerV:
+    """ Controller related validations """
+
+    def __init__(self):
+        self.version_cmd = "show versions"
+        self.success_msg = "Command completed successfully"
+
+    def validate(self, v_type, args):
+        """
+        Process controller validations.
+        Usage (arguments to be provided):
+        1. controller accessible <ip> <username> <password>
+        2. controller firmware <ip> <username> <password> <mc_version>
+        """
+
+        if not isinstance(args, list):
+            raise VError(errno.EINVAL, "Invalid parameters %s" % args)
+
+        if v_type == "accessible":
+            if len(args) < 3:
+                raise VError(
+                    errno.EINVAL, "Insufficient parameters. %s" % args)
+
+            if len(args) > 3:
+                raise VError(errno.EINVAL,
+                             "Too many parameters '%s' for 'Controller accessible'.\
+                                 Refer usage." % args)
+            self.validate_controller_accessibility(args[0], args[1], args[2])
+        elif v_type == "firmware":
+            if len(args) < 4:
+                raise VError(
+                    errno.EINVAL, "Insufficient parameters. %s" % args)
+
+            if len(args) > 4:
+                raise VError(errno.EINVAL,
+                             "Too many parameters '%s' for 'Controller firmware'.\
+                                 Refer usage." % args)
+            self.validate_firmware(args[0], args[1], args[2], args[3])
+        else:
+            raise VError(
+                errno.EINVAL, "Action parameter '{%s}' is not supported.\
+                    Refer usage." % v_type)
+
+    def validate_controller_accessibility(self, ip, username, password):
+        """ Check contoller console is accessible to node """
+        # Check if ssh connection is successful
+        try:
+            session = SSHChannel(
+                host=ip, username=username, password=password)
+            session.disconnect()
+        except:
+            err = traceback.format_exc()
+            raise VError(
+                errno.EINVAL, "Failed to create ssh connection to %s, Error: %s" % (ip, err))
+
+        # ping controller IP
+        cmd = "ping -c 1 -W 1 %s" % ip
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        if rc != 0:
+            msg = "Ping failed for IP '%s'. Command: '%s', Return Code: '%s'." % (
+                ip, cmd, rc)
+            msg += stderr.decode("utf-8").replace('\r', '').replace('\n', '')
+            raise VError(errno.EINVAL, msg)
+
+    def validate_firmware(self, ip, username, password, mc_expected):
+        """
+        Check expected contoller bundle version found
+        mc_expected: string or list of expected version(s).
+        """
+        try:
+            session = SSHChannel(
+                host=ip, username=username, password=password)
+        except:
+            err = traceback.format_exc()
+            raise VError(
+                errno.EINVAL, "Failed to create ssh connection to %s, Error: %s'" % (ip, err))
+
+        # check firmware version command execution on MC
+        rc, output = session.execute(self.version_cmd)
+        if (rc != 0) or (self.success_msg not in output):
+            raise VError(errno.EINVAL,
+                         "Controller command failure. Command: %s Output: %s" % (
+                             self.version_cmd, output))
+
+        # check expected bundle version is found on MC
+        _supported = False
+        if mc_expected:
+            if isinstance(mc_expected, list):
+                _supported = any(ver for ver in mc_expected if ver in output)
+            else:
+                _supported = True if mc_expected in output else False
+
+        if not _supported:
+            raise VError(errno.EINVAL, "Unsupported firmware version found on %s.\
+                Expected controller bundle version(s): %s" % (ip, mc_expected))
+
+        session.disconnect()

--- a/py-utils/src/utils/validator/validate.py
+++ b/py-utils/src/utils/validator/validate.py
@@ -43,6 +43,8 @@ class ValidatorCommandFactory:
                         "\t[elasticsearch service <host> <port>]\n"
                         "\t[bmc accessible <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
                         "\t[bmc stonith <node> <bmc_ip> <bmc_user> <bmc_passwd>]\n"
+                        "\t[controller accessible <ip> <username> <password>]\n"
+                        "\t[controller firmware <ip> <username> <password> <mc_version>]\n"
                         "\t[pkg <packagenames> <host>]\n"
                         "\t[service <servicenames> <host>]\n"
                         "\t[path <type:path> <host>]\n")

--- a/py-utils/test/test_conf_store/test_conf_cli.py
+++ b/py-utils/test/test_conf_store/test_conf_cli.py
@@ -90,6 +90,30 @@ class TestConfCli(unittest.TestCase):
                                                'get', 'bridge', '-f', 'yaml'])
         self.assertEqual(result_data, exp_result)
 
+    def test_conf_cli_kv_delim_set(self):
+        """
+        Test by setting a value into given key position with
+        mentioned kv_delim
+        """
+        set_cmd = "conf json:///tmp/file1.json set -d : cluster>id:093d"
+        set_cmd_proc = SimpleProcess(set_cmd)
+        set_cmd_proc.run()
+        get_cmd = "conf json:///tmp/file1.json get cluster>id"
+        get_cmd_proc = SimpleProcess(get_cmd)
+        result_data = get_cmd_proc.run()
+        self.assertTrue( True if result_data[2]==0 and 
+            result_data[0]==b'["093d"]\n' else False, result_data[1])
+    
+    def test_conf_cli_wrong_kv_delim(self):
+        """
+        Test by trying to set a value into given key position with
+        wrong kv_delim mentioned
+        """
+        set_cmd = "conf json:///tmp/file1.json set -d : cluster>id=093d"
+        set_cmd_proc = SimpleProcess(set_cmd)
+        result_data = set_cmd_proc.run()
+        self.assertTrue( True if result_data[2]==22 else False)
+
 if __name__ == '__main__':
 
     # create the file and load sample json into it. Start test

--- a/py-utils/test/validator/test_controller_validator.py
+++ b/py-utils/test/validator/test_controller_validator.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import sys
+import os
+import errno
+import unittest
+
+from cortx.utils import const
+from cortx.utils.validator.v_controller import ControllerV
+from cortx.utils.validator.error import VError
+
+utils_root = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.append(utils_root)
+
+
+class TestControllerV(unittest.TestCase):
+    """ Test storage controller related validations """
+
+    IP = ""
+    USERNAME = ""
+    PASSWD = ""
+
+    def setUp(self):
+        """ Initialize controller validator """
+        self.cntrlr_validator = ControllerV()
+
+    def test_accessibility_ok(self):
+        """ Check primary & secondary controller are reachable """
+        self.cntrlr_validator.validate(
+            "accessible", [self.IP, self.USERNAME, self.PASSWD])
+
+    def test_firmware_version_ok(self):
+        """ Check controller bundle version """
+        mc_expected = ["GN265", "GN280"]
+        self.cntrlr_validator.validate(
+            "firmware", [self.IP, self.USERNAME, self.PASSWD, mc_expected])
+
+    def test_accessibility_no_args_error(self):
+        """ Check 'accessible' validation type for no arguments """
+        self.assertRaises(
+            VError, self.cntrlr_validator.validate, 'accessible', [])
+
+    def test_incorrect_vtype(self):
+        """ Check incorrect validation type """
+        self.assertRaises(VError, self.cntrlr_validator.validate, 'dummy', [])
+
+    def test_accessibility_auth_error(self):
+        """ Check 'accessible' validation type for invalid user access """
+        invalid_data = [self.IP, "tester007", "Tester!007"]
+        self.assertRaises(VError, self.cntrlr_validator.validate,
+                          'accessible', invalid_data)
+
+    def test_accessibility_conn_error(self):
+        """ Check 'accessible' validation type for invalid ip """
+        invalid_data = ["10.256.256.10", "tester007", "Tester!007"]
+        self.assertRaises(VError, self.cntrlr_validator.validate,
+                          'accessible', invalid_data)
+
+    def test_unsupported_bundle(self):
+        """ Check 'accessible' validation for an unsupported bundle version of controller """
+        mc_expected = ["GN000", "280GN"]
+        self.assertRaises(VError, self.cntrlr_validator.validate, "firmware", [
+                          self.IP, self.USERNAME, self.PASSWD, mc_expected])
+
+    def test_web_service(self):
+        # TODO: validate web service availability
+        pass
+
+    def tearDown(self):
+        pass
+
+
+if __name__ == '__main__':
+    if len(sys.argv[1:]) < 3:
+        raise Exception(
+            "Insufficient arguments. Test requires <ip> <username> <password>")
+    TestControllerV.PASSWD = sys.argv.pop()
+    TestControllerV.USERNAME = sys.argv.pop()
+    TestControllerV.IP = sys.argv.pop()
+
+    unittest.main()


### PR DESCRIPTION
Added kv_delim changes -d option for conf cli set
Added testcases
* EOS-15071: Add support for enclosure controller accessibility validator

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>

* Add SSHChannel changes

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>

* Remove salt dependency

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>

* Comment line format correction

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>

* Addressing docstring style

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>

* Addressing charecters by line & replacing canonical naming

Signed-off-by: MARIYAPPAN PONNUSAMY <mariyappan.ponnusamy@seagate.com>
Signed-off-by: suryakumar <suryakumar.kumaravelan@seagate.com>