### PR TITLE
EOS24090 and EOS24092 and EOS23882-Openldap provisioning failing with different dc and different admin user and different pwd

### DIFF
--- a/py-utils/src/utils/setup/openldap/base_configure_ldap.py
+++ b/py-utils/src/utils/setup/openldap/base_configure_ldap.py
@@ -105,6 +105,7 @@ class BaseConfig:
             quit()
         if forcecleanup != None :
             forceclean = forcecleanup
+        adminuser = config_values.get('bind_base_dn').split('dc=')[0]
         mdb_dir = Conf.get(index= 'util_config_file_index', key='install_path') + '/cortx/utils/conf'
         BaseConfig.cleanup(forceclean)
         copyfile(mdb_dir + '/olcDatabase={2}mdb.ldif' ,\
@@ -116,7 +117,7 @@ class BaseConfig:
         #restart slapd post cleanup
         os.system('systemctl restart slapd')
         dn = 'olcDatabase={0}config,cn=config'
-        BaseConfig.modify_attribute(dn, 'olcRootDN', 'cn=admin,cn=config')
+        BaseConfig.modify_attribute(dn, 'olcRootDN', (adminuser+'cn=config'))
         BaseConfig.modify_attribute(dn, 'olcRootPW', pwd)
         BaseConfig.modify_attribute(dn, 'olcAccess', '{0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" write by self write by * read')
         dn = 'olcDatabase={2}mdb,cn=config'
@@ -146,10 +147,10 @@ class BaseConfig:
         BaseConfig.add_attribute(config_values.get('bind_base_dn'), config_values.get('base_dn'), add_record, ROOTDNPASSWORD)
 
         #add iam constraint
-        BaseConfig.perform_ldif_operation('/opt/seagate/cortx/utils/conf/iam-constraints.ldif','cn=admin,cn=config',ROOTDNPASSWORD)
+        BaseConfig.perform_ldif_operation('/opt/seagate/cortx/utils/conf/iam-constraints.ldif',(adminuser+'cn=config'),ROOTDNPASSWORD)
         #add ppolicy schema
-        BaseConfig.perform_ldif_operation('/etc/openldap/schema/ppolicy.ldif','cn=admin,cn=config',ROOTDNPASSWORD)
-        BaseConfig.perform_ldif_operation('/opt/seagate/cortx/utils/conf/ppolicymodule.ldif','cn=admin,cn=config',ROOTDNPASSWORD)
+        BaseConfig.perform_ldif_operation('/etc/openldap/schema/ppolicy.ldif',(adminuser+'cn=config'),ROOTDNPASSWORD)
+        BaseConfig.perform_ldif_operation('/opt/seagate/cortx/utils/conf/ppolicymodule.ldif',(adminuser+'cn=config'),ROOTDNPASSWORD)
         add_record = [
          ('objectClass', [b'olcOverlayConfig',b'olcPPolicyConfig']),
          ('olcOverlay',[b'ppolicy']),
@@ -158,7 +159,7 @@ class BaseConfig:
          ('olcPPolicyUseLockout',[b'FALSE']),
          ('olcPPolicyForwardUpdates',[b'FALSE'])
         ]
-        BaseConfig.add_attribute("cn=admin,cn=config", "olcOverlay=ppolicy,olcDatabase={2}mdb,cn=config", add_record, ROOTDNPASSWORD)
+        BaseConfig.add_attribute((adminuser+'cn=config'), "olcOverlay=ppolicy,olcDatabase={2}mdb,cn=config", add_record, ROOTDNPASSWORD)
 
         add_record = [
          ('objectClass', [b'organizationalUnit']),

--- a/py-utils/src/utils/setup/openldap/configcmd.py
+++ b/py-utils/src/utils/setup/openldap/configcmd.py
@@ -56,7 +56,7 @@ class ConfigCmd(SetupCmd):
     Log.debug("Inside config phaze, starting openldap base configuration")
     # Perform base configuration
     base_dn = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_BASE_DN'))
-    bind_base_dn = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_BIND_BASE_DN'))
+    bind_base_dn = 'cn=admin,' + base_dn
     confvalues = {'base_dn':base_dn , 'bind_base_dn':bind_base_dn}
     BaseConfig.perform_base_config(self.rootdn_passwd.decode("utf-8"),'True',confvalues)
     Log.debug("openldap base configuration completed successfully")

--- a/py-utils/src/utils/setup/openldap/openldap_prov_config.yaml
+++ b/py-utils/src/utils/setup/openldap/openldap_prov_config.yaml
@@ -27,7 +27,6 @@ CONFIG:
   CONFSTORE_STORAGE_SET_COUNT_KEY: "cluster>cluster-id>site>storage_set_count"
   CONFSTORE_STORAGE_SET_SERVER_NODES_KEY: "cluster>cluster-id>storage_set[storage-set-count]>server_nodes"
   OPENLDAP_BASE_DN: "cortx>software>openldap>base_dn"
-  OPENLDAP_BIND_BASE_DN: "cortx>software>openldap>bind_base_dn"
 INIT:
 TEST:
   CONFSTORE_CLUSTER_ID_KEY: "server_node>machine-id>cluster_id"
@@ -37,7 +36,6 @@ TEST:
   CONFSTORE_STORAGE_SET_COUNT_KEY: "cluster>cluster-id>site>storage_set_count"
   CONFSTORE_STORAGE_SET_SERVER_NODES_KEY: "cluster>cluster-id>storage_set[storage-set-count]>server_nodes"
   OPENLDAP_BASE_DN: "cortx>software>openldap>base_dn"
-  OPENLDAP_BIND_BASE_DN: "cortx>software>openldap>bind_base_dn"
 RESET:
 CLEANUP:
 # Unsolicited Keys should be added to the bottom.

--- a/py-utils/src/utils/setup/openldap/setupReplication.py
+++ b/py-utils/src/utils/setup/openldap/setupReplication.py
@@ -88,7 +88,7 @@ class Replication:
             Log.debug('Current host-'+socket.gethostname()+' is not present in input host file')
             quit()
         conn = ldap.initialize("ldapi://")
-        conn.simple_bind_s(config_values.get('bind_base_dn'), "seagate")
+        conn.simple_bind_s(config_values.get('bind_base_dn'), pwd)
         conn.sasl_non_interactive_bind_s('EXTERNAL')
 
         dn = "cn=config"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
@@ -15,4 +15,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID]"
+    - server_nodes: "['TMPL_MACHINE_ID']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node.sample
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
@@ -21,4 +21,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID1,TMPL_MACHINE_ID2,TMPL_MACHINE_ID3]"
+    - server_nodes: "['TMPL_MACHINE_ID1','TMPL_MACHINE_ID2','TMPL_MACHINE_ID3']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node.sample
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
@@ -15,4 +15,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID]"
+    - server_nodes: "['TMPL_MACHINE_ID']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node.sample
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
@@ -21,4 +21,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID1,TMPL_MACHINE_ID2,TMPL_MACHINE_ID3]"
+    - server_nodes: "['TMPL_MACHINE_ID1','TMPL_MACHINE_ID2','TMPL_MACHINE_ID3']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node.sample
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
@@ -15,4 +15,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID]"
+    - server_nodes: "['TMPL_MACHINE_ID']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node.sample
@@ -6,7 +6,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
@@ -21,4 +21,4 @@ cluster:
     site:
       storage_set_count: TMPL_STORAGE_SET_COUNT
     storage_set:
-    - server_nodes: "[TMPL_MACHINE_ID1,TMPL_MACHINE_ID2,TMPL_MACHINE_ID3]"
+    - server_nodes: "['TMPL_MACHINE_ID1','TMPL_MACHINE_ID2','TMPL_MACHINE_ID3']"

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node.sample
@@ -12,7 +12,6 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
-      bind_base_dn: "cn=admin,dc=seagate,dc=com"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/test.py
+++ b/py-utils/src/utils/setup/openldap/test.py
@@ -71,8 +71,9 @@ class Test(SetupCmd):
         return no_nodes
 
     def test_olcsyncrepl(self, pwd):
+        adminuser = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BIND_BASE_DN')).split('dc=')[0]
         baseDN = "olcDatabase={2}mdb,cn=config"
-        bind_base_DN = "cn=admin,cn=config"
+        bind_base_DN = adminuser+"cn=config"
         searchScope = ldap.SCOPE_BASE
         retrieveAttributes = ['olcSyncrepl']
         searchFilter = None
@@ -92,8 +93,9 @@ class Test(SetupCmd):
         ldap_conn.unbind_s()
 
     def test_olcserverId(self, pwd):
+        adminuser = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BIND_BASE_DN')).split('dc=')[0]
         baseDN = "cn=config"
-        bind_base_DN = "cn=admin,cn=config"
+        bind_base_DN = adminuser+"cn=config"
         searchScope = ldap.SCOPE_BASE
         retrieveAttributes = ['olcServerID']
         searchFilter = None

--- a/py-utils/src/utils/setup/openldap/test.py
+++ b/py-utils/src/utils/setup/openldap/test.py
@@ -40,7 +40,7 @@ class Test(SetupCmd):
 
     def test_base_dn(self,pwd):
         baseDN = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BASE_DN'))
-        bind_base_DN = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BIND_BASE_DN'))
+        bind_base_DN = 'cn=admin,' + baseDN
         searchScope = ldap.SCOPE_BASE
         retrieveAttributes = None
         searchFilter = None
@@ -71,9 +71,8 @@ class Test(SetupCmd):
         return no_nodes
 
     def test_olcsyncrepl(self, pwd):
-        adminuser = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BIND_BASE_DN')).split('dc=')[0]
         baseDN = "olcDatabase={2}mdb,cn=config"
-        bind_base_DN = adminuser+"cn=config"
+        bind_base_DN = "cn=admin,cn=config"
         searchScope = ldap.SCOPE_BASE
         retrieveAttributes = ['olcSyncrepl']
         searchFilter = None
@@ -93,9 +92,8 @@ class Test(SetupCmd):
         ldap_conn.unbind_s()
 
     def test_olcserverId(self, pwd):
-        adminuser = self.get_confvalue(self.get_confkey('TEST>OPENLDAP_BIND_BASE_DN')).split('dc=')[0]
         baseDN = "cn=config"
-        bind_base_DN = adminuser+"cn=config"
+        bind_base_DN = "cn=admin,cn=config"
         searchScope = ldap.SCOPE_BASE
         retrieveAttributes = ['olcServerID']
         searchFilter = None


### PR DESCRIPTION
# Problem Statement
Openldap provisioning failing with different Domain Component

# Design
seagate,com DC was hardcoded through ldif. Removed ldif and added data in py file to make it dynamic.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
