### PR TITLE
EOS-23314: Improve support_bundle_cli to have options like "cortxcli support_bundle" command

### DIFF
--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -110,7 +110,8 @@ setup(name='cortx-py-utils',
             'utils_setup = cortx.setup.utils_setup:main',
             'iem = cortx.utils.iem_framework.iem_cli:main',
             'kafka_setup = cortx.utils.setup.kafka.kafka_setup:main',
-            'utils_support_bundle = cortx.support.utils_support_bundle:main'
+            'utils_support_bundle = cortx.support.utils_support_bundle:main',
+            'support_bundle = cortx.support.support_bundle_cli:main'
         ]
       },
       data_files = [ ('/var/lib/cortx/ha/specs', specs),

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -1,5 +1,6 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
+# CORTX-Py-Utils: CORTX Python common library.
 # Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -14,77 +15,123 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-import asyncio
-import sys
 
+import errno
+import argparse
+import inspect
+import sys
+import traceback
+from argparse import RawTextHelpFormatter
 from cortx.utils.support_framework import SupportBundle
-from cortx.utils.cli_framework.command import Command
 
 
 class SupportBundleCli:
-    @staticmethod
-    def generate(comment: str, **kwargs):
-        components = ''
-        for key, value in kwargs.items():
-            if key == 'components':
-                components = value
-        options = {'comment': comment, 'components': components, 'comm': \
-            {'type': 'direct', 'target': 'utils.support_framework', 'method': \
-            'generate_bundle', 'class': 'SupportBundle', 'is_static': True, \
-            'params': {}, 'json': {}}, 'output': {}, 'need_confirmation': \
-            False, 'sub_command_name': 'generate_bundle'}
-
-        cmd_obj = Command('generate_bundle', options, [])
-        loop = asyncio.get_event_loop()
-        bundle_obj = loop.run_until_complete( \
-            SupportBundle._generate_bundle(cmd_obj))
-        return bundle_obj
+    """ CLI for the Support Bundle Framework. """
 
     @staticmethod
-    def get_status(bundle_id: str):
-         # Get the status of bundle
-        import time
-        time.sleep(5)
-
-        options = {'bundle_id': bundle_id, 'comm': {'type': 'direct', \
-            'target': 'utils.support_framework', 'method': 'get_bundle_status', \
-            'class': 'SupportBundle', \
-            'is_static': True, 'params': {}, 'json': {}},'output': {},\
-            'need_confirmation': False, 'sub_command_name': \
-            'get_bundle_status'}
-
-        cmd_obj = Command('get_bundle_status', options, [])
-        loop = asyncio.get_event_loop()
-        res = loop.run_until_complete(
-            SupportBundle._get_bundle_status(cmd_obj))
-        loop.close()
-        return res
-
-def main(argv):
-    from cortx.utils.conf_store.conf_store import Conf
-    from cortx.utils.log import Log
-
-    Conf.load('cortx_config', 'json:///etc/cortx/cortx.conf')
-    log_level = Conf.get('cortx_config', 'utils>log_level', 'INFO')
-    Log.init('support_bundle', '/var/log/cortx/utils/support', level=log_level, \
-        backup_count=5, file_size_in_mb=5)
+    def generate(args):
+        """ Generates support bundle for specified components. """
+        from cortx.utils.support_framework.errors import BundleError
+        if not args.comment:  # no comment provided
+            raise BundleError("Please provide comment, Why you are generating \
+                Support Bundle!")
+        components = args.component[0].split(';') if args.component else []
+        bundle_obj = SupportBundle.generate(comment=args.comment, \
+            components=components)
+        display_string_len = len(bundle_obj.bundle_id) + 4
+        response_msg = (
+            f"Please use the below bundle id for checking the status of support bundle."
+            f"\n{'-' * display_string_len}"
+            f"\n| {bundle_obj.bundle_id} |"
+            f"\n{'-' * display_string_len}"
+            f"\nPlease Find the file on -> {bundle_obj.bundle_path} .\n")
+        return response_msg
     
-    components = argv[3] if len(argv)>3 else []
-    if components:
-        components = [component for component in components.split(',')]
-    cmd = f"SupportBundleCli.{argv[1]}(comment='{argv[2]}', components={components})"
-    bundle_obj = eval(cmd)
-    print('bundle_id', bundle_obj.bundle_id)
-    status = SupportBundleCli.get_status(bundle_id=bundle_obj.bundle_id)
-    return status
+    @staticmethod
+    def get_status(args):
+        """ Get status of generated support bundle """
+        bundle_id = args.bundle_id[0] if args.bundle_id else None
+        status = SupportBundle.get_status(bundle_id=bundle_id)
+        return status
 
 
-if __name__ == '__main__':
-    # componets parameter is optional, if not specified support bundle
-    # will be created for all components.
-    # Usage eg:
-    # $sudo /opt/seagate/cortx/utils/bin/support_bundle generate 'Creating support bundle generation'
-    # $sudo /opt/seagate/cortx/utils/bin/support_bundle generate 'Creating support bundle generation' 'utils,csm'
-    # support_bundle bin path is temporary and  will be replaced with support_bundle command
-    # while implementing support_bundle cli
-    sys.exit(main(sys.argv))
+class GenerateCmd:
+    """ Get Generate Cmd Structure """
+
+    @staticmethod
+    def add_args(sub_parser) -> None:
+        s_parser = sub_parser.add_parser(
+            'generate',
+            help="generates suppport bundle for specified component.\n"
+                "components is optional parameter, if components is not specified\n"
+                "support bundle will be generated for all components\n"
+                "Example components passed: 'utils', 'utils;csm;provisioner'\n\n"
+                "Example command:\n"
+                "#$ support_bundle generate 'sample comment'\n"
+                "#$ support_bundle generate 'sample comment' -c 'utils'\n"
+                "#$ support_bundle generate 'sample comment' -c 'utils;csm'\n\n"
+                "For more help checkout support_bundle generate -h\n\n")
+        s_parser.set_defaults(func=SupportBundleCli.generate)
+        s_parser.add_argument('comment', nargs='+', help='Comment - Reason for generating Support Bundle')
+        s_parser.add_argument('-c', '--component', nargs='+', default=[], \
+            help='Optional, Specified component support bundle will be generated')
+
+class StatusCmd:
+    """ Get Status Cmd Structure """
+
+    @staticmethod
+    def add_args(sub_parser) -> None:
+        s_parser = sub_parser.add_parser(
+            'get_status',
+            help="Get status of generated suppport bundle.\n"
+                "bundle_id is optional, if bundle id is specified, only specified\n"
+                "support bundle status is fetched else will fetch all generated support bundle status.\n\n"
+                "Example command:\n"
+                "#$ support_bundle get_status -b 'SBag8s1f10' #Fetch status of SBag8s1f10\n"
+                "#$ support_bundle get_status #Fetch status of all support bundles\n\n"
+                "For more help checkout support_bundle get_status -h\n\n")
+        s_parser.set_defaults(func=SupportBundleCli.get_status)
+        s_parser.add_argument('-b', '--bundle_id', nargs='+', default='', \
+            help='Bundle ID of generated Support Bundle')
+
+
+
+def main():
+    from cortx.utils.log import Log
+    from cortx.utils.conf_store import Conf
+
+    Conf.load('config_file', 'json:///etc/cortx/cortx.conf')
+    log_level = Conf.get('config_file', 'utils>log_level', 'INFO')
+    Log.init('support_bundle', '/var/log/cortx/utils/support_framework/', \
+        level=log_level, backup_count=5, file_size_in_mb=5, \
+             syslog_server='localhost', syslog_port=514)
+    # Setup Parser
+    parser = argparse.ArgumentParser(description='Support Bundle CLI', \
+        formatter_class=RawTextHelpFormatter)
+    sub_parser = parser.add_subparsers(title='command', \
+        help='represents the action from: generate, get_status\n\n', \
+        dest='command')
+
+    # Add Command Parsers
+    members = inspect.getmembers(sys.modules[__name__])
+    for name, cls in members:
+        if name != "Cmd" and name.endswith("Cmd"):
+            cls.add_args(sub_parser)
+
+    # Parse and Process Arguments
+    try:
+        args = parser.parse_args()
+        out = args.func(args)
+        if out is not None and len(out) > 0:
+            print(out)
+        return 0
+
+    except Exception as e:
+        sys.stderr.write("%s\n\n" % str(e))
+        sys.stderr.write("%s\n" % traceback.format_exc())
+        return errno.EINVAL
+
+
+if __name__ == "__main__":
+    rc = main()
+    sys.exit(rc)

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -103,9 +103,9 @@ def main():
     from cortx.utils.log import Log
     from cortx.utils.conf_store import Conf
 
-    Conf.load('config_file', 'json:///etc/cortx/cortx.conf')
-    log_level = Conf.get('config_file', 'utils>log_level', 'INFO')
-    Log.init('support_bundle', '/var/log/cortx/utils/support_framework/', \
+    Conf.load('cortx_conf', 'json:///etc/cortx/cortx.conf')
+    log_level = Conf.get('cortx_conf', 'utils>log_level', 'INFO')
+    Log.init('support_bundle', '/var/log/cortx/utils/support/', \
         level=log_level, backup_count=5, file_size_in_mb=5, \
              syslog_server='localhost', syslog_port=514)
     # Setup Parser

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -78,6 +78,7 @@ class GenerateCmd:
         s_parser.add_argument('-c', '--component', nargs='+', default=[], \
             help='Optional, Specified component support bundle will be generated')
 
+
 class StatusCmd:
 
     """Get Status Cmd Structure."""

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -26,11 +26,12 @@ from cortx.utils.support_framework import SupportBundle
 
 
 class SupportBundleCli:
-    """ CLI for the Support Bundle Framework. """
+
+    """CLI for the Support Bundle Framework."""
 
     @staticmethod
     def generate(args):
-        """ Generates support bundle for specified components. """
+        """Generates support bundle for specified components."""
         from cortx.utils.support_framework.errors import BundleError
         if not args.comment:  # no comment provided
             raise BundleError("Please provide comment, Why you are generating \
@@ -49,14 +50,15 @@ class SupportBundleCli:
     
     @staticmethod
     def get_status(args):
-        """ Get status of generated support bundle """
+        """Get status of generated support bundle."""
         bundle_id = args.bundle_id[0] if args.bundle_id else None
         status = SupportBundle.get_status(bundle_id=bundle_id)
         return status
 
 
 class GenerateCmd:
-    """ Get Generate Cmd Structure """
+
+    """Get Generate Cmd Structure."""
 
     @staticmethod
     def add_args(sub_parser) -> None:
@@ -77,7 +79,8 @@ class GenerateCmd:
             help='Optional, Specified component support bundle will be generated')
 
 class StatusCmd:
-    """ Get Status Cmd Structure """
+
+    """Get Status Cmd Structure."""
 
     @staticmethod
     def add_args(sub_parser) -> None:

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -98,7 +98,6 @@ class StatusCmd:
             help='Bundle ID of generated Support Bundle')
 
 
-
 def main():
     from cortx.utils.log import Log
     from cortx.utils.conf_store import Conf

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -21,7 +21,8 @@ from cortx.utils.process import SimpleProcess
 
 
 class TestSupportBundleCli(unittest.TestCase):
-    """Test case will test available API's of Support Bundle"""
+
+    """Test case will test available API's of Support Bundle."""
 
     def test_001generate_1_component(self):
         cmd = "support_bundle generate 'sample comment' -c 'provisioner'"

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+import unittest
+from cortx.utils.process import SimpleProcess
+
+
+class TestSupportBundleCli(unittest.TestCase):
+    """Test case will test available API's of Support Bundle"""
+
+    def test_001generate_1_component(self):
+        cmd = "support_bundle generate 'sample comment' -c 'provisioner'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+
+    def test_002generate_multiple_component(self):
+        cmd = "support_bundle generate 'sample comment' -c 'csm;provisioner'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+
+    def test_003generate_all_component(self):
+        cmd = "support_bundle generate 'sample comment'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+
+    def test_004get_status_success(self):
+        cmd = "support_bundle generate 'sample comment' -c 'provisioner'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+        bundle_id = ''
+        if rc == 0:
+            bundle_id = stdout.decode('utf-8').split('|')[1]
+        cmd = f"support_bundle get_status -b '{bundle_id.strip()}'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+        status = stdout.decode('utf-8')
+        import ast
+        status = ast.literal_eval(status)
+        self.assertIsInstance(status, dict)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Improve support_bundle_cli to provide all options like "cortxcli support_bundle" command

# Design
https://jts.seagate.com/browse/EOS-23314

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
