### PR TITLE
EOS:23308 fix for Miniprovisioning fail

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -89,13 +89,13 @@ class Utils:
         return server_info
 
     @staticmethod
-    def _copy_cluster_map():
-        cluster_data = Conf.get("server_info", "server_node")
+    def _copy_cluster_map(conf_url_index: str):
+        cluster_data = Conf.get(conf_url_index, 'server_node')
         for _, node_data in cluster_data.items():
-            hostname = node_data.get("hostname")
-            node_name = node_data.get("name")
-            Conf.set("cluster", f"cluster>{node_name}", hostname)
-        Conf.save("cluster")
+            hostname = node_data.get('hostname')
+            node_name = node_data.get('name')
+            Conf.set('cluster', f'cluster>{node_name}', hostname)
+        Conf.save('cluster')
 
     @staticmethod
     def _create_cluster_config(server_info: dict):
@@ -219,7 +219,7 @@ class Utils:
                 "information in %s", config_template)
         Utils._create_cluster_config(server_info)
         #set cluster nodename:hostname mapping to cluster.conf
-        Utils._copy_cluster_map()
+        Utils._copy_cluster_map(config_template_index)
         Utils._configure_rsyslog()
         # temporary fix for a common message bus log file
         # The issue happend when some user other than root:root is trying


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
-  Method `_copy_cluster_map `  tries to load a file from a wrong conf index

# Design
-  added the argument for _copy_cluster_map method to take correct index name from parent method

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
