### PR TITLE
EOS-24887: cortxcli support_bundle CLI should invoke utils code

### DIFF
--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -151,8 +151,16 @@ class SupportBundle:
         #        Log.debug("Merging of node support bundle failed")
         #        return Response(output="Bundle Generation Failed in merging",
         #        rc=errno.EINVAL)
-
-
+        if command.sub_command_name == 'generate':
+            from cortx.utils.errors import OPERATION_SUCESSFUL
+            display_string_len = len(bundle_obj.bundle_id) + 4
+            response_msg = (
+            f"Please use the below bundle id for checking the status of support bundle."
+            f"\n{'-' * display_string_len}"
+            f"\n| {bundle_obj.bundle_id} |"
+            f"\n{'-' * display_string_len}"
+            f"\nPlease Find the file on -> {bundle_obj.bundle_path} .\n")
+            return Response(output=response_msg, rc=OPERATION_SUCESSFUL)
         return bundle_obj
 
     @staticmethod
@@ -171,6 +179,10 @@ class SupportBundle:
             all_nodes_status = await repo.retrieve_all(bundle_id)
             response = {'status': [each_status.to_primitive() for each_status in
                                    all_nodes_status]}
+            if command.sub_command_name == 'status':
+                from cortx.utils.errors import OPERATION_SUCESSFUL
+                return Response(output = response, rc = OPERATION_SUCESSFUL)
+
             return response
         except DataAccessExternalError as e:
             Log.warn(f"Failed to connect to elasticsearch: {e}")
@@ -219,8 +231,6 @@ class SupportBundle:
 
         bundle_id:  Using this will fetch bundle status :type: string
         """
-        import time
-        time.sleep(5)
         options = {'bundle_id': bundle_id, 'comm': {'type': 'direct', \
             'target': 'utils.support_framework', 'method': 'get_bundle_status', \
             'class': 'SupportBundle', \

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -23,6 +23,7 @@ from cortx.utils.log import Log
 from cortx.utils.schema import database
 from cortx.utils.shared_storage import Storage
 from cortx.utils.schema.providers import Response
+from cortx.utils.errors import OPERATION_SUCESSFUL
 from cortx.utils.schema.payload import Tar
 from cortx.utils.conf_store.conf_store import Conf
 from cortx.utils.cli_framework.command import Command
@@ -152,7 +153,6 @@ class SupportBundle:
         #        return Response(output="Bundle Generation Failed in merging",
         #        rc=errno.EINVAL)
         if command.sub_command_name == 'generate':
-            from cortx.utils.errors import OPERATION_SUCESSFUL
             display_string_len = len(bundle_obj.bundle_id) + 4
             response_msg = (
             f"Please use the below bundle id for checking the status of support bundle."
@@ -180,9 +180,7 @@ class SupportBundle:
             response = {'status': [each_status.to_primitive() for each_status in
                                    all_nodes_status]}
             if command.sub_command_name == 'status':
-                from cortx.utils.errors import OPERATION_SUCESSFUL
                 return Response(output = response, rc = OPERATION_SUCESSFUL)
-
             return response
         except DataAccessExternalError as e:
             Log.warn(f"Failed to connect to elasticsearch: {e}")

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -15,7 +15,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-
+import time
 import unittest
 from cortx.utils.process import SimpleProcess
 
@@ -58,6 +58,7 @@ class TestSupportBundleCli(unittest.TestCase):
         bundle_id = ''
         if rc == 0:
             bundle_id = stdout.decode('utf-8').split('|')[1]
+        time.sleep(5)
         cmd = f"support_bundle get_status -b '{bundle_id.strip()}'"
         cmd_proc = SimpleProcess(cmd)
         stdout, stderr, rc = cmd_proc.run()
@@ -73,9 +74,9 @@ class TestSupportBundleCli(unittest.TestCase):
         cmd = "support_bundle generate 'sample comment' -c 'util'"
         cmd_proc = SimpleProcess(cmd)
         stdout, stderr, rc = cmd_proc.run()
-        bundle_id = ''
-        if rc != 0:
-            cmd = f"support_bundle get_status -b '{bundle_id.strip()}'"
+        bundle_id = stdout.decode('utf-8').split('|')[1]
+        cmd = f"support_bundle get_status -b '{bundle_id.strip()}'"
+        time.sleep(5)
         cmd_proc = SimpleProcess(cmd)
         stdout, stderr, rc = cmd_proc.run()
         self.assertIsInstance(stdout, bytes)
@@ -87,8 +88,21 @@ class TestSupportBundleCli(unittest.TestCase):
         self.assertIsInstance(status, dict)
         if status['status']:
             self.assertEqual(status['status'][0]['result'], 'Error')
+    
+    def test_006_cortxcli_generate_status(self):
+        cmd = "cortxcli support_bundle generate 'sample comment' -c 'csm'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, _, rc = cmd_proc.run()
+        stdout = stdout.decode('utf-8')
+        self.assertIn("bundle id", stdout)
+        self.assertEqual(rc, 0)
+        bundle_id = stdout.split('|')[1].strip()
+        time.sleep(15)
+        cmd = f"cortxcli support_bundle status '{bundle_id}'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, _, rc = cmd_proc.run()
+        self.assertIn('Success', stdout.decode('utf-8'))
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/py-utils/test/support_bundle/test_support_bundle_cli.py
+++ b/py-utils/test/support_bundle/test_support_bundle_cli.py
@@ -88,7 +88,7 @@ class TestSupportBundleCli(unittest.TestCase):
         self.assertIsInstance(status, dict)
         if status['status']:
             self.assertEqual(status['status'][0]['result'], 'Error')
-    
+
     def test_006_cortxcli_generate_status(self):
         cmd = "cortxcli support_bundle generate 'sample comment' -c 'csm'"
         cmd_proc = SimpleProcess(cmd)
@@ -102,6 +102,12 @@ class TestSupportBundleCli(unittest.TestCase):
         cmd_proc = SimpleProcess(cmd)
         stdout, _, rc = cmd_proc.run()
         self.assertIn('Success', stdout.decode('utf-8'))
+
+    def test_007_cortxcli_wrong_generate(self):
+        cmd = "cortxcli support_bundle generate 'sample comment' -c 'csmm'"
+        cmd_proc = SimpleProcess(cmd)
+        stdout, _, _ = cmd_proc.run()
+        self.assertEqual(stdout, b'')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- cortxcli support_bundle CLI should invoke utils code

# Design
-  https://jts.seagate.com/browse/EOS-24887

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: N
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
