### PR TITLE
EOS-17458: Change compute type to server type in discovery

### DIFF
--- a/py-utils/src/utils/discovery/discovery.py
+++ b/py-utils/src/utils/discovery/discovery.py
@@ -57,8 +57,8 @@ class Discovery:
             If rpath is not given, it will fetch whole Cortx Node
             data health.
             Examples:
-                node>compute[0]>hw>disk
-                node>compute[0]
+                node>server[0]>hw>disk
+                node>server[0]
                 node>storage[0]
                 node>storage[0]>hw>psu
         store_url: Path to store resource health information

--- a/py-utils/src/utils/discovery/resource.py
+++ b/py-utils/src/utils/discovery/resource.py
@@ -35,10 +35,6 @@ class Resource:
         """Initialize resource"""
         self._name = name
         self._child_resource = child_resource
-        self.resource_provider_map = {
-            "storage": "storage",
-            "compute": "server"
-            }
 
     @property
     def name(self):
@@ -72,7 +68,7 @@ class Resource:
         Using the configured solution monitor path, import
         solution specific module to collect data.
 
-        The module communicate with resources such as compute
+        The module communicate with resources such as server
         and storage, etc,. in the solution path.
         Example: lr2.__init__
         """
@@ -106,8 +102,7 @@ class Resource:
         members = inspect.getmembers(module, inspect.isclass)
 
         for _, cls in members:
-            if hasattr(cls, 'name') and \
-                self.resource_provider_map.get(self.name) == cls.name:
+            if hasattr(cls, 'name') and cls.name == self.name:
                 try:
                     if request_type == "health":
                         return cls().get_health_info(rpath)
@@ -120,7 +115,7 @@ class Resource:
         raise DiscoveryError(
             errno.EINVAL,
             "%s resource provider not found in configured solution path %s" % (
-                self.resource_provider_map[self.name].title(),
+                self.name.title(),
                 monitor_path))
 
 

--- a/py-utils/src/utils/discovery/resource_collection.py
+++ b/py-utils/src/utils/discovery/resource_collection.py
@@ -20,7 +20,7 @@ from cortx.utils.discovery.resource import Resource
 
 class Server(Resource):
 
-    name = "compute"
+    name = "server"
     childs = []
 
     def __init__(self, child_resource=None):
@@ -47,7 +47,7 @@ class Storage(Resource):
 class Node(Resource):
 
     name = "node"
-    childs = ["compute", "storage"]
+    childs = ["server", "storage"]
 
     def __init__(self, child_resource=None):
         super().__init__(self.name, child_resource)

--- a/py-utils/test/discovery/solution/lr2/health.json
+++ b/py-utils/test/discovery/solution/lr2/health.json
@@ -4,7 +4,7 @@
       {
         "uid":"cortx_node_1",
         "last_updated":"1615290352",
-        "compute":[
+        "server":[
             {
               "node_type":"server",
               "uid":"sm_001",

--- a/py-utils/test/discovery/solution/lr2/server/server_resource_map.py
+++ b/py-utils/test/discovery/solution/lr2/server/server_resource_map.py
@@ -32,7 +32,7 @@ class ServerResourceMap:
     def get_health_info(rpath):
         """
         Fetch health information for given FRU
-        rpath: Resource id (Example: node>compute[0]>hw>disk)
+        rpath: Resource id (Example: node>server[0]>hw>disk)
         """
         return Conf.get(mock_health, rpath)
 
@@ -40,6 +40,6 @@ class ServerResourceMap:
     def get_manifest_info(rpath):
         """
         Fetch manifest information for given FRU
-        rpath: Resource id (Example: node>compute[0]>hw>disk)
+        rpath: Resource id (Example: node>server[0]>hw>disk)
         """
         return Conf.get(mock_manifest, rpath)

--- a/py-utils/test/discovery/test_discovery.py
+++ b/py-utils/test/discovery/test_discovery.py
@@ -44,7 +44,7 @@ Conf.load(mock_manifest, mock_manifest_data_url)
 
 # Sample rpaths
 #valid_rpath = "node"
-#valid_rpath = "node>compute[0]"
+#valid_rpath = "node>server[0]"
 #valid_rpath = "node>storage[0]"
 valid_rpath = "node>storage[0]>hw>controller"
 invalid_rpath = "node>notexist[0]"


### PR DESCRIPTION
Signed-off-by: Satish Darade <satish.darade@seagate.com>

# Problem Statement
- Decided to change compute type to server type for discovery in the SSPL Arch Roadmap meeting with @ujjwalpl 

# Design
-  Changed compute type to server type in discovery.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
