### PR TITLE
Return stdout and stderror as it is in case of exception in process run method

### DIFF
--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -72,7 +72,7 @@ setup(name='cortx-py-utils',
                 'cortx.utils.schema', 'cortx.utils.appliance_info',
                 'cortx.setup', 'cortx.utils.service',
                 'cortx.utils.setup', 'cortx.utils.setup.kafka',
-                'cortx.utils.rest_server'
+                'cortx.utils.rest_server', 'cortx.utils.iem_framework'
                 ],
       package_data={
         'cortx': ['py.typed'],

--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -1,5 +1,5 @@
 # CORTX-Py-Utils: CORTX Python common library.
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or
@@ -71,7 +71,8 @@ setup(name='cortx-py-utils',
                 'cortx.utils.product_features', 'cortx.utils.security',
                 'cortx.utils.schema', 'cortx.utils.appliance_info',
                 'cortx.setup', 'cortx.utils.service',
-		'cortx.utils.setup', 'cortx.utils.setup.kafka'
+                'cortx.utils.setup', 'cortx.utils.setup.kafka',
+                'cortx.utils.rest_server'
                 ],
       package_data={
         'cortx': ['py.typed'],
@@ -89,8 +90,10 @@ setup(name='cortx-py-utils',
                                             'src/utils/ha/hac/re_build.sh']),
                      ('/opt/seagate/cortx/utils/conf',
                           ['requirements.txt', 'src/setup/setup.yaml']),
-                     ('/opt/seagate/cortx/utils/conf', tmpl_files)],
+                     ('/opt/seagate/cortx/utils/conf', tmpl_files),
+                     ('/etc/systemd/system', ['src/utils/message_bus/cortx_message_bus.service'])],
       long_description=long_description,
       zip_safe=False,
       python_requires='>=3.6',
       install_requires=get_install_requirements())
+

--- a/py-utils/src/utils/errors.py
+++ b/py-utils/src/utils/errors.py
@@ -20,42 +20,28 @@ INTERNAL_ERROR = 0x1005
 ERR_OP_FAILED = 0x1100
 
 
-class BaseError(Exception):
-    """ Parent class for the cli error classes """
+class UtilsError(Exception):
+    """ Generic Exception with error code and output """
 
-    _rc = OPERATION_SUCESSFUL
-    _desc = 'Operation Successful'
-    _caller = ''
+    def __init__(self, rc, message, *args):
+        self._rc = rc
+        self._desc = message % (args)
 
-    def __init__(self, rc=0, desc=None, message_id=None, message_args=None):
-        super(BaseError, self).__init__()
-        self._caller = inspect.stack()[1][3]
-        if rc is not None:
-            self._rc = str(rc)
-        self._desc = desc or self._desc
-        self._message_id = message_id
-        self._message_args = message_args
-
-    def message_id(self):
-        return self._message_id
-
-    def message_args(self):
-        return self._message_args
-
+    @property
     def rc(self):
         return self._rc
 
-    def error(self):
+    @property
+    def desc(self):
         return self._desc
 
-    def caller(self):
-        return self._caller
-
     def __str__(self):
-        return "error(%s): %s" % (self._rc, self._desc)
+        if self._rc == 0:
+            return self._desc
+        return "error(%d): %s" %(self._rc, self._desc)
 
 
-class InternalError(BaseError):
+class InternalError(Exception):
     """
     This error is raised by CLI for all unknown internal errors
     """

--- a/py-utils/src/utils/iem_framework/__init__.py
+++ b/py-utils/src/utils/iem_framework/__init__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+__title__ = 'iem_framework'
+
+from cortx.utils.iem_framework.event_message import EventMessage
+from cortx.utils.iem_framework.error import EventMessageError

