### PR TITLE
EOS-24154: Handle non-existent component support bundle generation

### DIFF
--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -180,6 +180,10 @@ class ComponentsBundle:
             components_commands = []
             components_files = command_files_info[each_component]
             for file_path in components_files:
+                if not os.path.exists(file_path):
+                    ComponentsBundle._publish_log(f"'{file_path}' file does not exist!", \
+                        ERROR, bundle_id, node_name, comment)
+                    continue
                 try:
                     file_data = Yaml(file_path).load()
                 except Exception as e:
@@ -192,7 +196,7 @@ class ComponentsBundle:
                     components_commands = file_data.get(
                         const.SUPPORT_BUNDLE.lower(), [])
                 else:
-                    ComponentsBundle._publish_log(f"Support.yaml file does not exist/empty: " \
+                    ComponentsBundle._publish_log(f"Support.yaml file is empty: " \
                         f"{file_path}", ERROR, bundle_id, node_name, comment)
                     break
                 if components_commands:

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -94,8 +94,8 @@ class SupportBundle:
             components = []
         if command.options.get(const.SOS_COMP, False) == 'true':
             components.append('os')
-        comp_list = SupportBundle._get_components(components)
-
+        Conf.load('cortx_conf', 'json:///etc/cortx/cortx.conf', \
+            skip_reload=True)
         # Get HostNames and Node Names.
         node_hostname_map = await SupportBundle._get_active_nodes()
         if not isinstance(node_hostname_map, dict):
@@ -110,6 +110,19 @@ class SupportBundle:
         
         bundle_obj = Bundle(bundle_id=bundle_id, bundle_path=path, \
             comment=comment,is_shared=True if shared_path else False)
+        
+        support_bundle_file = os.path.join(Conf.get('cortx_conf', 'install_path'),\
+            'cortx/utils/conf/support_bundle.yaml')
+        Conf.load('sb_yaml', f'yaml://{support_bundle_file}', skip_reload=True)
+        all_components = Conf.get('sb_yaml', 'COMPONENTS')
+        invalid_comps = [component for component in components if component not in all_components.keys()]
+        if invalid_comps:
+            components = list(set(components) - set(invalid_comps))
+            ComponentsBundle._publish_log(f"""Invalid components - '{", ".join(invalid_comps)}'""", \
+                'error', bundle_id,'', comment)
+        if invalid_comps and not components:
+            return bundle_obj
+        comp_list = SupportBundle._get_components(components)
 
         # Start SB Generation on all Nodes.
         for nodename, hostname in node_hostname_map.items():

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -119,7 +119,7 @@ class SupportBundle:
         if invalid_comps:
             components = list(set(components) - set(invalid_comps))
             ComponentsBundle._publish_log(f"""Invalid components - '{", ".join(invalid_comps)}'""", \
-                'error', bundle_id,'', comment)
+                'error', bundle_id, '', comment)
         if invalid_comps and not components:
             return bundle_obj
         comp_list = SupportBundle._get_components(components)

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -66,7 +66,7 @@ class TestSupportBundle(unittest.TestCase):
         self.assertIsNotNone(status)
         status = json.loads(status)
         if status['status']:
-            self.assertEqual(status['status'][0]['result'], "Success")
+            self.assertEqual(status['status'][0]['result'], 'Success')
 
     def test_005status(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['wrong'])

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -46,7 +46,7 @@ class TestSupportBundle(unittest.TestCase):
 
     def test_002generated_path(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm'])
-        time.sleep(5)
+        time.sleep(10)
         Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf')
         node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
         tar_file_name = f"{bundle_obj.bundle_id}_{node_name}.tar.gz"

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -45,8 +45,7 @@ class TestSupportBundle(unittest.TestCase):
 
     def test_002generated_path(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm'])
-        time.sleep(10)
-        from cortx.utils.conf_store import Conf
+        time.sleep(5)
         Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf')
         node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
         tar_file_name = f"{bundle_obj.bundle_id}_{node_name}.tar.gz"

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -84,21 +84,21 @@ class TestSupportBundle(unittest.TestCase):
         status = json.loads(status)
         if status['status']:
             self.assertEqual(status['status'][0]['result'], 'Error')
-    
+
     def test_007_wrong_comp(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util'])
         status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
         status = json.loads(status)
         if status['status']:
             self.assertEqual(status['status'][0]['result'], 'Error')
-    
+
     def test_008_wrong_comp(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util;csmm'])
         status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
         status = json.loads(status)
         if status['status']:
             self.assertEqual(status['status'][0]['result'], 'Error')
-    
+
     def test_009_wrong_comp(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util;csm'])
         time.sleep(10)

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -45,7 +45,7 @@ class TestSupportBundle(unittest.TestCase):
 
     def test_002generated_path(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm'])
-        time.sleep(5)
+        time.sleep(10)
         from cortx.utils.conf_store import Conf
         Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf')
         node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
@@ -65,7 +65,8 @@ class TestSupportBundle(unittest.TestCase):
         status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
         self.assertIsNotNone(status)
         status = json.loads(status)
-        self.assertEqual(status['status'][0]['result'], "Success")
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], "Success")
 
     def test_005status(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['wrong'])
@@ -81,7 +82,30 @@ class TestSupportBundle(unittest.TestCase):
         bundle_obj = SupportBundle.generate(comment=self.sb_description)
         status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
         status = json.loads(status)
-        self.assertEqual(status['status'][0]['result'], 'Error')
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], 'Error')
+    
+    def test_007_wrong_comp(self):
+        bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util'])
+        status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
+        status = json.loads(status)
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], 'Error')
+    
+    def test_008_wrong_comp(self):
+        bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util;csmm'])
+        status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
+        status = json.loads(status)
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], 'Error')
+    
+    def test_009_wrong_comp(self):
+        bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['util;csm'])
+        time.sleep(10)
+        status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
+        status = json.loads(status)
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], 'Error')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -68,7 +68,7 @@ class TestSupportBundleCli(unittest.TestCase):
         import ast
         status = ast.literal_eval(status)
         self.assertIsInstance(status, dict)
-    
+
     def test_005_wrong_comp(self):
         cmd = "support_bundle generate 'sample comment' -c 'util'"
         cmd_proc = SimpleProcess(cmd)

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -68,6 +68,25 @@ class TestSupportBundleCli(unittest.TestCase):
         import ast
         status = ast.literal_eval(status)
         self.assertIsInstance(status, dict)
+    
+    def test_005_wrong_comp(self):
+        cmd = "support_bundle generate 'sample comment' -c 'util'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        bundle_id = ''
+        if rc != 0:
+            cmd = f"support_bundle get_status -b '{bundle_id.strip()}'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, stderr, rc = cmd_proc.run()
+        self.assertIsInstance(stdout, bytes)
+        self.assertEqual(stderr, b'')
+        self.assertEqual(rc, 0)
+        status = stdout.decode('utf-8')
+        import ast
+        status = ast.literal_eval(status)
+        self.assertIsInstance(status, dict)
+        if status['status']:
+            self.assertEqual(status['status'][0]['result'], 'Error')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Handle non-existent component support bundle generation
- User should be get to know when he entered wrong component in SB generation

# Design
-  https://jts.seagate.com/browse/EOS-24154

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: N
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
