### PR TITLE
EOS-22810: add support for pre-factory phase in mini-provisioning

### DIFF
--- a/py-utils/src/setup/setup.yaml
+++ b/py-utils/src/setup/setup.yaml
@@ -40,7 +40,7 @@ utils:
 
     cleanup:
         cmd: /opt/seagate/cortx/utils/bin/utils_setup cleanup
-        args: --config $URL
+        args: --config $URL [--pre-factory]
 
     upgrade:
 

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -15,6 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import os
+import glob
 import json
 import errno
 from pathlib import Path
@@ -38,6 +39,28 @@ class Utils:
     """ Represents Utils and Performs setup related actions """
 
     # Utils private methods
+
+
+    @staticmethod
+    def _delete_files(files: list):
+        """
+        Deletes the passed list of files
+
+        Args:
+            files ([str]): List of files to be deleted
+
+        Raises:
+            SetupError: If unable to delete file
+        """
+        for each_file in files:
+            if os.path.exists(each_file):
+                try:
+                    os.remove(each_file)
+                except OSError as e:
+                    raise SetupError(e.errno, "Error deleting file %s, \
+                        %s", each_file, e)
+        return 0
+
     @staticmethod
     def _get_utils_path() -> str:
         """ Gets install path from cortx.conf and returns utils path """
@@ -289,7 +312,7 @@ class Utils:
         return 0
 
     @staticmethod
-    def cleanup():
+    def cleanup(pre_factory: bool):
         """Remove/Delete all the data that was created after post install."""
         conf_file = '/etc/cortx/message_bus.conf'
         if os.path.exists(conf_file):
@@ -308,14 +331,14 @@ class Utils:
 
         config_files = ['/etc/cortx/message_bus.conf', \
             '/etc/cortx/cluster.conf']
-        for each_file in config_files:
-            if os.path.exists(each_file):
-                # delete data/config stored
-                try:
-                    os.remove(each_file)
-                except OSError as e:
-                    raise SetupError(e.errno, "Error deleting config file %s, \
-                        %s", each_file, e)
+        Utils._delete_files(config_files)
+
+        if pre_factory:
+            # deleting all log files as part of pre-factory cleanup
+            cortx_utils_log_regex = '/var/log/cortx/utils/**/*.log'
+            log_files = glob.glob(cortx_utils_log_regex, recursive=True)
+            Utils._delete_files(log_files)
+
         return 0
 
     @staticmethod

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -171,12 +171,20 @@ class CleanupCmd(Cmd):
     """ Cleanup Setup Cmd """
     name = 'cleanup'
 
+    @staticmethod
+    def _add_extended_args(parser):
+        parser.add_argument('--pre-factory', help=' Pre-Factory cleanup',\
+            action='store_true')
+
     def __init__(self, args: dict):
         super().__init__(args)
+        # hifen(-) in argparse is converted to underscore(_)
+        # to make sure string is valid attrtibute
+        self.pre_factory = args.pre_factory
 
     def process(self):
         Utils.validate('cleanup')
-        rc = Utils.cleanup()
+        rc = Utils.cleanup(self.pre_factory)
         return rc
 
 


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Add  support for the pre-factory phase in mini-provisioning 

# Design
- added additional argument `--pre-factory` for cleanup phase in utils_setup
- if option `--pre-factory` passed, fetch and delete all the logs from `/var/log/cortx/utils`

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: N

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
