### PR TITLE
Update README.md: Correcting RPM version

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -63,7 +63,7 @@ Note : The rpm package installation will fail if any dependent python package is
 Please refer to WIKI (https://github.com/Seagate/cortx-utils/wiki/%22cortx-py-utils%22-single-node-manual-provisioning)
 ```bash
 $ cd ./py-utils/dist
-$ yum install -y cortx-py-utils-1.0.0-1.noarch.rpm
+$ sudo yum install -y cortx-py-utils-*.noarch.rpm
 ```
 
 ## Uninstall


### PR DESCRIPTION
This existing README has this following line: `./jenkins/build.sh -v 2.0.0 -b 2` which will generate these following rpms:
```sh
cortx-py-utils-2.0.0-2_4e0eede.src.rpm
cortx-py-utils-2.0.0-2_4e0eede.noarch.rpm  
cortx-py-utils-2.0.0.tar.gz
```

However, when installing the RPM, the current script will look for version 1.0.0: `yum install -y cortx-py-utils-1.0.0-1.noarch.rpm`, which does not exist. Also, installing rpm should be executed by root. Therefore, the updated script should be: `sudo yum install -y cortx-py-utils-*.noarch.rpm`

Noted that this new input arg is utilizing `*` regex so that it can install any RPM regardless of the future version that will be generated.



-----
[View rendered py-utils/README.md](https://github.com/daniarherikurniawan/cortx-utils/blob/patch-1/py-utils/README.md)