### PR TITLE
EOS-24935: add services hook in utils_Setup

### DIFF
--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -35,6 +35,7 @@ class Cmd:
             raise SetupError(errno.EPERM, "Permission denied! You need to be a \
                 root user")
         self._url = args.config
+        self._services = args.services
         self._args = args.args
 
     @property
@@ -79,6 +80,7 @@ class Cmd:
 
         parser1 = parser.add_parser(cls.name, help='setup %s' % name)
         parser1.add_argument('--config', help='Conf Store URL', type=str)
+        parser1.add_argument('--services', help='Cortx Services', default='all')
         cls._add_extended_args(parser1)
         parser1.add_argument('args', nargs='*', default=[], help='args')
         parser1.set_defaults(command=cls)


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- in kubernetes environment, services hook is added in utils_setup to trigger services.

# Design
-  Added a new keyword argument, --services in all the stages of 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]: Y

# Review Checklist 
  Before posting the PR please ensure
- [x ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x ] Jira is updated
- [ x] Check if the description is clear and explained. 
- [ x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
