### PR TITLE
EOS-21280: sorting enabled for text fields in ES

### DIFF
--- a/py-utils/src/utils/data/access/queries.py
+++ b/py-utils/src/utils/data/access/queries.py
@@ -44,9 +44,10 @@ class OrderBy:
 
     """Class to represent order by parameters for DB"""
 
-    def __init__(self, field, order: SortOrder = SortOrder.ASC):
+    def __init__(self, field, order: SortOrder = SortOrder.ASC, **kwargs):
         self.field = field
         self.order = order
+        self.kwargs = kwargs
 
 
 class Query:
@@ -72,7 +73,7 @@ class Query:
         self.data = self.Data(order_by, filter_by, limit, offset)
 
     # TODO: order_by can be chained and we can store an array of fields to sort by them
-    def order_by(self, by_field: BaseType, by_order: SortOrder = SortOrder.ASC):
+    def order_by(self, by_field: BaseType, by_order: SortOrder = SortOrder.ASC, **kwargs):
         """
         Set Query order_by parameter
 
@@ -80,7 +81,7 @@ class Query:
         :param int by_order: direction of ordering
 
         """
-        self.data.order_by = OrderBy(by_field, by_order)
+        self.data.order_by = OrderBy(by_field, by_order, **kwargs)
         return self
 
     def filter_by(self, by_filter: IFilter):

--- a/py-utils/src/utils/data/db/elasticsearch_db/storage.py
+++ b/py-utils/src/utils/data/db/elasticsearch_db/storage.py
@@ -278,7 +278,13 @@ class ElasticSearchQueryService:
             search = search.extra(**extra_params)
 
         if q.order_by is not None:
-            sort_by[field_to_str(q.order_by.field)] = {ESWords.ORDER: convert(q.order_by.order)}
+            string_field_type = q.order_by.kwargs.get("string_field_type")
+            if string_field_type is not None and \
+                isinstance(q.order_by.field, StringType):
+                sort_by[f"{field_to_str(q.order_by.field)}.{string_field_type}"] = \
+                    {ESWords.ORDER: convert(q.order_by.order)}
+            else:
+                sort_by[field_to_str(q.order_by.field)] = {ESWords.ORDER: convert(q.order_by.order)}
             search = search.sort(sort_by)
 
         return search


### PR DESCRIPTION
Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>

# Problem Statement
- Problem statement Sorting is not enabled on text fields in ES

# Design
-  For Bug describe the fix here. Using text field sub types, sorting is enabled
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 
- https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/486114207/Elasticsearch-+Sorting+on+text+fields

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
