### PR TITLE
= delim added in valid list

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -39,7 +39,7 @@ class ConfCli:
     def set(args):
         """ Set Key Value """
         kv_delim = '=' if args.kv_delim == None else args.kv_delim
-        if len(kv_delim) > 1 or kv_delim not in [':', '>', '.', '|', '/']:
+        if len(kv_delim) > 1 or kv_delim not in [':', '>', '.', '|', '/', '=']:
             raise ConfError(errno.EINVAL, "invalid delim %s", kv_delim)
         kv_list = args.args[0].split(';')
         for kv in kv_list:


### PR DESCRIPTION
Error:
```
[root@ssc-vm-2516 ~]# conf json:///root/provisioner_cluster.json set "cluster>srvnode-1>machine_id=$MACHINEID"
error(22): invalid delim =

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cli.py", line 154, in main
    out = args.func(args)
  File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cli.py", line 43, in set
    raise ConfError(errno.EINVAL, "invalid delim %s", kv_delim)
cortx.utils.conf_store.error.ConfError: error(22): invalid delim =
```
Signed-off-by: Bansidhar Soni <bansidhar.soni@seagate.com>