### PR TITLE
EOS-24922: Confstore: consul should be able to connect to consul cluster outside localhost

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -465,7 +465,14 @@ class ConsulKVStore(KvStore):
 
     def __init__(self, store_loc, store_path, delim='>'):
         KvStore.__init__(self, store_loc, store_path, delim)
-        self.c = Consul()
+        if store_loc:
+            if ':' in store_loc:
+                host, port = store_loc.split(':')
+            else:
+                host, port = store_loc, 8500
+        else:
+            host, port = '127.0.0.1', 8500
+        self.c = Consul(host=host, port=port)
         self._payload = ConsulKvPayload(self.c, self._delim)
 
     def load(self, **kwargs) -> ConsulKvPayload:


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- Consul was not able to connect to dc present on other hosts. It expects that host should be part of consul cluster

# Design
-  Added host and port information while creating the consul object

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: No
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/316342315/Conf+Store