### PR TITLE
Copying Supportbundle to cortx-py-utils

### DIFF
--- a/py-utils/src/utils/support_bundle/bundle_generate.py
+++ b/py-utils/src/utils/support_bundle/bundle_generate.py
@@ -1,0 +1,242 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import os
+import threading
+import shutil
+from typing import Dict, List
+from csm.common import comm
+from csm.common.payload import Yaml, Tar
+from csm.core.blogic import const
+from datetime import datetime
+from csm.common.process import SimpleProcess
+from cortx.utils.conf_store.conf_store import Conf
+from cortx.utils.log import Log
+
+ERROR = "error"
+INFO = "info"
+
+class ComponentsBundle:
+    """
+    This class handles generation for support bundles for different components.
+    """
+    @staticmethod
+    def publish_log(msg, level, bundle_id, node_name, comment):
+        """
+        Format and Publish Log to ElasticSearch via Rsyslog.
+        :param msg: Message to Be added :type: str.
+        :param bundle_id: Unique Bundle Id for the Bundle :type:str.
+        :param level: Level for the Log. :type: Log.ERROR/LOG.INFO.
+        :param node_name: Name of the Node where this is running :type:str.
+        :param comment: Comment Added by user to Generate the Bundle :type:str.
+        :return: None.
+        """
+        #Initilize Logger for Uploading the Final Comment to ElasticSearch.
+        Log.init("support_bundle",
+                 syslog_server=Conf.get(const.CSM_GLOBAL_INDEX, "Log>syslog_server"),
+                 syslog_port=int(Conf.get(const.CSM_GLOBAL_INDEX, "Log>syslog_port")),
+                 backup_count=Conf.get(const.CSM_GLOBAL_INDEX, "Log>total_files"),
+                 file_size_in_mb=Conf.get(const.CSM_GLOBAL_INDEX,
+                                          "Log>file_size"),
+                 log_path=Conf.get(const.CSM_GLOBAL_INDEX, "Log>log_path"),
+                 level=Conf.get(const.CSM_GLOBAL_INDEX, "Log>log_level"))
+        result = "Success"
+        if level == ERROR:
+            result = ERROR.capitalize()
+        message = (f"{const.SUPPORT_BUNDLE_TAG}|{bundle_id}|{node_name}|{comment}|"
+                   f"{result}|{msg}")
+        Log.support_bundle(message)
+
+    @staticmethod
+    def exc_components_cmd(commands: List, bundle_id: str, path: str,
+            component: str, node_name: str, comment: str):
+        """
+        Executes the Command for Bundle Generation of Every Component.
+        :param commands: Command of the component :type:str
+        :param bundle_id: Unique Bundle ID of the generation process. :type:str
+        :param path: Path to create the tar by components :type:str
+        :param component: Name of Component to be executed :type: str
+        :param node_name:Name of Node where the Command is being Executed
+        :type:str
+        :param comment: :User Comment: type:str
+        :return:
+        """
+        for command in commands:
+            Log.debug(f"Executing command -> {command} {bundle_id} {path}")
+            cmd_proc = SimpleProcess(f"{command} {bundle_id} {path}")
+            output, err, return_code = cmd_proc.run()
+            Log.debug(f"Command Output -> {output} {err}, {return_code}")
+            if return_code != 0:
+                Log.error(f"Command Output -> {output} {err}, {return_code}")
+                ComponentsBundle.publish_log(
+                    f"Bundle generation failed for {component}", ERROR,
+                    bundle_id, node_name, comment)
+
+
+    @staticmethod
+    def send_file(protocol_details: Dict, file_path: str):
+        """
+        Method to send the tar files ove FTP Location.
+        :param protocol_details: Dictionary of FTP Details. :type:dict
+        :param file_path: Path of tar file to be sent. :type:str
+        :return:
+        """
+        if not protocol_details.get("host", None):
+            Log.warn("Skipping file upload as host is not configured.")
+            return False
+        url = protocol_details.get('url')
+        protocol = url.split("://")[0]
+        channel = f"{protocol.upper()}Channel"
+        if hasattr(comm, channel):
+            try:
+                channel_obj = getattr(comm, channel)(**protocol_details)
+                channel_obj.connect()
+            except Exception as e:
+                Log.error(f"File connection failed. {e}")
+                raise Exception((f"Failed to connect to {protocol}, "
+                                 f"please check credentials."))
+            try:
+                channel_obj.send_file(file_path, protocol_details.get('remote_file'))
+            except Exception as e:
+                Log.error(f"File upload failed. {e}")
+                raise Exception(f"Could not upload the file to {protocol}.")
+            finally:
+                channel_obj.disconnect()
+        else:
+            Log.error("Invalid url in csm.conf.")
+            raise Exception(f"{protocol} is Invalid.")
+        return True
+
+    @staticmethod
+    async def init(command: List):
+        """
+        Initializes the Process of Support Bundle Generation for Every Component.
+        :param command: Csm_cli Command Object :type: command
+        :return:
+        """
+        # Fetch Command Arguments.
+        bundle_id = command.options.get(const.SB_BUNDLE_ID, "")
+        node_name = command.options.get(const.SB_NODE_NAME, "")
+        comment = command.options.get(const.SB_COMMENT, "")
+        components = command.options.get(const.SB_COMPONENTS, [])
+        ftp_msg, file_link_msg, components_list = "", "", []
+
+        Log.debug((f"{const.SB_BUNDLE_ID}: {bundle_id}, {const.SB_NODE_NAME}: {node_name}, "
+                   f" {const.SB_COMMENT}: {comment}, {const.SB_COMPONENTS}: {components},"
+                   f" {const.SOS_COMP}"))
+        # Read Commands.Yaml and Check's If It Exists.
+        support_bundle_config = Yaml(const.COMMANDS_FILE).load()
+        if not support_bundle_config:
+            ComponentsBundle.publish_log(f"No such file {const.COMMANDS_FILE}",
+                                         ERROR, bundle_id, node_name, comment)
+            return None
+        # Path Location for creating Support Bundle.
+        path = os.path.join(Conf.get(const.CSM_GLOBAL_INDEX,
+                                     f"{const.SUPPORT_BUNDLE}>{const.SB_BUNDLE_PATH}"))
+        if os.path.isdir(path):
+            try:
+                shutil.rmtree(path)
+            except PermissionError:
+                Log.warn(const.PERMISSION_ERROR_MSG.format(path=path))
+
+        bundle_path = os.path.join(path, bundle_id)
+        os.makedirs(bundle_path)
+        # Start Execution for each Component Command.
+        threads = []
+        command_files_info = support_bundle_config.get("COMMANDS")
+        # OS Logs are specifically generated hence here Even When All is Selected O.S. Logs Will Be Skipped.
+        if components:
+            if "all" not in components:
+                components_list = list(set(command_files_info.keys()).intersection(set(components)))
+            else:
+                components_list = list(command_files_info.keys())
+                components_list.remove(const.SOS_COMP)
+        Log.debug(
+            f"Generating for {const.SB_COMPONENTS} {' '.join(components_list)}")
+        for each_component in components_list:
+            components_commands = []
+            components_files = command_files_info[each_component]
+            for file_path in components_files:
+                file_data = Yaml(file_path).load()
+                if file_data:
+                    components_commands = file_data.get(const.SUPPORT_BUNDLE.lower(), [])
+                if components_commands:
+                    thread_obj = threading.Thread(
+                        ComponentsBundle.exc_components_cmd(components_commands,
+                            bundle_id, f"{bundle_path}{os.sep}", each_component,
+                            node_name, comment))
+                    thread_obj.start()
+                    Log.debug(f"Started thread -> {thread_obj.ident}  Component -> {each_component}")
+                    threads.append(thread_obj)
+        directory_path = Conf.get(const.CSM_GLOBAL_INDEX,
+                                  f"{const.SUPPORT_BUNDLE}>{const.SB_BUNDLE_PATH}")
+        tar_file_name = os.path.join(directory_path,
+                                     f"{bundle_id}_{node_name}.tar.gz")
+        # Create Summary File for Tar.
+        summary_file_path = os.path.join(bundle_path, "summary.yaml")
+        Log.debug(f"Adding summary file at {summary_file_path}")
+        summary_data = {
+            const.SB_BUNDLE_ID: str(bundle_id),
+            const.SB_NODE_NAME: str(node_name),
+            const.SB_COMMENT: repr(comment),
+            "Generated Time": str(datetime.isoformat(datetime.now()))
+        }
+        try:
+            Yaml(summary_file_path).dump(summary_data)
+        except PermissionError as e:
+            ComponentsBundle.publish_log(f"Permission denied for creating summary file {e}",
+                                         ERROR, bundle_id, node_name, comment)
+            return None
+        except Exception as e:
+            ComponentsBundle.publish_log(f"{e}", ERROR, bundle_id, node_name,
+                comment)
+            return None
+
+        Log.debug(f'Summary file created')
+        symlink_path = Conf.get(const.CSM_GLOBAL_INDEX,
+            f"{const.SUPPORT_BUNDLE}>{const.SB_SYMLINK_PATH}")
+        if os.path.exists(symlink_path):
+            try:
+                shutil.rmtree(symlink_path)
+            except PermissionError:
+                Log.warn(const.PERMISSION_ERROR_MSG.format(path = symlink_path))
+        os.makedirs(symlink_path, exist_ok = True)
+
+        # Wait Until all the Threads Execution is not Complete.
+        for each_thread in threads:
+            Log.debug(
+                f"Waiting for thread - {each_thread.ident} to complete process")
+            each_thread.join(timeout=1800)
+        try:
+            Log.debug(f"Generating tar.gz file on path {tar_file_name} from {bundle_path}")
+            Tar(tar_file_name).dump([bundle_path])
+        except Exception as e:
+            ComponentsBundle.publish_log(f"Could not generate tar file {e}", ERROR, bundle_id,
+                                         node_name, comment)
+            return None
+        try:
+            Log.debug("Create soft-link for generated tar.")
+            os.symlink(tar_file_name, os.path.join(symlink_path,
+                                                   f"{const.SUPPORT_BUNDLE}.{bundle_id}"))
+            ComponentsBundle.publish_log(f"Tar file linked at location - {symlink_path}", INFO, bundle_id, node_name,
+                                         comment)
+        except Exception as e:
+            ComponentsBundle.publish_log(f"Linking failed {e}", ERROR, bundle_id,
+                                         node_name, comment)
+        finally:
+            if os.path.isdir(bundle_path):
+                shutil.rmtree(bundle_path)
+        msg = f"Support bundle generation completed."
+        ComponentsBundle.publish_log(msg, INFO, bundle_id, node_name, comment)

