### PR TITLE
EOS-20211: Raise exception for unknown topic for n retries

### DIFF
--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -66,8 +66,7 @@ class KafkaMessageBroker(MessageBroker):
                 client = self._clients[client_type][client_conf["client_id"]]
                 available_message_types = client.list_topics().topics.keys()
                 if client_type == "producer":
-                    if client_conf[
-                        "message_type"] not in available_message_types:
+                    if client_conf["message_type"] not in available_message_types:
                         raise KafkaException(KafkaError(3))
                 elif client_type == "consumer":
                     if not any(each_message_type in available_message_types for \

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -63,6 +63,7 @@ class KafkaMessageBroker(MessageBroker):
 
         if client_conf["client_id"] in self._clients[client_type].keys():
             if self._clients[client_type][client_conf["client_id"]] != {}:
+                # Check if message_type exists to send/receive
                 client = self._clients[client_type][client_conf["client_id"]]
                 available_message_types = client.list_topics().topics.keys()
                 if client_type == "producer":

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -19,7 +19,7 @@ import errno
 import time
 import json
 import re
-from confluent_kafka import Producer, Consumer, KafkaError
+from confluent_kafka import Producer, Consumer, KafkaError, KafkaException
 from confluent_kafka.admin import AdminClient, ConfigResource, NewTopic, \
     NewPartitions
 from cortx.utils.message_bus.error import MessageBusError
@@ -61,8 +61,19 @@ class KafkaMessageBroker(MessageBroker):
             raise MessageBusError(errno.EINVAL, "Invalid client type %s", \
                 client_type)
 
-        if client_conf['client_id'] in self._clients[client_type].keys():
-            if self._clients[client_type][client_conf['client_id']] != {}:
+        if client_conf["client_id"] in self._clients[client_type].keys():
+            if self._clients[client_type][client_conf["client_id"]] != {}:
+                client = self._clients[client_type][client_conf["client_id"]]
+                available_message_types = client.list_topics().topics.keys()
+                if client_type == "producer":
+                    if client_conf[
+                        "message_type"] not in available_message_types:
+                        raise KafkaException(KafkaError(3))
+                elif client_type == "consumer":
+                    if not any(each_message_type in available_message_types for \
+                               each_message_type in
+                               client_conf["message_types"]):
+                        raise KafkaException(KafkaError(3))
                 return
 
         kafka_conf = {}


### PR DESCRIPTION
confluent-kafka does not raise an unknown topic exception if it tries to send/receive for successive times.
A check is made on producer/consumer initialization and UNKNOWN_TOPIC_OR_PART error is thrown if topic does not exist.

Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>