--- a/py-utils/src/utils/iem_framework/error.py
+++ b/py-utils/src/utils/iem_framework/error.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from cortx.utils.errors import UtilsError
+
+
+class EventMessageError(UtilsError):
+    """ Generic Exception with error code and output """
+
+    def __init__(self, rc, message, *args):
+        super().__init__(rc, message, *args)

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import json
+import time
+import errno
+from cortx.template import Singleton
+from cortx.utils.conf_store import Conf
+from cortx.utils.iem_framework.error import EventMessageError
+from cortx.utils.message_bus import MessageProducer, MessageConsumer
+
+
+class EventMessage(metaclass=Singleton):
+    """ Event Message framework to generate alerts """
+
+    _conf_file = "json:///etc/cortx/cluster.conf"
+
+    # VALID VALUES for IEC Components
+    _SEVERITY_LEVELS = {
+        'A': 'Alert',
+        'X': 'Critical',
+        'E': 'Error',
+        'W': 'Warning',
+        'N': 'Notice',
+        'C': 'Configuration',
+        'I': 'Informational',
+        'D': 'Detail',
+        'B': 'Debug'
+    }
+    _SOURCE = {
+        'H': 'Hardware',
+        'S': 'Software',
+        'F': 'Firmware',
+        'O': 'OS'
+    }
+
+    @classmethod
+    def __init__(cls):
+        try:
+            Conf.load('cluster', cls._conf_file)
+            ids = Conf.get('cluster', 'server_node')
+            cls._site_id = int(ids['site_id'])
+            cls._rack_id = int(ids['rack_id'])
+            cls._node_id = int(ids['node_id'])
+        except Exception as e:
+            raise EventMessageError(errno.EINVAL, "Invalid config in %s. %s", \
+                cls._conf_file, e)
+
+    @classmethod
+    def init(cls, component: str, source: str, receiver: bool = False):
+        """ Set the Event Message context """
+        cls._component = component
+        cls._source = source
+        cls()
+
+        if cls._component is None:
+            raise EventMessageError(errno.EINVAL, "Invalid component type: %s", \
+                cls._component)
+
+        if cls._source not in cls._SOURCE.keys():
+            raise EventMessageError(errno.EINVAL, "Invalid source type: %s", \
+                cls._source)
+
+        if receiver:
+            cls._client = MessageConsumer(consumer_id='event_consumer', \
+                consumer_group=cls._component, message_types=['IEM'], \
+                auto_ack=True, offset='earliest')
+        else:
+            cls._client = MessageProducer(producer_id='event_producer', \
+                message_type='IEM', method='sync')
+
+    @classmethod
+    def send(cls, module: str, event_id: str, severity: str, message: str, \
+        *params):
+        """ Sends IEM alert message """
+
+        # Validate attributes before sending
+        for attribute in [module, event_id, message]:
+            if attribute is None:
+                raise EventMessageError(errno.EINVAL, "Invalid IEM attributes \
+                    %s", attribute)
+
+        if severity not in cls._SEVERITY_LEVELS:
+            raise EventMessageError(errno.EINVAL, "Invalid severity level: %s" \
+                , severity)
+
+        alert = json.dumps({
+            'iem': {
+                'version': '1',
+                'info': {
+                    'severity': cls._SEVERITY_LEVELS[severity],
+                    'type': cls._SOURCE[cls._source],
+                    'event_time': time.time()
+                    },
+                'location': {
+                    'site_id': cls._site_id,
+                    'node_id': cls._node_id,
+                    'rack_id': cls._rack_id
+                    },
+                'source': {
+                    'component': cls._component,
+                    'module': module
+                    },
+                'contents': {
+                    'event': event_id,
+                    'message': message,
+                    'params': params,
+                }
+            }
+        })
+
+        cls._client.send([alert])
+
+    @classmethod
+    def receive(cls):
+        """ Receive IEM alert message """
+        alert = cls._client.receive()
+        if alert is not None:
+            try:
+                return json.loads(alert.decode('utf-8'))
+            except Exception as e:
+                raise EventMessageError(errno.EPERM, "Unable to load the json. \
+                    %s", e)
+        return alert

--- a/py-utils/src/utils/message_bus/__init__.py
+++ b/py-utils/src/utils/message_bus/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # CORTX-Py-Utils: CORTX Python common library.
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or

