### PR TITLE
EOS-22891: LIKE operator implementation for Elasticsearch queries (For StringType)

### DIFF
--- a/py-utils/src/utils/data/db/elasticsearch_db/storage.py
+++ b/py-utils/src/utils/data/db/elasticsearch_db/storage.py
@@ -138,6 +138,7 @@ class ElasticSearchQueryConverter(GenericQueryConverter):
     def __init__(self, model):
         self.comparison_conversion = {
             ComparisonOperation.OPERATION_EQ: self._match_query,
+            ComparisonOperation.OPERATION_LIKE: self._wildcard_query(model),
             ComparisonOperation.OPERATION_LT: self._range_generator('lt'),
             ComparisonOperation.OPERATION_GT: self._range_generator('gt'),
             ComparisonOperation.OPERATION_LEQ: self._range_generator('lte'),
@@ -154,6 +155,19 @@ class ElasticSearchQueryConverter(GenericQueryConverter):
         }
 
         return Q("match", **obj)
+
+    @staticmethod
+    def _wildcard_query(model):
+        def _make_query(field: str, target):
+            if isinstance(getattr(model, field), StringType):
+                raise DataAccessInternalError("Can only use like operator with keyword and text fields")
+            else:
+                target = "*" + target + "*"
+                obj = {
+                    field: target
+                }
+            return Q("wildcard", **obj)
+        return _make_query
 
     @staticmethod
     def _range_generator(op_string: str):

--- a/py-utils/src/utils/data/db/elasticsearch_db/storage.py
+++ b/py-utils/src/utils/data/db/elasticsearch_db/storage.py
@@ -159,7 +159,7 @@ class ElasticSearchQueryConverter(GenericQueryConverter):
     @staticmethod
     def _wildcard_query(model):
         def _make_query(field: str, target):
-            if isinstance(getattr(model, field), StringType):
+            if not isinstance(getattr(model, field), StringType):
                 raise DataAccessInternalError("Can only use like operator with keyword and text fields")
             else:
                 target = "*" + target + "*"


### PR DESCRIPTION
Signed-off-by: Pranali04796 <pranali.ugale@seagate.com>

# Problem Statement
- Overview: EOS-22891:LIKE filter for Elasticsearch queries
- Currently the cortx-utils data framework does not support 'LIKE' operator for partial search. Elasticsearch supports full-text search using many ways. 


# Design
-  Used wildcard query for StringType data search to support partial text search

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: yes
-  Confirm All CODACY errors are resolved [Y/N]: yes

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: yes
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: yes
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  No

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed: yes
- [ ] Is there a change in filename/package/module or signature [Y/N]: No
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated : yes
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
