### PR TITLE
Add method to return machine id in Conf

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -36,6 +36,7 @@ class ConfStore:
         self._delim = delim
         self._cache = {}
         self._callbacks = {}
+        self._machine_id = None
 
     def load(self, index: str, kvs_url: str, **kwargs):
         """
@@ -153,6 +154,16 @@ class ConfStore:
         for key in key_list:
             self._cache[dst_index].set(key, self._cache[src_index].get(key))
 
+    def get_machine_id(self):
+        """ Returns the machine id from /etc/machine-id """
+        if self._machine_id is None:
+            from pathlib import Path
+            machine_id_file = Path("/etc/machine-id")
+            if machine_id_file.is_file() and machine_id_file.stat().st_size > 0:
+                with open("/etc/machine-id", 'r') as mc_id_file:
+                    self._machine_id = mc_id_file.read()
+        return self._machine_id
+
 
 class Conf:
     """ Singleton class instance based on conf_store """
@@ -201,3 +212,8 @@ class Conf:
     def get_keys(index: str):
         """ Obtains list of keys stored in the specific config store """
         return Conf._conf.get_keys(index)
+
+    @staticmethod
+    def get_machine_id():
+        """ Returns the machine id from /etc/machine-id """
+        return Conf._conf.get_machine_id()

--- a/py-utils/test/test_conf_store/test_conf_store.py
+++ b/py-utils/test/test_conf_store/test_conf_store.py
@@ -292,6 +292,21 @@ class TestConfStore(unittest.TestCase):
         except Exception as err:
             self.assertEqual('Invalid properties store format %s. %s.', err.args[1])
 
+    def test_conf_store_get_machin_id_none(self):
+        """ Test get_machine_id None value """
+        # rename /etc/machine-id
+        os.rename("/etc/machine-id", "/etc/machine-id.old")
+        mc_id = Conf.get_machine_id()
+        # restore /etc/machine-id
+        os.rename("/etc/machine-id.old", "/etc/machine-id")
+        self.assertEqual(mc_id, None)
+
+    def test_conf_store_get_machin_id(self):
+        """ Test get_machine_id """
+        mc_id = Conf.get_machine_id()
+        self.assertTrue(mc_id)
+
+
 if __name__ == '__main__':
     """
     Firstly create the file and load sample json into it.


### PR DESCRIPTION
Add method get_machine_id in Conf class. This will read from
file /etc/machine-id and return the unique id.

Signed-off-by: Sachin Punadikar <sachin.punadikar@seagate.com>