### PR TITLE
Fix for pp warnings

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -79,7 +79,7 @@ echo "\""  >> utils-pre-install
 echo "rc=0
 for package in \$PACKAGE_LIST
 do
-    pip3 freeze | grep \$package > /dev/null
+    python3 -m pip freeze | grep \$package > /dev/null
     if [ \$? -ne 0 ]; then
        if [ \$rc -eq 0 ]; then
            echo \"===============================================\"


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- `WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
`
- above warning needs to be suppresed in cortx-py-utils-post-install section

# Design
-  instead of calling pip directly, it is now called as a python module.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
