### PR TITLE
ConfStore: KvStore Pillar support

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+set -e
+PROG_NAME=$(basename "$0")
+BASE_DIR=$(realpath $(dirname "$0")/../py-utils)
+BUILD_NUMBER=
+GIT_VER=
+
+usage() {
+    echo """usage: $PROG_NAME [-v version] [-g git_version] [-b build_number]""" 1>&2;
+    exit 1;
+}
+
+# Check for passed in arguments
+while getopts ":g:v:b:" o; do
+    case "${o}" in
+        v)
+            VER=${OPTARG}
+            ;;
+        g)
+            GIT_VER=${OPTARG}
+            ;;
+        b)
+            BUILD_NUMBER=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[ -z $"$GIT_VER" ] && GIT_VER="$(git rev-parse --short HEAD)" \
+        || GIT_VER="${GIT_VER}_$(git rev-parse --short HEAD)"
+[ -z "$VER" ] && VER="1.0.0"
+[ -z "$BUILD_NUMBER" ] && BUILD_NUMBER=1
+REL="${BUILD_NUMBER}_${GIT_VER}"
+
+cd "$BASE_DIR"
+echo "Creating cortx-py-utils RPM with version $VER, release $REL"
+
+# Create the utils-pre-install
+echo "#!/bin/bash" > utils-pre-install
+echo ""  >> utils-pre-install
+echo "PACKAGE_LIST=\""  >> utils-pre-install
+/bin/cat requirements.txt >> utils-pre-install
+echo "\""  >> utils-pre-install
+echo "rc=0
+for package in \$PACKAGE_LIST
+do
+    pip3 freeze | grep \$package > /dev/null
+    if [ \$? -ne 0 ]; then
+       if [ \$rc -eq 0 ]; then
+           echo \"===============================================\"
+       fi
+       echo \"Required python package \$package is missing\"
+       rc=-1
+    fi
+done
+if [ \$rc -ne 0 ]; then
+    echo \"Please install above python packages\"
+    echo \"===============================================\"
+fi
+exit \$rc " >> utils-pre-install
+/bin/chmod +x utils-pre-install
+
+# Create the rpm
+/bin/python3.6 setup.py bdist_rpm --version="$VER" --release="$REL" --pre-install \
+utils-pre-install --post-install utils-post-install --post-uninstall utils-post-uninstall

--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -44,10 +44,11 @@ $ python3 setup.py bdist_wheel
 ```
 
   - Create RPM Package
-It will create `cortx-py-utils-1.0.0-1.noarch.rpm` by default. One can change the version by passing extra `--version=<version_string>` parameter.
-Below command passes version string as 2.0.0, which creates `cortx-py-utils-2.0.0-1.noarch.rpm`
+It will create `cortx-py-utils-1.0.0-1_<git-version>.noarch.rpm` by default. One can change the version by passing extra `-v <version_string>` parameter.
+Below command passes version string as 2.0.0 and build number 2, which creates `cortx-py-utils-2.0.0-2_<git-version>.noarch.rpm`
+Run below command from repo root.
 ```bash
-$ python3.6 setup.py bdist_rpm --version=2.0.0 --post-install utils-post-install --post-uninstall utils-post-uninstall
+$ ./jenkins/build.sh -v 2.0.0 -b 2
 ```
 
 ## Installation
@@ -58,7 +59,7 @@ $ pip3 install cortx_py_utils-1.0.0-py3-none-any.whl
 ```
 
   - Installation with RPM package
