### PR TITLE
EOS-21195: Restrict schema generation if specified in config

### DIFF
--- a/py-utils/src/utils/data/db/consul_db/storage.py
+++ b/py-utils/src/utils/data/db/consul_db/storage.py
@@ -229,18 +229,19 @@ class ConsulDB(GenericDataBase):
         self._model_scheme = dict()
 
     @classmethod
-    async def create_database(cls, config, collection: str,
+    async def create_database(cls, config, model_settings,
                               model: Type[BaseModel]) -> IDataBase:
         """
         Creates new instance of Consul KV DB and performs necessary initializations
 
         :param DBSettings config: configuration for consul kv server
-        :param str collection: collection for storing model onto db
+        :param model_settings: Model settings
         :param Type[BaseModel] model: model which instances will be stored in DB
         :return:
         """
         # NOTE: please, be sure that you avoid using this method twice (or more times) for the same
         # model
+        collection = model_settings.collection
         if not all((cls.consul_client, cls.thread_pool, cls.loop)):
             cls.loop = asyncio.get_event_loop()
             try:

--- a/py-utils/src/utils/data/db/db_provider.py
+++ b/py-utils/src/utils/data/db/db_provider.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Type
 
 from schematics import Model
-from schematics.types import DictType, StringType, ListType, ModelType, IntType
+from schematics.types import DictType, StringType, ListType, ModelType, IntType, BooleanType
 
 from cortx.utils.data.access import BaseModel
 from cortx.utils.errors import MalformedConfigurationError, DataAccessInternalError, DataAccessError
@@ -65,6 +65,7 @@ class ModelSettings(Model):
     Configuration for base model like collection as example
     """
     collection = StringType(required=True)
+    create_schema = BooleanType(default=True)
 
 
 class DBModelConfig(Model):
@@ -157,7 +158,7 @@ class AsyncDataBase:
         self._database_status = ServiceStatus.IN_PROGRESS
         try:
             self._database = await self._database_module.create_database(self._db_config.config,
-                                                                         self._model_settings.collection,
+                                                                         self._model_settings,
                                                                          self._model)
         except DataAccessError:
             raise

--- a/py-utils/src/utils/data/db/elasticsearch_db/storage.py
+++ b/py-utils/src/utils/data/db/elasticsearch_db/storage.py
@@ -385,7 +385,7 @@ class ElasticSearchDB(GenericDataBase):
 
         def _get(_index):
             return self._es_client.indices.get(self._index)
-        
+
         try:
             indices = await self._loop.run_in_executor(self._tread_pool_exec, _get_alias, self._index)
         except ConnectionError as e:


### PR DESCRIPTION
Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>

# Problem Statement
- Problem statement s3-rsys-index should not be generated through generic db framework

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 
- https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/494600216/Rsyslog+and+Elasticsearch 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
