### PR TITLE
EOS-24017: Component wise folders should be removed after support bundle generation

### DIFF
--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -236,7 +236,7 @@ class ComponentsBundle:
                 ERROR, bundle_id, node_name, comment)
         finally:
             if os.path.exists(bundle_path):
-                [shutil.rmtree(os.path.join(bundle_path, dir_path)) for dir_path in 
-                    os.listdir(bundle_path) if os.path.isdir(os.path.join(bundle_path, dir_path))]
+                _ = [shutil.rmtree(os.path.join(bundle_path, dir_path)) for dir_path in \
+                        os.listdir(bundle_path) if os.path.isdir(os.path.join(bundle_path, dir_path))]
         msg = "Support bundle generation completed."
         ComponentsBundle._publish_log(msg, INFO, bundle_id, node_name, comment)

--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -236,7 +236,10 @@ class ComponentsBundle:
                 ERROR, bundle_id, node_name, comment)
         finally:
             if os.path.exists(bundle_path):
-                _ = [shutil.rmtree(os.path.join(bundle_path, dir_path)) for dir_path in \
-                        os.listdir(bundle_path) if os.path.isdir(os.path.join(bundle_path, dir_path))]
+                for each_dir in os.listdir(bundle_path):
+                    comp_dir = os.path.join(bundle_path, each_dir)
+                    if os.path.isdir(comp_dir):
+                        shutil.rmtree(comp_dir)
+
         msg = "Support bundle generation completed."
         ComponentsBundle._publish_log(msg, INFO, bundle_id, node_name, comment)

--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -234,8 +234,9 @@ class ComponentsBundle:
         except Exception as e:
             ComponentsBundle._publish_log(f"Could not generate tar file {e}", \
                 ERROR, bundle_id, node_name, comment)
-        # finally:
-        #     if os.path.isdir(bundle_path):
-        #         shutil.rmtree(bundle_path)
+        finally:
+            if os.path.exists(bundle_path):
+                [shutil.rmtree(os.path.join(bundle_path, dir_path)) for dir_path in 
+                    os.listdir(bundle_path) if os.path.isdir(os.path.join(bundle_path, dir_path))]
         msg = "Support bundle generation completed."
         ComponentsBundle._publish_log(msg, INFO, bundle_id, node_name, comment)

--- a/py-utils/test/support_bundle/test_support_bundle.py
+++ b/py-utils/test/support_bundle/test_support_bundle.py
@@ -20,8 +20,9 @@ import os
 import json
 import time
 import unittest
-from cortx.utils.support_framework import SupportBundle
+from cortx.utils.conf_store import Conf
 from cortx.utils.support_framework import Bundle
+from cortx.utils.support_framework import SupportBundle
 
 
 class TestSupportBundle(unittest.TestCase):
@@ -46,7 +47,6 @@ class TestSupportBundle(unittest.TestCase):
     def test_002generated_path(self):
         bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm'])
         time.sleep(5)
-        from cortx.utils.conf_store import Conf
         Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf')
         node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
         tar_file_name = f"{bundle_obj.bundle_id}_{node_name}.tar.gz"
@@ -82,6 +82,22 @@ class TestSupportBundle(unittest.TestCase):
         status = SupportBundle.get_status(bundle_id=bundle_obj.bundle_id)
         status = json.loads(status)
         self.assertEqual(status['status'][0]['result'], 'Error')
+
+    def test_007_dir_remove(self):
+        bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm'])
+        time.sleep(5)
+        Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf', skip_reload=True)
+        node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
+        self.assertFalse(os.path.exists(f'{bundle_obj.bundle_path}/{bundle_obj.bundle_id}/{node_name}/csm'))
+
+    def test_008_dir_remove(self):
+        bundle_obj = SupportBundle.generate(comment=self.sb_description, components=['csm', 'provisioner'])
+        time.sleep(15)
+        Conf.load('cluster_conf', 'json:///etc/cortx/cluster.conf', skip_reload=True)
+        node_name = Conf.get('cluster_conf', 'cluster>srvnode-1')
+        self.assertFalse(os.path.exists(f'{bundle_obj.bundle_path}/{bundle_obj.bundle_id}/{node_name}/csm'))
+        self.assertFalse(os.path.exists(f'{bundle_obj.bundle_path}/{bundle_obj.bundle_id}/{node_name}/provisioner'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Component wise folders should be removed after support bundle generation

# Design
-  https://jts.seagate.com/browse/EOS-24017

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: N
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
