### PR TITLE
EOS-23513: Remove dependent services validations from csm-agent

### DIFF
--- a/py-utils/src/utils/data/db/db_provider.py
+++ b/py-utils/src/utils/data/db/db_provider.py
@@ -92,7 +92,9 @@ class GeneralConfig(Model):
 class ProxyStorageCallDecorator:
     """Class to decorate proxy call"""
 
-    def __init__(self, async_storage, model: Type[BaseModel], attr_name: str, event: ThreadSafeEvent):
+    def __init__(
+        self, async_storage, model: Type[BaseModel], attr_name: str, event: ThreadSafeEvent
+    ):
         self._async_storage = async_storage
         self._model = model
         self._attr_name = attr_name
@@ -165,9 +167,9 @@ class AsyncDataBase:
     async def create_database(self) -> None:
         self._database_status = ServiceStatus.IN_PROGRESS
         try:
-            self._database = await self._database_module.create_database(self._db_config.config,
-                                                                         self._model_settings.collection,
-                                                                         self._model, self._model_settings.create_schema)
+            self._database = await self._database_module.create_database(
+                self._db_config.config, self._model_settings.collection, self._model,
+                self._model_settings.create_schema)
         except DataAccessError:
             raise
         except Exception as e:


### PR DESCRIPTION
# Problem Statement
[EOS-23513](https://jts.seagate.com/browse/EOS-23513):
Remove dependency on the Consul KV and Elasticsearch.

# Design
CSM agent is able to start without properly configured Consul and Elasticsearch, but their absence generate ugly errors later, during the execution. The goal of this PR is to separate exceptions coming from the py-utils database framework and handle them gracefully.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
