### PR TITLE
Added deepcopy functionality for get api return value

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -87,6 +87,7 @@ class ConfStore:
         Return Value:
                 Return type will be dict or string based of key
         """
+        import copy
         if index not in self._cache.keys():
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index)
@@ -94,7 +95,8 @@ class ConfStore:
             raise ConfError(errno.EINVAL, "can't able to find config key "
                                                "%s in loaded config", key)
         val = self._cache[index].get(key)
-        return default_val if val is None else val
+        ret_val = default_val if val is None else val
+        return copy.deepcopy(ret_val)
 
     def set(self, index: str, key: str, val):
         """

--- a/py-utils/test/test_conf_store/test_conf_store.py
+++ b/py-utils/test/test_conf_store/test_conf_store.py
@@ -292,6 +292,13 @@ class TestConfStore(unittest.TestCase):
         except Exception as err:
             self.assertEqual('Invalid properties store format %s. %s.', err.args[1])
 
+    def test_conf_store_return_val_ref_test(self):
+        """Test by getting the key from the loaded config"""
+        retrived_list_1 = Conf.get('msg_local', 'bridge>lte_type')
+        retrived_list_1.append(3)
+        retrived_list_2 = Conf.get('msg_local', 'bridge>lte_type')
+        self.assertTrue(True if retrived_list_1 != retrived_list_2 else False)
+
 if __name__ == '__main__':
     """
     Firstly create the file and load sample json into it.


### PR DESCRIPTION
Fix for get api return value
Fix for:
if return value modified from used side then the conf in-memory value also get affected 

Added deepcopy method which used to return only copy of the object instead of returning the actual object ref.

Signed-off-by: suryakumar <suryakumar.kumaravelan@seagate.com>