### PR TITLE
Add pre-install checks for required python packages

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -e
+PROG_NAME=$(basename "$0")
+BASE_DIR=$(realpath $(dirname "$0")/../py-utils)
+BUILD_NUMBER=
+GIT_VER=
+
+usage() {
+    echo """usage: $PROG_NAME [-v version] [-g git_version] [-b build_number]""" 1>&2;
+    exit 1;
+}
+
+# Check for passed in arguments
+while getopts ":g:v:b:" o; do
+    case "${o}" in
+        v)
+            VER=${OPTARG}
+            ;;
+        g)
+            GIT_VER=${OPTARG}
+            ;;
+        b)
+            BUILD_NUMBER=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[ -z $"$GIT_VER" ] && GIT_VER="$(git rev-parse --short HEAD)" \
+        || GIT_VER="${GIT_VER}_$(git rev-parse --short HEAD)"
+[ -z "$VER" ] && VER="1.0.0"
+[ -z "$BUILD_NUMBER" ] && BUILD_NUMBER=1
+REL="${BUILD_NUMBER}_${GIT_VER}"
+
+cd "$BASE_DIR"
+echo "Creating cortx-py-utils RPM with version $VER, release $REL"
+
+# Create the utils-pre-install
+echo "#!/bin/bash" > utils-pre-install
+echo ""  >> utils-pre-install
+echo "PACKAGE_LIST=\""  >> utils-pre-install
+/bin/cat requirements.txt >> utils-pre-install
+echo "\""  >> utils-pre-install
+echo "rc=0
+for package in \$PACKAGE_LIST
+do
+    pip3 freeze | grep \$package > /dev/null
+    if [ \$? -ne 0 ]; then
+       if [ \$rc -eq 0 ]; then
+           echo \"===============================================\"
+       fi
+       echo \"Required python package \$package is missing\"
+       rc=-1
+    fi
+done
+if [ \$rc -ne 0 ]; then
+    echo \"Please install above python packages\"
+    echo \"===============================================\"
+fi
+exit \$rc " >> utils-pre-install
+/bin/chmod +x utils-pre-install
+
+# Create the rpm
+/bin/python3.6 setup.py bdist_rpm --version="$VER" --release="$REL" --pre-install \
+utils-pre-install --post-install utils-post-install --post-uninstall utils-post-uninstall

--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -44,10 +44,11 @@ $ python3 setup.py bdist_wheel
 ```
 
   - Create RPM Package
-It will create `cortx-py-utils-1.0.0-1.noarch.rpm` by default. One can change the version by passing extra `--version=<version_string>` parameter.
-Below command passes version string as 2.0.0, which creates `cortx-py-utils-2.0.0-1.noarch.rpm`
+It will create `cortx-py-utils-1.0.0-1_<git-version>.noarch.rpm` by default. One can change the version by passing extra `-v <version_string>` parameter.
+Below command passes version string as 2.0.0 and build number 2, which creates `cortx-py-utils-2.0.0-2_<git-version>.noarch.rpm`
+Run below command from repo root.
 ```bash
-$ python3.6 setup.py bdist_rpm --version=2.0.0 --post-install utils-post-install --post-uninstall utils-post-uninstall
+$ ./jenkins/build.sh -v 2.0.0 -b 2
 ```
 
 ## Installation
@@ -58,7 +59,7 @@ $ pip3 install cortx_py_utils-1.0.0-py3-none-any.whl
 ```
 
   - Installation with RPM package
-Note : The rpm package installation will not install any dependent python packages.
+Note : The rpm package installation will fail if any dependent python package is not installed.
 Please refer to WIKI (https://github.com/Seagate/cortx-utils/wiki/%22cortx-py-utils%22-single-node-manual-provisioning)
 ```bash
 $ cd dist;


### PR DESCRIPTION
"cortx-py-utils" rpm depends on various python packages.
The %pre phase should check whether these python packages are
installed or not. If these packages do not exists, then throw
message asking to install them


-----
[View rendered py-utils/README.md](https://github.com/sachinpunadikar/cortx-utils/blob/pre_install_checks/py-utils/README.md)