--- a/py-utils/src/utils/message_bus/cortx_message_bus.service
+++ b/py-utils/src/utils/message_bus/cortx_message_bus.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=cortx rest server
+After=network.target
+
+[Service]
+User=root
+ExecStart=/opt/seagate/cortx/utils/bin/message_bus_server
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/py-utils/src/utils/message_bus/error.py
+++ b/py-utils/src/utils/message_bus/error.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # CORTX-Py-Utils: CORTX Python common library.
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or
@@ -14,7 +14,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
-
 
 class MessageBusError(Exception):
     """ Generic Exception with error code and output """

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # CORTX-Py-Utils: CORTX Python common library.
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or
@@ -425,7 +425,7 @@ class KafkaMessageBroker(MessageBroker):
                     if timeout > 0:
                         return None
                 elif msg.error():
-                    raise MessageBusError(errno.ECONN, "Cant receive. %s", \
+                    raise MessageBusError(errno.ECONNRESET, "Cant receive. %s", \
                         msg.error())
                 else:
                     return msg.value()

--- a/py-utils/src/utils/message_bus/message_bus_server.py
+++ b/py-utils/src/utils/message_bus/message_bus_server.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from cortx.utils.message_bus import MessageConsumer, MessageProducer
+from cortx.utils.message_bus.error import MessageBusError
+from cortx.utils.rest_server import RestServer
+from cortx.utils.rest_server.error import RestServerError
+
+from aiohttp import web
+import json
+
+routes = web.RouteTableDef()
+
+class MessageBusRestHandler(RestServer):
+    """ Rest interface of message bus """
+
+    _message_bus_ip = '127.0.0.1'
+    _message_bus_port = 28300
+
+    def __init__(self):
+        super().__init__(web, routes, self._message_bus_ip, \
+            self._message_bus_port)
+
+    @staticmethod
+    @routes.get('/MessageBus/message/{message_type}')
+    @routes.post('/MessageBus/message/{message_type}')
+    async def message_bus_rest(request):
+        if request.method == 'POST':
+            try:
+                message_type = request.match_info['message_type']
+                payload = await request.json()
+                messages = payload['messages']
+                producer = MessageProducer(producer_id='rest_producer', \
+                    message_type=message_type, method='sync')
+
+                producer.send(messages)
+            except MessageBusError as e:
+                status_code = e.rc
+                error_message = e.desc
+                response_obj = {'error_code': status_code, 'exception': ["MessageBusError", {'message' : error_message}]}
+            except Exception as e:
+                exception_key = type(e).__name__
+                exception = RestServerError(exception_key).http_error()
+                status_code = exception[0]
+                error_message = exception[1]
+                response_obj = {'error_code': status_code, 'exception': [exception_key, {'message' : error_message}]}
+                raise MessageBusError(status_code, error_message) from e
+            else:
+                status_code = 200 # No exception, Success
+                response_obj = {'status_code': status_code, 'status': 'success'}
+            finally:
+                return web.Response(text=json.dumps(response_obj) , status=status_code)
+
+        if request.method == 'GET':
+            try:
+                message_types = str(request.match_info['message_type']).split('&')
+                consumer_group = request.rel_url.query['consumer_group']
+                consumer = MessageConsumer(consumer_id='rest_consumer', \
+                    consumer_group=consumer_group, message_types=message_types, \
+                    auto_ack=True, offset='latest')
+
+                message = consumer.receive()
+            except MessageBusError as e:
+                status_code = e.rc
+                error_message = e.desc
+                response_obj = {'error_code': status_code, 'exception': ["MessageBusError", {'message' : error_message}]}
+            except Exception as e:
+                exception_key = type(e).__name__
+                exception = RestServerError(exception_key).http_error()
+                status_code = exception[0]
+                error_message = exception[1]
+                response_obj = {'error_code': status_code, 'exception': [exception_key, {'message' : error_message}]}
+                raise MessageBusError(status_code, error_message) from e
+            else:
+                status_code = 200  # No exception, Success
+                response_obj = {'messages': str(message)}
+            finally:
+                return web.Response(text=json.dumps(response_obj), status=status_code)
+
+if __name__ == '__main__':
+    MessageBusRestHandler()
+

--- a/py-utils/src/utils/process.py
+++ b/py-utils/src/utils/process.py
@@ -55,8 +55,10 @@ class SimpleProcess(Process):
             self._err = self._cp.stderr
             self._returncode = self._cp.returncode
         except Exception as err:
-            self._err = "SubProcess Error: " + str(err)
-            self._output = ""
+            # in case of exception return whatever
+            # is there in stdout and stderr(along with Exception) as it is
+            self._err = str(self._cp.stderr) + "SubProcess Error: " + str(err)
+            self._output = self._cp.stdout
             self._returncode = -1
         return self._output, self._err, self._returncode
 

--- a/py-utils/src/utils/rest_server/__init__.py
+++ b/py-utils/src/utils/rest_server/__init__.py
@@ -1,5 +1,6 @@
-#!/bin/bash
-#
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -14,14 +15,8 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# Create /etc/cortx. This will be used for storing message_bus.conf file
-/bin/mkdir -p /etc/cortx
+__title__ = 'rest_server'
 
-# Copy the setup_cli.py as utils_setup
-/bin/mkdir -p /opt/seagate/cortx/utils/bin
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/setup/utils_setup.py /opt/seagate/cortx/utils/bin/utils_setup
-/bin/chmod +x /opt/seagate/cortx/utils/bin/utils_setup
+from cortx.utils.rest_server.rest_server import RestServer
+from cortx.utils.rest_server.error import RestServerError
 
-# Copy the message_bus_server.py as message_bus_server
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/utils/message_bus/message_bus_server.py /opt/seagate/cortx/utils/bin/message_bus_server
-/bin/chmod +x /opt/seagate/cortx/utils/bin/message_bus_server

--- a/py-utils/src/utils/rest_server/error.py
+++ b/py-utils/src/utils/rest_server/error.py
@@ -1,5 +1,6 @@
-#!/bin/bash
-#
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -14,14 +15,21 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# Create /etc/cortx. This will be used for storing message_bus.conf file
-/bin/mkdir -p /etc/cortx
+from collections import defaultdict
 
-# Copy the setup_cli.py as utils_setup
-/bin/mkdir -p /opt/seagate/cortx/utils/bin
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/setup/utils_setup.py /opt/seagate/cortx/utils/bin/utils_setup
-/bin/chmod +x /opt/seagate/cortx/utils/bin/utils_setup
+class RestServerError(Exception):
+    """ Error class for cortx rest server """
 
-# Copy the message_bus_server.py as message_bus_server
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/utils/message_bus/message_bus_server.py /opt/seagate/cortx/utils/bin/message_bus_server
-/bin/chmod +x /opt/seagate/cortx/utils/bin/message_bus_server
+    def __init__(self, e):
+        self._e = e
+
+    def http_error(self):
+        return self._http_error(self._e)
+
+    @staticmethod
+    def _http_error(except_name):
+        ret_code_map = defaultdict(lambda: 500)
+        ret_code_map['KeyError'] = (418, "Wrong Key in payload!") # wrong key from client
+        ret_code_map['KafkaException'] = (514, "MessageBus backend error!")
+        return ret_code_map[except_name]
+

--- a/py-utils/src/utils/rest_server/rest_server.py
+++ b/py-utils/src/utils/rest_server/rest_server.py
@@ -1,5 +1,6 @@
-#!/bin/bash
-#
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -14,14 +15,12 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-# Create /etc/cortx. This will be used for storing message_bus.conf file
-/bin/mkdir -p /etc/cortx
 
-# Copy the setup_cli.py as utils_setup
-/bin/mkdir -p /opt/seagate/cortx/utils/bin
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/setup/utils_setup.py /opt/seagate/cortx/utils/bin/utils_setup
-/bin/chmod +x /opt/seagate/cortx/utils/bin/utils_setup
+class RestServer:
+    """ Base class for Cortx Rest Server implementation """
 
-# Copy the message_bus_server.py as message_bus_server
-/bin/cp -f /usr/lib/python3.6/site-packages/cortx/utils/message_bus/message_bus_server.py /opt/seagate/cortx/utils/bin/message_bus_server
-/bin/chmod +x /opt/seagate/cortx/utils/bin/message_bus_server
+    def __init__(self, web, routes, host: str, port: int):
+        app = web.Application()
+        app.add_routes(routes)
+        web.run_app(app, host=host, port=port)
+

--- a/py-utils/src/utils/service/service_handler.py
+++ b/py-utils/src/utils/service/service_handler.py
@@ -169,27 +169,27 @@ class Service:
         self._service_name = service_name
         if handler_type is None:
             handler_type = "dbus"
-        self._handler = ServiceHandler.get(handler_type)
+        self._handler = ServiceHandler.get(handler_type)()
 
     def start(self):
-        self._handler.start(self, self._service_name)
+        self._handler.start(self._service_name)
 
     def stop(self):
-        self._handler.stop(self, self._service_name)
+        self._handler.stop(self._service_name)
 
     def restart(self):
-        self._handler.restart(self, self._service_name)
+        self._handler.restart(self._service_name)
 
     def enable(self):
-        self._handler.enable(self, self._service_name)
+        self._handler.enable(self._service_name)
 
     def disable(self):
-        self._handler.disable(self, self._service_name)
+        self._handler.disable(self._service_name)
 
     def get_state(self):
-        service_state = self._handler.get_state(self, self._service_name)
+        service_state = self._handler.get_state(self._service_name)
         return service_state
 
     def is_enabled(self):
-        status = self._handler.is_enabled(self, self._service_name)
-        return status
+        status = self._handler.is_enabled(self._service_name)
+        return status == 'enabled'

--- a/py-utils/test/iem_framework/test_iem.py
+++ b/py-utils/test/iem_framework/test_iem.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import unittest
+from cortx.utils.iem_framework import EventMessage
+from cortx.utils.iem_framework.error import EventMessageError
+
+
+class TestMessage(unittest.TestCase):
+    """Test EventMessage send and receive functionality."""
+
+    def test_alert_send(self):
+        """ Test send alerts """
+        EventMessage.init(component='cmp', source='H')
+        EventMessage.send(module='mod', event_id='500', severity='B', \
+            message='This is message')
+
+    def test_alert_verify_receive(self):
+        """ Test receive alerts """
+        EventMessage.init(component='cmp', source='H', receiver=True)
+        alert = EventMessage.receive()
+        self.assertIs(type(alert), dict)
+
+    def test_bulk_alert_send(self):
+        """ Test bulk send alerts """
+        EventMessage.init(component='cmp', source='H')
+        for alert_count in range(0, 1000):
+            EventMessage.send(module='mod', event_id='500', severity='B', \
+                message='This is message' + str(alert_count))
+
+    def test_bulk_verify_receive(self):
+        """ Test bulk receive alerts """
+        EventMessage.init(component='cmp', source='H', receiver=True)
+        count = 0
+        while True:
+            alert = EventMessage.receive()
+            if alert is None:
+                break
+            self.assertIs(type(alert), dict)
+            count += 1
+        self.assertEqual(count, 1000)
+
+    def test_receive_fail(self):
+        """ Receive message with receiver as False """
+        EventMessage.init(component='cmp', source='H')
+        with self.assertRaises(KeyError):
+            EventMessage.receive()
+
+    def test_send_fail(self):
+        """ Send message with receiver as True """
+        EventMessage.init(component='cmp', source='H', receiver=True)
+        with self.assertRaises(NameError):
+            EventMessage.send(module='mod', event_id='500', severity='B', \
+                message='This is message')
+
+    def test_receive_without_send(self):
+        """ Receive message without send """
+        EventMessage.init(component='cmp', source='H', receiver=True)
+        alert = EventMessage.receive()
+        self.assertIsNone(alert)
+
+    def test_init_validation(self):
+        """ Validate init attributes """
+        with self.assertRaises(EventMessageError):
+            EventMessage.init(component=None, source='H')
+            EventMessage.init(component='cmp', source='I')
+
+    def test_send_validation(self):
+        """ Validate send attributes """
+        with self.assertRaises(EventMessageError):
+            EventMessage.send(module=None, event_id='500', severity='B', \
+                message='This is message')
+            EventMessage.send(module='mod', event_id=None, severity='B', \
+                message='This is message')
+            EventMessage.send(module='mod', event_id='500', severity='Z', \
+                message='This is message')
+            EventMessage.send(module='mod', event_id='500', severity='Z', \
+                message=None)
+
+    def test_json_alert_send(self):
+        """ Test send json as message description """
+        EventMessage.init(component='cmp', source='H')
+        EventMessage.send(module='mod', event_id='500', severity='B', \
+            message={'input': 'This is message'})
+
+    def test_json_verify_receive(self):
+        """ Test receive json as message description """
+        EventMessage.init(component='cmp', source='H', receiver=True)
+        alert = EventMessage.receive()
+        self.assertIs(type(alert), dict)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py-utils/test/test_message_bus/test_rest_server.py
+++ b/py-utils/test/test_message_bus/test_rest_server.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+import unittest
+import requests
+import json
+
+
+class TestMessage(unittest.TestCase):
+    """ Test MessageBus rest server functionality. """
+
+    _base_url = 'http://127.0.0.1:28300/MessageBus/message/'
+    _message_type = 'big'
+    _consumer_group = 'connn'
+
+    def test_post(self):
+        """ Test send message. """
+        url = self._base_url + self._message_type
+        data = json.dumps({'messages': ['hello', 'how are you']})
+        headers = {'content-type': 'application/json'}
+        response = requests.post(url=url, data=data, headers=headers)
+        self.assertEqual(response.json()['status'], 'success')
+        self.assertEqual(response.status_code, 200)
+
+    def test_get(self):
+        """ Test receive message. """
+        response = requests.get(self._base_url + self._message_type
+                                + '?consumer_group=' + self._consumer_group)
+        self.assertEqual(response.status_code, 200)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/py-utils/test/test_service_handler.py
+++ b/py-utils/test/test_service_handler.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import sys
+import os
+import unittest
+
+from cortx.utils.service.service_handler import Service
+
+utils_root = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.append(utils_root)
+
+class TestSystemHandler(unittest.TestCase):
+    _service_name = 'rsyslog.service'
+
+    def setUp(self):
+        self.service_obj = Service(TestSystemHandler._service_name)
+
+    def test_start(self):
+        self.service_obj.start()
+        service_state = self.test_get_state()
+        self.assertEqual(service_state.state,'active')
+        self.assertEqual(service_state.substate,'running')
+
+    def test_stop(self):
+        self.service_obj.stop()
+        service_state = self.test_get_state()
+        self.assertEqual(service_state.state,'inactive')
+        self.assertEqual(service_state.substate,'dead')
+
+    def test_restart(self):
+        self.service_obj.restart()
+        service_state = self.test_get_state()
+        self.assertEqual(service_state.state,'active')
+        self.assertEqual(service_state.substate,'running')
+
+    def test_enable(self):
+        self.service_obj.enable()
+        is_enable = self.test_is_enabled()
+        self.assertTrue(is_enable)
+
+    def test_disable(self):
+        self.service_obj.disable()
+        is_enable = self.test_is_enabled()
+        self.assertFalse(is_enable)
+
+    def test_get_state(self):
+        return self.service_obj.get_state()
+
+    def test_is_enabled(self):
+        return self.service_obj.is_enabled()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Change Summary
## Problem Statement/Description
while running sh script from python, S3 uses SimpleProcess class. 
In case of failure in the shell script, S3 expect to return whatever is present in stdout as well as stderr. so that it can be log in to log file. 
consider a scenario where shell script is running 5 commands. If scripts fails at 3rd command then it is expected to return the o/p of first 3 command in stdout during failure too. 

## Solution Overview
In case of exception in run method return whatever is present in stdout and stderr(along with Exception) as it is
So that we can log stdout and stderr as is in the deployment log file 
             