--- a/py-utils/src/utils/support_bundle/commands.yaml
+++ b/py-utils/src/utils/support_bundle/commands.yaml
@@ -1,0 +1,43 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+#Component Commands file Path.
+COMMANDS:
+  health_map:
+    - '/opt/seagate/health_view/conf/setup.yaml'
+  os:
+    - '/opt/seagate/os/conf/setup.yaml'
+  csm:
+    - '<CORTX_PATH>/cli/conf/setup.yaml'
+  sspl:
+    - '<CORTX_PATH>/sspl/conf/setup.yaml'
+  s3server:
+    - '<CORTX_PATH>/s3/conf/setup.yaml'
+  motr:
+    - '<CORTX_PATH>/motr/conf/setup.yaml'
+  hare:
+    - '<CORTX_PATH>/hare/conf/setup.yaml'
+  provisioner:
+    - '<CORTX_PATH>/provisioner/conf/setup.yaml'
+  manifest:
+    - '<CORTX_PATH>/sspl/conf/manifest.yaml'
+  alerts:
+    - '<CORTX_PATH>/cli/conf/alerts_setup.yaml'
+  uds:
+    - '<CORTX_PATH>/cli/conf/uds_setup.yaml'
+  elasticsearch:
+    - '<CORTX_PATH>/cli/conf/elasticsearch_setup.yaml'
+  ha:
+    - '/opt/seagate/cortx/ha/conf/setup.yaml'

