### PR TITLE
EOS-22103: remove the roles hack from CommandFactory

### DIFF
--- a/py-utils/src/utils/cli_framework/command_factory.py
+++ b/py-utils/src/utils/cli_framework/command_factory.py
@@ -56,17 +56,8 @@ class CommandFactory(object):
             cmd_obj._handle_main_parse(subparsers)
         namespace = parser.parse_args(argv)
 
-        CommandFactory._edit_arguments(namespace)
-
         sys_module = sys.modules[__name__]
         for attr in ["command", "action", "args"]:
             setattr(sys_module, attr, getattr(namespace, attr))
             delattr(namespace, attr)
         return command(action, vars(namespace), args)
-
-    @staticmethod
-    def _edit_arguments(namespace):
-        # temporary solution till user create api is not fixed
-        # remove when fixed
-        if namespace.action == "users" and namespace.sub_command_name == "create":
-            namespace.roles = [namespace.roles]


### PR DESCRIPTION
# Problem Statement
[EOS-22103](https://jts.seagate.com/browse/EOS-22103) - After the User model changed 'roles' field to 'role' the hack that turns the string parameter to list is no longer required.

# Design
-  Remove the hack that turns the string 'Roles' parameter to list.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
