### PR TITLE
Making openldap install dir and data dir configurable

### DIFF
--- a/py-utils/src/utils/setup/openldap/cleanupcmd.py
+++ b/py-utils/src/utils/setup/openldap/cleanupcmd.py
@@ -42,12 +42,14 @@ class CleanupCmd(SetupCmd):
         try:
             self.delete_replication_config()
             self.delete_log_files()
-            BaseConfig.cleanup(True)
+            install_dir = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_INSTALL_DIR'))
+            data_dir = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_DATA_DIR'))
+            BaseConfig.cleanup(True, install_dir, data_dir)
             # restart slapd
             if(os.system('kill -15 $(pidof slapd)')!=0) :
                 Log.error('failed to kill slapd process while cleanup')
                 quit()
-            if(os.system('/usr/sbin/slapd -u ldap -h \'ldapi:/// ldap:///\'')!=0) :
+            if(os.system('/usr/sbin/slapd -F '+install_dir +'/openldap/slapd.d -u ldap -h \'ldapi:/// ldap:///\'')!=0) :
                 Log.error('failed to start slapd in cleanup')
                 quit()
 

--- a/py-utils/src/utils/setup/openldap/configcmd.py
+++ b/py-utils/src/utils/setup/openldap/configcmd.py
@@ -57,7 +57,9 @@ class ConfigCmd(SetupCmd):
     # Perform base configuration
     base_dn = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_BASE_DN'))
     bind_base_dn = 'cn=admin,' + base_dn
-    confvalues = {'base_dn':base_dn , 'bind_base_dn':bind_base_dn}
+    install_dir = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_INSTALL_DIR'))
+    data_dir = self.get_confvalue(self.get_confkey('CONFIG>OPENLDAP_DATA_DIR'))
+    confvalues = {'base_dn':base_dn , 'bind_base_dn':bind_base_dn, 'install_dir':install_dir, 'data_dir':data_dir}
     BaseConfig.perform_base_config(self.rootdn_passwd.decode("utf-8"),'True',confvalues)
     Log.debug("openldap base configuration completed successfully")
     # set openldap-replication

--- a/py-utils/src/utils/setup/openldap/openldap_prov_config.yaml
+++ b/py-utils/src/utils/setup/openldap/openldap_prov_config.yaml
@@ -27,6 +27,9 @@ CONFIG:
   CONFSTORE_STORAGE_SET_COUNT_KEY: "cluster>cluster-id>site>storage_set_count"
   CONFSTORE_STORAGE_SET_SERVER_NODES_KEY: "cluster>cluster-id>storage_set[storage-set-count]>server_nodes"
   OPENLDAP_BASE_DN: "cortx>software>openldap>base_dn"
+  OPENLDAP_INSTALL_DIR: "cortx>software>openldap>install_dir"
+  OPENLDAP_DATA_DIR: "cortx>software>openldap>data_dir"
+
 INIT:
 TEST:
   CONFSTORE_CLUSTER_ID_KEY: "server_node>machine-id>cluster_id"

--- a/py-utils/src/utils/setup/openldap/setupcmd.py
+++ b/py-utils/src/utils/setup/openldap/setupcmd.py
@@ -42,7 +42,6 @@ class SetupCmd(object):
   rootdn_passwd = None
   cluster_id = None
   machine_id = None
-  ldap_mdb_folder = "/var/lib/ldap"
   _preqs_conf_file = "openldapsetup_prereqs.json"
   ha_service_map = {}
   sgiam_user_key = 'cluster_config>sgiam_user'

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.1-node.sample
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.config.tmpl.3-node.sample
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.1-node.sample
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.init.tmpl.3-node.sample
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.1-node.sample
@@ -6,6 +6,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: TMPL_ROOT_USER
         secret: TMPL_ROOT_SECRET_KEY

--- a/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node.sample
+++ b/py-utils/src/utils/setup/openldap/templates/openldap.test.tmpl.3-node.sample
@@ -12,6 +12,8 @@ cortx:
   software:
     openldap:
       base_dn: "dc=seagate,dc=com"
+      install_dir: "/etc"
+      data_dir: "/var/lib/ldap"
       root:
         user: "admin"
         secret: "gAAAAABgiBKtyL7Y0QUvbsNeaJRvh7ihTq9EQDCiZlGkO2k2doSEepB0-dYFPM3V12NyjagS3oCU5YcO6JPBTe5pEMaTKbVPDg=="


### PR DESCRIPTION
# Problem Statement
Openldap install dir and data dir not configurable

# Design
Added 2 new keys to confstore and made both install and data path for openldap configurable

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  NA

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