--- a/py-utils/src/utils/support_bundle/support_bundle.py
+++ b/py-utils/src/utils/support_bundle/support_bundle.py
@@ -1,0 +1,240 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import sys
+import os
+import string
+import random
+import getpass
+import errno
+from importlib import import_module
+from csm.common.payload import Yaml, JsonMessage
+from csm.core.blogic import const
+from csm.core.services.support_bundle import SupportBundleRepository
+from csm.common.errors import (CSM_OPERATION_SUCESSFUL, CsmError,
+                            InvalidRequest, CSM_ERR_INVALID_VALUE)
+from cortx.utils.data.db.db_provider import (DataBaseProvider, GeneralConfig)
+from cortx.utils.errors import DataAccessExternalError
+from csm.core.providers.providers import Response
+from cortx.utils.conf_store.conf_store import Conf
+from cortx.utils.log import Log
+import time
+from csm.common.process import SimpleProcess
+
+class SupportBundle:
+    """
+    This Class initializes the Support Bundle Generation for CORTX.
+    """
+
+    @staticmethod
+    def import_provisioner_plugin():
+        """Import Plugin for Provisioner."""
+        try:
+            params = {"username": Conf.get(const.CSM_GLOBAL_INDEX, const.NON_ROOT_USER_KEY),
+                      "password": Conf.get(const.CSM_GLOBAL_INDEX, "CSM>password")}
+            provisioner = import_module(
+                f"csm.plugins.{const.PLUGIN_DIR}.{const.PROVISIONER_PLUGIN}").ProvisionerPlugin(
+                **params)
+        except ImportError as e:
+            Log.error(f"Provisioner package not installed on system. {e}")
+            return None
+        return provisioner
+
+    @staticmethod
+    async def fetch_active_nodes_hosts():
+        """
+        This Method is for reading hostnames, node_list information.
+        :return: hostnames : List of Hostname :type: List
+        :return: node_list : : List of Node Name :type: List
+        """
+        Log.info("reading hostnames, node_list information")
+        node_hostname_map = dict()
+        mapping_dict = dict()
+        mapping_dict = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        node_hostname_map = mapping_dict.copy()
+        node_hostname_map.pop(const.SHUTDOWN_CRON_TIME)
+        if not node_hostname_map:
+            response_msg = {
+                "message": "Node list and hostname not found."}
+            return Response(output=response_msg,
+                            rc=CSM_ERR_INVALID_VALUE), None
+        active_nodes = list(node_hostname_map.keys())
+        hostnames = list(node_hostname_map.values())
+        return hostnames, active_nodes
+
+    @staticmethod
+    def generate_bundle_id():
+        """Generate Unique Bundle ID."""
+        alphabet = string.ascii_lowercase + string.digits
+        return f"SB{''.join(random.choices(alphabet, k = 8))}"
+
+    @staticmethod
+    def get_components(components):
+        """Get Components to Generate Support Bundle."""
+        if components and "all" not in components:
+            Log.info(f"Generating bundle for  {' '.join(components)}")
+            shell_args = f"{' '.join(components)}"
+        else:
+            Log.info("Generating bundle for all CORTX components.")
+            shell_args = "all"
+        return f" -c {shell_args}"
+
+    @staticmethod
+    async def bundle_generate(command) -> sys.stdout:
+        """
+        Initializes the process for Generating Support Bundle on Each CORTX Node.
+        :param command: Csm_cli Command Object :type: command
+        :return: None.
+        """
+        current_user = str(getpass.getuser())
+        # Check if User is Root User.
+        if current_user.lower() != const.SSH_USER_NAME:
+            response_msg = f"Support Bundle {const.ROOT_PRIVILEGES_MSG}"
+            return Response(output = response_msg, rc = str(errno.EACCES))
+        bundle_id = SupportBundle.generate_bundle_id()
+        provisioner = SupportBundle.import_provisioner_plugin()
+        if not provisioner:
+            return Response(output = "Provisioner package not found.",
+                            rc = str(errno.ENOENT))
+        # Get Arguments From Command
+        comment = command.options.get(const.SB_COMMENT)
+        components = command.options.get(const.SB_COMPONENTS)
+        if not components:
+            components = []
+        if command.options.get(const.SOS_COMP, False) == "true":
+            components.append("os")
+        comp_list = SupportBundle.get_components(components)
+
+        # Get HostNames and Node Names.
+        hostnames, node_list = await SupportBundle.fetch_active_nodes_hosts()
+        if not isinstance(hostnames, list):
+            return hostnames
+
+        # Start SB Generation on all Nodes.
+        for index, hostname in enumerate(hostnames):
+            Log.debug(f"Connect to {hostname}")
+            try:
+                await provisioner.begin_bundle_generation(
+                    f"bundle_generate '{bundle_id}' '{comment}' "
+                    f"'{hostname}' {comp_list}", node_list[index])
+            except InvalidRequest:
+                return Response(output = "Bundle generation failed.\nPlease "
+                         "check CLI for details.", rc = str(errno.ENOENT))
+            except Exception as e:
+                Log.error(f"Provisioner API call failed : {e}")
+                return Response(output = "Bundle Generation Failed.",
+                                rc = str(errno.ENOENT))
+
+        symlink_path = Conf.get(const.CSM_GLOBAL_INDEX,
+                                f"{const.SUPPORT_BUNDLE}>{const.SB_SYMLINK_PATH}")
+        display_string_len = len(bundle_id) + 4
+        response_msg = (
+            f"Please use the below bundle id for checking the status of support bundle."
+            f"\n{'-' * display_string_len}"
+            f"\n| {bundle_id} |"
+            f"\n{'-' * display_string_len}"
+            f"\nPlease Find the file on -> {symlink_path} .\n")
+
+        return Response(output = response_msg,
+                        rc =CSM_OPERATION_SUCESSFUL)
+
+    @staticmethod
+    async def bundle_status(command):
+        """
+        Initializes the process for Displaying the Status for Support Bundle.
+        :param command: Csm_cli Command Object :type: command
+        :return: None
+        """
+        try:
+            bundle_id = command.options.get("bundle_id", "")
+            conf = GeneralConfig(Yaml(const.DATABASE_CONF).load())
+            db = DataBaseProvider(conf)
+            repo = SupportBundleRepository(db)
+            all_nodes_status = await repo.retrieve_all(bundle_id)
+            response = {"status": [each_status.to_primitive() for each_status in
+                               all_nodes_status]}
+            return Response(output = response, rc = CSM_OPERATION_SUCESSFUL)
+        except DataAccessExternalError as e:
+            Log.warn(f"Failed to connect to elasticsearch: {e}")
+            return Response(output = ("Support Bundle status is not available currently"
+                " as required services are not running."
+                " Please wait and check the /tmp/support_bundle"
+                " folder for newly generated support bundle."),
+                            rc = str(errno.ECONNREFUSED))
+        except Exception as e:
+            Log.error(f"Failed to get bundle status: {e}")
+            return Response(output = ("Support Bundle status is not available currently"
+                " as required services are not running."
+                " Failed to get status of bundle."),
+                            rc = str(errno.ENOENT))
+
+    @staticmethod
+    async def fetch_ftp_data(ftp_details):
+        """
+        Fetch and Validate FTP Data.
+        #todo: Need to Implement Validation Framework for CLI. And Inputs in it.
+        :param ftp_details: Current Keys for FTP.
+        :return:
+        """
+        Log.debug("Configuring FTP channel for support bundle")
+        ftp_details[const.HOST] = str(input("Input FTP Host: "))
+        try:
+            ftp_details[const.PORT] = int(input("Input FTP Port:  "))
+        except ValueError:
+            raise CsmError(rc = errno.EINVAL,
+                           desc = f"{const.PORT} must be a integer type.")
+        ftp_details[const.USER] = str(input("Input FTP User: "))
+        ftp_details[const.PASS] = str(input("Input FTP Password: "))
+        ftp_details['remote_file'] = str(input("Input FTP Remote File Path: "))
+        return ftp_details
+
+    @staticmethod
+    async def configure(command):
+        """
+        Configure FTP for Support Bundle
+        :param command: Csm_cli Command Object :type: command
+        :return:
+        """
+        csm_conf_file_name = os.path.join(const.CORTXCLI_CONF_PATH,
+                                          const.CORTXCLI_CONF_FILE_NAME)
+        if not os.path.exists(csm_conf_file_name):
+            raise CsmError(rc = errno.ENOENT,
+                           desc = "Config file does not exist.")
+        conf_file_data = Yaml(csm_conf_file_name).load()
+        ftp_details = conf_file_data.get(const.SUPPORT_BUNDLE)
+        ftp_details = await SupportBundle.fetch_ftp_data(ftp_details)
+        conf_file_data[const.SUPPORT_BUNDLE] = ftp_details
+        Yaml(csm_conf_file_name).dump(conf_file_data)
+        hostnames, node_list = await SupportBundle.fetch_active_nodes_hosts()
+        if not isinstance(hostnames, list):
+            return hostnames
+        for hostname in hostnames:
+            process = SimpleProcess(
+                f"scp {csm_conf_file_name}  {hostname}:{csm_conf_file_name}")
+            process.run()
+
+    @staticmethod
+    async def show_config(command):
+        """
+        Display Config for Current FTP.
+        # Todo: Need to change this command to display the FTP configuration for an individual node.
+        :param command: Csm_cli Command Object :type: command
+        :return:
+        """
+        support_bundle_config = Conf.get(const.CSM_GLOBAL_INDEX,
+                                         const.SUPPORT_BUNDLE)
+        return Response(output = support_bundle_config,
+                        rc = CSM_OPERATION_SUCESSFUL)
+


### PR DESCRIPTION
Copying supportbundle to cortx-py-utils

Currently supportbundle is tightly coupled with CSM. As per discussion over call, copying the files to pyutils as per requested by Sachine and Rahul.

`def import_provisioner_plugin()`
This will return provisioner api object which is authenticated using service user and password
```
import provisioner
import provisioner.freeze

provisioner.auth_init(
                    username=username,
                    password=password,
                    eauth="pam"
                )
```
`def fetch_active_nodes_hosts()`
This will return hostnames and node ids available in cluster
```
hostname = [ssc-vm-1234.colo.seagate.com,ssc-vm-5678.colo.seagate.com]
node_list = [srvnode-1,srvnode-2]
```

Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>