### PR TITLE
EOS-23280: Factory reset(data+logs) command implementation failing as After cluster start Utils Kafka services were in failed state

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -257,8 +257,8 @@ class Utils:
 
     @staticmethod
     def reset():
-        """ Remove/Delete all the data/logs that was created by user/testing """
-        # TODO
+        """Remove/Delete all the data/logs that was created by user/testing."""
+        # TODO # deleting all messages from all message_types
         return 0
 
     @staticmethod

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -257,7 +257,7 @@ class Utils:
 
     @staticmethod
     def reset():
-        """ Remove/Delete all the data that was created after post install """
+        """ Remove/Delete all the data/logs that was created by user/testing """
         # TODO
         return 0
 

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -258,32 +258,27 @@ class Utils:
     @staticmethod
     def reset():
         """ Remove/Delete all the data that was created after post install """
-        conf_file = '/etc/cortx/message_bus.conf'
-        if os.path.exists(conf_file):
-            # delete message_types
-            from cortx.utils.message_bus import MessageBusAdmin
-            try:
-                mb = MessageBusAdmin(admin_id='reset')
-                message_types_list = mb.list_message_types()
-                if message_types_list:
-                    mb.deregister_message_type(message_types_list)
-            except MessageBusError as e:
-                raise SetupError(e.rc, "Can not reset Message Bus. %s", e)
-            except Exception as e:
-                raise SetupError(errors.ERR_OP_FAILED, "Can not reset Message  \
-                    Bus. %s", e)
-
-        # Stop MessageBus Service
-        cmd = SimpleProcess("systemctl stop cortx_message_bus")
-        _, stderr, res_rc = cmd.run()
-        if res_rc != 0:
-            raise SetupError(res_rc, "Unable to stop MessageBus Service. \
-                %s", stderr.decode('utf-8'))
+        # TODO
         return 0
 
     @staticmethod
     def cleanup():
-        """ Cleanup configs and logs. """
+        """Remove/Delete all the data that was created after post install."""
+        conf_file = '/etc/cortx/message_bus.conf'
+        if os.path.exists(conf_file):
+            # delete message_types
+            try:
+                from cortx.utils.message_bus import MessageBusAdmin
+                mb = MessageBusAdmin(admin_id='cleanup')
+                message_types_list = mb.list_message_types()
+                if message_types_list:
+                    mb.deregister_message_type(message_types_list)
+            except MessageBusError as e:
+                raise SetupError(e.rc, "Can not cleanup Message Bus. %s", e)
+            except Exception as e:
+                raise SetupError(errors.ERR_OP_FAILED, "Can not cleanup Message  \
+                    Bus. %s", e)
+
         config_files = ['/etc/cortx/message_bus.conf', \
             '/etc/cortx/cluster.conf']
         for each_file in config_files:


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Factory reset(data+logs) command implementation failing as After cluster start Utils Kafka services were in failed state
- BUG

# Design
-  https://jts.seagate.com/browse/EOS-23280

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: N
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