-Note : The rpm package installation will not install any dependent python packages.
+Note : The rpm package installation will fail if any dependent python package is not installed.
 Please refer to WIKI (https://github.com/Seagate/cortx-utils/wiki/%22cortx-py-utils%22-single-node-manual-provisioning)
 ```bash
 $ cd dist;

--- a/py-utils/test/test_conf_store/test_conf_store.py
+++ b/py-utils/test/test_conf_store/test_conf_store.py
@@ -291,6 +291,36 @@ class TestConfStore(unittest.TestCase):
             load_config('pro_local1', 'properties:///tmp/example.properties')
         except Exception as err:
             self.assertEqual('Invalid properties store format %s. %s.', err.args[1])
+    
+    # Pillar
+    def test_conf_store_a_pillar_load_and_get_keys(self):
+        """ Test by loading the given pillar file to conf in-memory """
+        load_config("pillar_local", "pillar://930404:Seagate#123@127.0.0.1")
+        result_data = Conf.get_keys('pillar_local')
+        self.assertTrue(len(result_data))
+
+    def test_conf_store_pillar_get(self):
+        """ Test by loading the given pillar file to conf in-memory """
+        result_keys = Conf.get_keys('pillar_local')
+        if len(result_keys)>0:
+            out = Conf.get("pillar_local", result_keys[0])
+            self.assertTrue(out)
+        else:
+            self.assertTrue(True if len(result_keys)==0 else False)
+
+    def test_conf_store_pillar_copy_api(self):
+        """ 
+        Test by coping the pillar to new index and dumping to a json file 
+        """
+        custom_file_loc = "/tmp/conf_pillar_copy.json"
+        Conf.load('pillar_local_backup', f"json://{custom_file_loc}.bak")
+        Conf.copy('pillar_local', 'pillar_local_backup')
+        Conf.save('pillar_local_backup')
+        pillar_local = Conf.get_keys("pillar_local_backup")
+        Conf.load('pillar_local_backup_loaded', f"json://{custom_file_loc}.bak")
+        bkup_loaded = Conf.get_keys("pillar_local_backup_loaded")
+        self.assertListEqual(bkup_loaded, pillar_local)
+
 
 if __name__ == '__main__':
     """

--- a/py-utils/test/test_kv_store/test_kv_store.py
+++ b/py-utils/test/test_kv_store/test_kv_store.py
@@ -300,5 +300,61 @@ class TestStore(unittest.TestCase):
             'values to unpack (expected 2, got 1).'
             self.assertEqual(exp_err, err._desc)
 
+    def test_kv_pillar_support(self):
+        """ Test Kv Store with pillar data by loading it to KvStore """
+        kv_store = KvStoreFactory.get_instance("pillar://930404:Seagate#123@127.0.0.1")
+        data = kv_store.load()
+        self.assertGreaterEqual(len(data.get_keys()), 0)
+
+    def test_kv_pillar_set_target(self):
+        """ Test Kv Store with pillar data by setting targeted minions """
+        kv_store = KvStoreFactory.get_instance("pillar://930404:Seagate#123@127.0.0.1")
+        kv_store.set_target('srvnode-1')
+        self.assertEqual(kv_store._target, 'srvnode-1')
+
+    def test_kv_pillar_get_api(self):
+        """ Test Kv Store with pillar data by getting value for key """
+        kv_store = KvStoreFactory.get_instance("pillar://930404:Seagate#123@127.0.0.1")
+        kv_inst = kv_store.load()
+        data = kv_inst.get_data()
+        # To get the key for testing dynamically 
+        # since pillar store data unknown on other system
+        key1 = list(data.keys())[0]
+        key2_list = list(data[key1].keys())
+        if len(key2_list) > 0:
+            out = kv_inst.get(key2_list[0])
+            out = list(out.values())
+            result = data[key1][key2_list[0]]
+            self.assertEqual(out[0], result)
+        else:
+            #Consider your pillar has no values
+            self.assertTrue(True if len(key2)==0 else False)
+
+    def test_kv_pillar_dump_api_test(self):
+        """ 
+        Test Kv Store with pillar data by dump pillar data into a file 
+        dump file default location
+        /tmp/pillar_store.json
+        """
+        kv_store = KvStoreFactory.get_instance("pillar://930404:Seagate#123@127.0.0.1")
+        data = kv_store.load()
+        kv_store.dump(data)
+        ret_json = test_current_file("json:///tmp/pillar_store.json")
+        result = ret_json[1].get_data()
+        self.assertTrue(result)
+    
+    def test_kv_pillar_dump_api_custom_location_test(self):
+        """ 
+        Test Kv Store with pillar data by dump pillar data into a file 
+        dump file custom location
+        /tmp/cust_pillar_bkup.json
+        """
+        kv_store = KvStoreFactory.get_instance("pillar://930404:Seagate#123@127.0.0.1")
+        data = kv_store.load()
+        kv_store.dump(data, "/tmp/cust_pillar_bkup.json")
+        ret_json = test_current_file("json:///tmp/cust_pillar_bkup.json")
+        result = ret_json[1].get_data()
+        self.assertTrue(result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Pillar load, get, dump, set_target api's

kvStore pillar with saltstack api integration has below working api's with testcases
KvStorePillar get
KvStorePillar load
KvStorepillar dump

"cortx-py-utils" rpm depends on various python packages.
The %pre phase should check whether these python packages are
installed or not. If these packages do not exists, then throw
message asking to install them

Signed-off-by: Sachin Punadikar <sachin.punadikar@seagate.com>
Signed-off-by: suryakumar <suryakumar.kumaravelan@seagate.com>

-----
[View rendered py-utils/README.md](https://github.com/suryakumar1024/cortx-utils/blob/kv_pillar/py-utils/README.md)