### PR TITLE
EOS-24472: Add Jinja2 python pkg as install time dependency.

### DIFF
--- a/py-utils/python_requirements.txt
+++ b/py-utils/python_requirements.txt
@@ -12,3 +12,4 @@ python-crontab==2.5.1
 PyYAML==5.1.2
 schematics==2.1.0
 toml==0.10.0
+Jinja2==2.11.1


### PR DESCRIPTION
Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

# Problem Statement
- While creating consul mini provisioner wiki realized that Jinja2 python pkg is used in consul mini-provisioner but is missing in python_requirements.txt, which causes run time failure for consul mini-provisioner api's 

# Design
-  Add the Jinja2==2.11.1 pkg install time dependency

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y 
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
