### PR TITLE
Validator - PkgV - Add version check on installed python 3rd party packages

### DIFF
--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -47,9 +47,8 @@ class PkgV:
             stdout, stderr, retcode = handler.run()
             result = stdout.decode("utf-8") if retcode == 0 else stderr.decode("utf-8")
         if retcode != 0:
-            raise VError(
-                errno.EINVAL, "Command failure. cmd: %s stderr: %s" % (cmd, result)
-            )
+            raise VError(errno.EINVAL,
+                "Command failure. cmd: %s stderr: %s" % (cmd, result))
         return result
 
     def validate(self, v_type: str, args: list, host: str = None):
@@ -71,9 +70,8 @@ class PkgV:
             self.ssh = SSHChannel(host=host, username=user, password=passwd, port=port)
         elif host != socket.getfqdn():
             # Ensure we can perform passwordless ssh and there are no prompts
-            NetworkV().validate(
-                "passwordless", [pwd.getpwuid(os.getuid()).pw_name, host]
-            )
+            NetworkV().validate("passwordless",
+                [pwd.getpwuid(os.getuid()).pw_name, host])
             self.passwdless_ssh_enabled = True
 
         if v_type == "rpms":
@@ -96,19 +94,16 @@ class PkgV:
 
         for pkg in pkgs:
             if result.find("%s" % pkg) == -1:
-                raise VError(
-                    errno.EINVAL, "rpm pkg %s not installed on host %s." % (pkg, host)
-                )
+                raise VError(errno.EINVAL,
+                    "rpm pkg %s not installed on host %s." % (pkg, host))
             if not skip_version_check:
                 matched_str = re.search(r"%s-([^-][0-9.]+)-" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
-                    raise VError(
-                        errno.EINVAL,
+                    raise VError(errno.EINVAL,
                         "Mismatched version for rpm package %s on host %s. Installed %s. Expected %s."
-                        % (pkg, host, installed_version, expected_version),
-                    )
+                        % (pkg, host, installed_version, expected_version))
 
     def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if pip3 pkg is installed."""
@@ -120,16 +115,13 @@ class PkgV:
 
         for pkg in pkgs:
             if result.find("%s" % pkg) == -1:
-                raise VError(
-                    errno.EINVAL, "pip3 pkg %s not installed on host %s." % (pkg, host)
-                )
+                raise VError(errno.EINVAL,
+                    "pip3 pkg %s not installed on host %s." % (pkg, host))
             if not skip_version_check:
                 matched_str = re.search(r"%s \((.*)\)" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
-                    raise VError(
-                        errno.EINVAL,
+                    raise VError(errno.EINVAL,
                         "Mismatched version for pip3 package %s on host %s. Installed %s. Expected %s."
-                        % (pkg, host, installed_version, expected_version),
-                    )
+                        % (pkg, host, installed_version, expected_version))

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -64,26 +64,19 @@ class PkgV:
 		if not isinstance(pkgs, dict):
 			skip_version_check = True
 
-		if host != None:
-			cmd = "ssh %s rpm -qa" % host
-		else:
-			cmd = "rpm -qa"
-
+		cmd = "ssh %s rpm -qa" % host if host != None else "rpm -qa"
 		result = self.__search_pkg(cmd)
 
 		for pkg in pkgs:
 			if result.find(f"{pkg}") == -1:
-				raise VError(errno.EINVAL,
-					     "rpm pkg: %s not found" % pkg)
+				raise VError(errno.EINVAL, "rpm pkg %s not installed." % pkg)
 			if not skip_version_check:
 				matched_str = re.search(f"{pkg}-([^-][0-9.]+)-", result)
 				installed_version = matched_str.groups()[0]
 				expected_version = pkgs[pkg]
 				if installed_version != expected_version:
-					err_desc = "rpm pkg: %s is not having expected version. " + \
-     							"Installed: %s Expected: %s"
-					raise VError(errno.EINVAL,
-								err_desc % (pkg, installed_version, expected_version))
+					raise VError(errno.EINVAL, "Mismatched version for rpm package %s. " \
+								"Installed %s. Expected %s." %(pkg, installed_version, expected_version))
 
 	def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
 		"""Check if pip3 pkg is installed."""
@@ -91,23 +84,16 @@ class PkgV:
 		if not isinstance(pkgs, dict):
 			skip_version_check = True
 
-		if host != None:
-			cmd = "ssh %s pip3 list" % host
-		else:
-			cmd = "pip3 list"
-
+		cmd = "ssh %s pip3 list" % host if host != None else "pip3 list"
 		result = self.__search_pkg(cmd)
 
 		for pkg in pkgs:
 			if result.find(f"{pkg}") == -1:
-				raise VError(errno.EINVAL,
-							"pip3 pkg: %s not found" % pkg)
+				raise VError(errno.EINVAL, "pip3 pkg %s not installed." % pkg)
 			if not skip_version_check:
 				matched_str = re.search(f"{pkg} \((.*)\)", result)
 				installed_version = matched_str.groups()[0]
 				expected_version = pkgs[pkg]
 				if installed_version != expected_version:
-					err_desc = "pip3 pkg: %s is not having expected version. " + \
-     							"Installed: %s Expected: %s"
-					raise VError(errno.EINVAL,
-								err_desc % (pkg, installed_version, expected_version))
+					raise VError(errno.EINVAL, "Mismatched version for pip3 package %s. " \
+								"Installed %s. Expected %s." %(pkg, installed_version, expected_version))

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -32,9 +32,9 @@ class PkgV:
         handler = SimpleProcess(cmd)
         stdout, stderr, retcode = handler.run()
         if retcode != 0:
-            raise VError(errno.EINVAL,
-                     "cmd: %s failed with error code: %d, stderr: %s"
-                     %(cmd, retcode, stderr))
+            raise VError(
+                errno.EINVAL,
+                "Package dependency check failed. cmd: %s stderr: %s" %(cmd, stderr))
         return stdout.decode("utf-8")
 
     def validate(self, v_type: str, args: list, host: str = None):
@@ -55,8 +55,7 @@ class PkgV:
         elif v_type == "pip3s":
             return self.validate_pip3_pkgs(host, args)
         else:
-            raise VError(errno.EINVAL,
-                     "Action parameter %s not supported" % v_type)
+            raise VError(errno.EINVAL, "Action parameter %s not supported" % v_type)
 
     def validate_rpm_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if rpm pkg is installed."""
@@ -76,7 +75,7 @@ class PkgV:
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
                     raise VError(errno.EINVAL, "Mismatched version for rpm package %s. " \
-                            "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+                        "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
 
     def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if pip3 pkg is installed."""
@@ -96,4 +95,4 @@ class PkgV:
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
                     raise VError(errno.EINVAL, "Mismatched version for pip3 package %s. " \
-                            "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+                        "Installed %s. Expected %s." %(pkg, installed_version, expected_version))

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -65,9 +65,11 @@ class PkgV:
 			skip_version_check = True
 
 		if host != None:
-			result = self.__search_pkg(f"ssh {host} rpm -qa")
+			cmd = "ssh %s rpm -qa" % host
 		else:
-			result = self.__search_pkg("rpm -qa")
+			cmd = "rpm -qa"
+
+		result = self.__search_pkg(cmd)
 
 		for pkg in pkgs:
 			if result.find(f"{pkg}") == -1:
@@ -90,9 +92,11 @@ class PkgV:
 			skip_version_check = True
 
 		if host != None:
-			result = self.__search_pkg(f"ssh {host} pip3 list")
+			cmd = "ssh %s pip3 list" % host
 		else:
-			result = self.__search_pkg("pip3 list")
+			cmd = "pip3 list"
+
+		result = self.__search_pkg(cmd)
 
 		for pkg in pkgs:
 			if result.find(f"{pkg}") == -1:

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -25,75 +25,75 @@ from cortx.utils.process import SimpleProcess
 from cortx.utils.validator.v_network import NetworkV
 
 class PkgV:
-	"""Pkg related validations."""
+    """Pkg related validations."""
 
-	def __search_pkg(self, cmd):
-		# print(f"Running {cmd}")
-		handler = SimpleProcess(cmd)
-		stdout, stderr, retcode = handler.run()
-		if retcode != 0:
-			raise VError(errno.EINVAL,
-				     "cmd: %s failed with error code: %d, stderr: %s"
-				     %(cmd, retcode, stderr))
-		return stdout.decode("utf-8")
+    def __search_pkg(self, cmd):
+        # print(f"Running {cmd}")
+        handler = SimpleProcess(cmd)
+        stdout, stderr, retcode = handler.run()
+        if retcode != 0:
+            raise VError(errno.EINVAL,
+                     "cmd: %s failed with error code: %d, stderr: %s"
+                     %(cmd, retcode, stderr))
+        return stdout.decode("utf-8")
 
-	def validate(self, v_type: str, args: list, host: str = None):
-		"""
-		Process rpm validations.
-		Usage (arguments to be provided):
-		1. pkg validate_rpms host (optional) [packagenames]
-		2. pkg validate_pip3s host (optional) [pip3 packagenames]
-		"""
+    def validate(self, v_type: str, args: list, host: str = None):
+        """
+        Process rpm validations.
+        Usage (arguments to be provided):
+        1. pkg validate_rpms host (optional) [packagenames]
+        2. pkg validate_pip3s host (optional) [pip3 packagenames]
+        """
 
-		# Ensure we can perform passwordless ssh and there are no prompts
-		if host:
-			NetworkV().validate('passwordless',
-				[pwd.getpwuid(os.getuid()).pw_name, host])
+        # Ensure we can perform passwordless ssh and there are no prompts
+        if host:
+            NetworkV().validate('passwordless',
+                [pwd.getpwuid(os.getuid()).pw_name, host])
 
-		if v_type == "rpms":
-			return self.validate_rpm_pkgs(host, args)
-		elif v_type == "pip3s":
-			return self.validate_pip3_pkgs(host, args)
-		else:
-			raise VError(errno.EINVAL,
-				     "Action parameter %s not supported" % v_type)
+        if v_type == "rpms":
+            return self.validate_rpm_pkgs(host, args)
+        elif v_type == "pip3s":
+            return self.validate_pip3_pkgs(host, args)
+        else:
+            raise VError(errno.EINVAL,
+                     "Action parameter %s not supported" % v_type)
 
-	def validate_rpm_pkgs(self, host, pkgs, skip_version_check=True):
-		"""Check if rpm pkg is installed."""
+    def validate_rpm_pkgs(self, host, pkgs, skip_version_check=True):
+        """Check if rpm pkg is installed."""
 
-		if not isinstance(pkgs, dict):
-			skip_version_check = True
+        if not isinstance(pkgs, dict):
+            skip_version_check = True
 
-		cmd = "ssh %s rpm -qa" % host if host != None else "rpm -qa"
-		result = self.__search_pkg(cmd)
+        cmd = "ssh %s rpm -qa" % host if host != None else "rpm -qa"
+        result = self.__search_pkg(cmd)
 
-		for pkg in pkgs:
-			if result.find(f"{pkg}") == -1:
-				raise VError(errno.EINVAL, "rpm pkg %s not installed." % pkg)
-			if not skip_version_check:
-				matched_str = re.search(f"{pkg}-([^-][0-9.]+)-", result)
-				installed_version = matched_str.groups()[0]
-				expected_version = pkgs[pkg]
-				if installed_version != expected_version:
-					raise VError(errno.EINVAL, "Mismatched version for rpm package %s. " \
-								"Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+        for pkg in pkgs:
+            if result.find(f"{pkg}") == -1:
+                raise VError(errno.EINVAL, "rpm pkg %s not installed." % pkg)
+            if not skip_version_check:
+                matched_str = re.search(f"{pkg}-([^-][0-9.]+)-", result)
+                installed_version = matched_str.groups()[0]
+                expected_version = pkgs[pkg]
+                if installed_version != expected_version:
+                    raise VError(errno.EINVAL, "Mismatched version for rpm package %s. " \
+                            "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
 
-	def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
-		"""Check if pip3 pkg is installed."""
+    def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
+        """Check if pip3 pkg is installed."""
 
-		if not isinstance(pkgs, dict):
-			skip_version_check = True
+        if not isinstance(pkgs, dict):
+            skip_version_check = True
 
-		cmd = "ssh %s pip3 list" % host if host != None else "pip3 list"
-		result = self.__search_pkg(cmd)
+        cmd = "ssh %s pip3 list" % host if host != None else "pip3 list"
+        result = self.__search_pkg(cmd)
 
-		for pkg in pkgs:
-			if result.find(f"{pkg}") == -1:
-				raise VError(errno.EINVAL, "pip3 pkg %s not installed." % pkg)
-			if not skip_version_check:
-				matched_str = re.search(f"{pkg} \((.*)\)", result)
-				installed_version = matched_str.groups()[0]
-				expected_version = pkgs[pkg]
-				if installed_version != expected_version:
-					raise VError(errno.EINVAL, "Mismatched version for pip3 package %s. " \
-								"Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+        for pkg in pkgs:
+            if result.find(f"{pkg}") == -1:
+                raise VError(errno.EINVAL, "pip3 pkg %s not installed." % pkg)
+            if not skip_version_check:
+                matched_str = re.search(f"{pkg} \((.*)\)", result)
+                installed_version = matched_str.groups()[0]
+                expected_version = pkgs[pkg]
+                if installed_version != expected_version:
+                    raise VError(errno.EINVAL, "Mismatched version for pip3 package %s. " \
+                            "Installed %s. Expected %s." %(pkg, installed_version, expected_version))

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -20,6 +20,8 @@ import re
 import os
 import pwd
 import errno
+import traceback
+from cortx.utils.ssh import SSHChannel
 from cortx.utils.validator.error import VError
 from cortx.utils.process import SimpleProcess
 from cortx.utils.validator.v_network import NetworkV
@@ -27,15 +29,29 @@ from cortx.utils.validator.v_network import NetworkV
 class PkgV:
     """Pkg related validations."""
 
-    def __search_pkg(self, cmd):
+    def __init__(self):
+        self.passwdless_ssh_enabled = False
+        self.ssh = None
+
+    def __execute_cmd(self, cmd):
+        """
+        Execute command using SSHChannel or SimpleProcees
+        Uses SSHChannel to execute ommand on host if passwordless ssh is not configured.
+        Uses SimpleProcess to execute command if no host is provided in args or
+        passwordless ssh is configured on host.
+        """
         # print(f"Running {cmd}")
-        handler = SimpleProcess(cmd)
-        stdout, stderr, retcode = handler.run()
+        if self.ssh:
+            retcode, result = self.ssh.execute(cmd)
+        else:
+            handler = SimpleProcess(cmd)
+            stdout, stderr, retcode = handler.run()
+            result = stdout.decode("utf-8") if retcode ==0 else stderr.decode("utf-8")
         if retcode != 0:
             raise VError(
                 errno.EINVAL,
-                "Package dependency check failed. cmd: %s stderr: %s" %(cmd, stderr))
-        return stdout.decode("utf-8")
+                "Command failure. cmd: %s stderr: %s" %(cmd, result))
+        return result
 
     def validate(self, v_type: str, args: list, host: str = None):
         """
@@ -44,11 +60,30 @@ class PkgV:
         1. pkg validate_rpms host (optional) [packagenames]
         2. pkg validate_pip3s host (optional) [pip3 packagenames]
         """
-
-        # Ensure we can perform passwordless ssh and there are no prompts
         if host:
-            NetworkV().validate('passwordless',
-                [pwd.getpwuid(os.getuid()).pw_name, host])
+            try:
+                # Ensure we can perform passwordless ssh and there are no prompts
+                NetworkV().validate('passwordless',
+                    [pwd.getpwuid(os.getuid()).pw_name, host])
+                self.passwdless_ssh_enabled = True
+            except VError:
+                # Create ssh connection in case passwordless ssh is not configured
+                host_details = re.search(r"(\w+):(.+)@(.+):(\d+)", host)
+                if not host_details or len(host_details.groups()) != 4:
+                    raise VError(
+                        errno.EINVAL,
+                        "Invalid host_url format is given for passwordless ssh not configured host.")
+                user = host_details.groups()[0]
+                passwd = host_details.groups()[1]
+                host = host_details.groups()[2]
+                port = host_details.groups()[3]
+                try:
+                    self.ssh = SSHChannel(
+                        host=host, username=user, password=passwd, port=port)
+                except:
+                    err = traceback.format_exc()
+                    raise VError(
+                        errno.EINVAL, "Failed to create ssh connection to %s, Error: %s" % (host, err))
 
         if v_type == "rpms":
             return self.validate_rpm_pkgs(host, args)
@@ -57,20 +92,26 @@ class PkgV:
         else:
             raise VError(errno.EINVAL, "Action parameter %s not supported" % v_type)
 
+        if self.ssh:
+            self.ssh.disconnect()
+
     def validate_rpm_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if rpm pkg is installed."""
+        rpm_cmd = "rpm -qa"
 
         if not isinstance(pkgs, dict):
             skip_version_check = True
 
-        cmd = "ssh %s rpm -qa" % host if host != None else "rpm -qa"
-        result = self.__search_pkg(cmd)
+        if self.passwdless_ssh_enabled:
+            rpm_cmd = "ssh %s %s" % (host, rpm_cmd)
+
+        result = self.__execute_cmd(rpm_cmd)
 
         for pkg in pkgs:
-            if result.find(f"{pkg}") == -1:
+            if result.find("%s" % pkg) == -1:
                 raise VError(errno.EINVAL, "rpm pkg %s not installed." % pkg)
             if not skip_version_check:
-                matched_str = re.search(f"{pkg}-([^-][0-9.]+)-", result)
+                matched_str = re.search(r"%s-([^-][0-9.]+)-" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
@@ -79,18 +120,21 @@ class PkgV:
 
     def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if pip3 pkg is installed."""
+        pip3_cmd = "pip3 list"
 
         if not isinstance(pkgs, dict):
             skip_version_check = True
 
-        cmd = "ssh %s pip3 list" % host if host != None else "pip3 list"
-        result = self.__search_pkg(cmd)
+        if self.passwdless_ssh_enabled:
+            pip3_cmd = "ssh %s %s" % (host, pip3_cmd)
+
+        result = self.__execute_cmd(pip3_cmd)
 
         for pkg in pkgs:
-            if result.find(f"{pkg}") == -1:
+            if result.find("%s" % pkg) == -1:
                 raise VError(errno.EINVAL, "pip3 pkg %s not installed." % pkg)
             if not skip_version_check:
-                matched_str = re.search(f"{pkg} \((.*)\)", result)
+                matched_str = re.search(r"%s \((.*)\)" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:

--- a/py-utils/src/utils/validator/v_pkg.py
+++ b/py-utils/src/utils/validator/v_pkg.py
@@ -20,22 +20,36 @@ import re
 import os
 import pwd
 import errno
+import socket
+from cortx.utils.ssh import SSHChannel
 from cortx.utils.validator.error import VError
 from cortx.utils.process import SimpleProcess
 from cortx.utils.validator.v_network import NetworkV
 
+
 class PkgV:
     """Pkg related validations."""
 
+    def __init__(self):
+        self.passwdless_ssh_enabled = False
+        self.ssh = None
+
     def __execute_cmd(self, cmd):
-        """Execute command and return decoded string as result."""
-        handler = SimpleProcess(cmd)
-        stdout, stderr, retcode = handler.run()
-        result = stdout.decode("utf-8") if retcode ==0 else stderr.decode("utf-8")
+        """
+        Execute command using SSHChannel or SimpleProcees and returns result.
+        Uses SimpleProcess to execute the command on passwordless ssh configured
+        host. Otherwise, uses SSHChannel to execute command.
+        """
+        if self.ssh:
+            retcode, result = self.ssh.execute(cmd)
+        else:
+            handler = SimpleProcess(cmd)
+            stdout, stderr, retcode = handler.run()
+            result = stdout.decode("utf-8") if retcode == 0 else stderr.decode("utf-8")
         if retcode != 0:
             raise VError(
-                errno.EINVAL,
-                "Command failure. cmd: %s stderr: %s" %(cmd, result))
+                errno.EINVAL, "Command failure. cmd: %s stderr: %s" % (cmd, result)
+            )
         return result
 
     def validate(self, v_type: str, args: list, host: str = None):
@@ -44,11 +58,23 @@ class PkgV:
         Usage (arguments to be provided):
         1. pkg validate_rpms host (optional) [packagenames]
         2. pkg validate_pip3s host (optional) [pip3 packagenames]
+        host should be host url in case passwordless ssh is not configured.
+        host url format - user:passwd@fqdn:port
         """
-        if host:
+        host = socket.getfqdn() if host == None or host == "localhost" else host
+        host_details = re.search(r"(\w+):(.+)@(.+):(\d+)", host)
+        if host_details:
+            user = host_details.groups()[0]
+            passwd = host_details.groups()[1]
+            host = host_details.groups()[2]
+            port = host_details.groups()[3]
+            self.ssh = SSHChannel(host=host, username=user, password=passwd, port=port)
+        elif host != socket.getfqdn():
             # Ensure we can perform passwordless ssh and there are no prompts
-            NetworkV().validate('passwordless',
-                [pwd.getpwuid(os.getuid()).pw_name, host])
+            NetworkV().validate(
+                "passwordless", [pwd.getpwuid(os.getuid()).pw_name, host]
+            )
+            self.passwdless_ssh_enabled = True
 
         if v_type == "rpms":
             return self.validate_rpm_pkgs(host, args)
@@ -57,40 +83,53 @@ class PkgV:
         else:
             raise VError(errno.EINVAL, "Action parameter %s not supported" % v_type)
 
+        if self.ssh:
+            self.ssh.disconnect()
+
     def validate_rpm_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if rpm pkg is installed."""
+        cmd = "ssh %s rpm -qa" % host if self.passwdless_ssh_enabled else "rpm -qa"
+        result = self.__execute_cmd(cmd)
+
         if not isinstance(pkgs, dict):
             skip_version_check = True
 
-        rpm_cmd = "ssh %s rpm -qa" % host if host else "rpm -qa"
-        result = self.__execute_cmd(rpm_cmd)
-
         for pkg in pkgs:
             if result.find("%s" % pkg) == -1:
-                raise VError(errno.EINVAL, "rpm pkg %s not installed." % pkg)
+                raise VError(
+                    errno.EINVAL, "rpm pkg %s not installed on host %s." % (pkg, host)
+                )
             if not skip_version_check:
                 matched_str = re.search(r"%s-([^-][0-9.]+)-" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
-                    raise VError(errno.EINVAL, "Mismatched version for rpm package %s. " \
-                        "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+                    raise VError(
+                        errno.EINVAL,
+                        "Mismatched version for rpm package %s on host %s. Installed %s. Expected %s."
+                        % (pkg, host, installed_version, expected_version),
+                    )
 
     def validate_pip3_pkgs(self, host, pkgs, skip_version_check=True):
         """Check if pip3 pkg is installed."""
+        cmd = "ssh %s pip3 list" % host if self.passwdless_ssh_enabled else "pip3 list"
+        result = self.__execute_cmd(cmd)
+
         if not isinstance(pkgs, dict):
             skip_version_check = True
 
-        pip3_cmd = "ssh %s pip3 list" % host if host else "pip3 list"
-        result = self.__execute_cmd(pip3_cmd)
-
         for pkg in pkgs:
             if result.find("%s" % pkg) == -1:
-                raise VError(errno.EINVAL, "pip3 pkg %s not installed." % pkg)
+                raise VError(
+                    errno.EINVAL, "pip3 pkg %s not installed on host %s." % (pkg, host)
+                )
             if not skip_version_check:
                 matched_str = re.search(r"%s \((.*)\)" % pkg, result)
                 installed_version = matched_str.groups()[0]
                 expected_version = pkgs[pkg]
                 if installed_version != expected_version:
-                    raise VError(errno.EINVAL, "Mismatched version for pip3 package %s. " \
-                        "Installed %s. Expected %s." %(pkg, installed_version, expected_version))
+                    raise VError(
+                        errno.EINVAL,
+                        "Mismatched version for pip3 package %s on host %s. Installed %s. Expected %s."
+                        % (pkg, host, installed_version, expected_version),
+                    )


### PR DESCRIPTION
Unittest result:
```
[root 2021-03-09 ~]$ python3 utils_pgk_check_EOS-18332/cortx-utils/py-utils/src/utils/validator/validate.py Pkg pip3s zope.component
[root 2021-03-09 ~]$
[root 2021-03-09 ~]$
[root 2021-03-09 ~]$ python3 utils_pgk_check_EOS-18332/cortx-utils/py-utils/src/utils/validator/validate.py Pkg rpms cortx-py-utils
[root 2021-03-09 ~]$
```

```
[root 2021-03-10 ~]$
[root 2021-03-10 ~]$ python3 utils_pgk_check_EOS-18332/cortx-utils/py-utils/test/validator/test_pkg_validator.py -v
test_pip3_installed (__main__.TestRpmValidator)
Check if pip3 pkg installed. ... ok
test_remote_pip3_installed (__main__.TestRpmValidator)
Check if pip3 pkg installed. ... ok
test_remote_rpm_installed (__main__.TestRpmValidator)
Check if rpm pkg installed. ... ok
test_rpm_installed (__main__.TestRpmValidator)
Check if rpm pkg installed. ... ok

----------------------------------------------------------------------
Ran 4 tests in 2.974s

OK
```