### PR TITLE
EOS-18264: Cortx utils Conf should provide way to check if index is already exists

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -98,6 +98,18 @@ class ConfStore:
 
         self._cache[index].dump()
 
+    def is_loaded(self, index: str) -> bool:
+        """
+        Checks the index loaded into ConfStore or not
+
+        Parameters:
+        index:          Identifier for the config loaded from the KV Store
+        return type:    Boolean
+                        True - index already loaded
+                        False - index not loaded
+        """
+        return True if index in self._cache.keys() else False
+
     def get(self, index: str, key: str, default_val: str = None):
         """
         Obtain value for the given configuration
@@ -247,6 +259,11 @@ class Conf:
     def save(index: str):
         """ Saves the configuration onto the backend store """
         Conf._conf.save(index)
+
+    @staticmethod
+    def is_loaded(index: str):
+        """ Checks the index is loaded into ConfStore or not """
+        return False if Conf._conf is None else Conf._conf.is_loaded(index)
 
     @staticmethod
     def set(index: str, key: str, val):

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -438,6 +438,19 @@ class TestConfStore(unittest.TestCase):
         self.assertEqual('kafka', Conf.get('dest_index', \
             'cortx>software>common>message_bus_type'))
 
+    def test_conf_store_is_loaded(self):
+        res = Conf.is_loaded('index')
+        self.assertEqual(res, False)
+        Conf.load('index', 'yaml:///tmp/test_conf_merge.conf.sample')
+        res = Conf.is_loaded('index')
+        self.assertEqual(res, True)
+        res = Conf.is_loaded('unknown_index')
+        self.assertEqual(res, False)
+        if not Conf.is_loaded('new_index'):
+            Conf.load('new_index', 'yaml:///tmp/test_conf_merge.conf.sample')
+            res = Conf.is_loaded('new_index')
+            self.assertEqual(res, True)
+
     @classmethod
     def tearDownClass(cls):
         delete_files()


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Cortx utils Conf should provide way to check if index is already exists
- load interface load schema but through exception if index already loaded
   Currently there is no way to check if index already loaded, user should be able to check if index already loaded.

# Design
-  Jira - https://jts.seagate.com/browse/EOS-18264
- [Conf Store - Private-Cortx - Confluence (atlassian.net)​​​​​​​](https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/316342315/Conf+Store#%5BhardBreak%5DCheck-if-ConfStore-index-loaded)

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: NA
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
