### PR TITLE
EOS-2332: Shared framework returns None if key is not present in prov…

### DIFF
--- a/py-utils/src/setup/templates/utils.config.tmpl.1-node
+++ b/py-utils/src/setup/templates/utils.config.tmpl.1-node
@@ -6,7 +6,7 @@ cortx:
       servers:
       # Value should be in format <FQDN>:<port>. Port is optional
       - TMPL_KAFKA_SERVER1_FQDN:TMPL_KAFKA_SERVER1_PORT
-  support: TMPL_SHARED_URL
+  support: TMPL_SHARED_URL #Remove this key if shared storage is unavailable
 server_node:
   TMPL_MACHINE_ID:
     cluster_id: TMPL_CLUSTER_ID

--- a/py-utils/src/setup/templates/utils.config.tmpl.3-node
+++ b/py-utils/src/setup/templates/utils.config.tmpl.3-node
@@ -8,7 +8,7 @@ cortx:
       - TMPL_KAFKA_SERVER1_FQDN:TMPL_KAFKA_SERVER1_PORT
       - TMPL_KAFKA_SERVER2_FQDN:TMPL_KAFKA_SERVER2_PORT
       - TMPL_KAFKA_SERVER3_FQDN:TMPL_KAFKA_SERVER3_PORT
-  support: TMPL_SHARED_URL
+  support: TMPL_SHARED_URL #Remove this key if shared storage is unavailable
 server_node:
   TMPL_MACHINE_ID1:
     name: TMPL_NAME1

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -249,7 +249,8 @@ class Utils:
         shared_storage = Conf.get('cluster_config', 'cortx>support')
 
         # set shared storage info to cortx.conf conf file
-        Utils._set_to_conf_file('support>shared_path', shared_storage)
+        if shared_storage:
+            Utils._set_to_conf_file('support>shared_path', shared_storage)
 
         # temporary fix for a common message bus log file
         # The issue happend when some user other than root:root is trying

--- a/py-utils/src/utils/shared_storage/shared_storage.py
+++ b/py-utils/src/utils/shared_storage/shared_storage.py
@@ -30,18 +30,20 @@ class Storage:
         """ Initialize and load shared storage backend """
 
         Conf.load('cotrx_config', Storage.config_file, skip_reload=True)
-        shared_storage_url = Conf.get('cotrx_config', 'support>shared_path')
-
-        self.shared_storage_agent = SharedStorageFactory.get_instance( \
-            shared_storage_url)
+        self.shared_storage_url = Conf.get('cotrx_config', 'support>shared_path')
+        if self.shared_storage_url is not None:
+            self.shared_storage_agent = SharedStorageFactory.get_instance( \
+                self.shared_storage_url)
 
     @staticmethod
     def get_path(name: str = None, exist_ok: bool = True) -> str:
         """ return shared storage mountpoint """
+
         storage = Storage()
-        shared_path = storage.shared_storage_agent.get_path()
-        if shared_path is None:
+        if storage.shared_storage_url is None:
             return None
+
+        shared_path = storage.shared_storage_agent.get_path()
         if name:
             try:
                 spec_path = os.path.join(shared_path, name)


### PR DESCRIPTION
# Problem Statement
- Return None if key is not present 'cortx>support' in constore file

# Design
-  Return None if key is not present 'cortx>support' in constore file

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
