### PR TITLE
EOS-24944: Dependent yum packages for utils should be installed as dependency

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -96,8 +96,9 @@ exit \$rc " >> utils-pre-install
 /bin/chmod +x utils-pre-install
 
 # Create the rpm
-/bin/python3.6 setup.py bdist_rpm --release="$REL" --pre-install utils-pre-install \
- --post-install utils-post-install --post-uninstall utils-post-uninstall
+/bin/python3.6 setup.py bdist_rpm --requires python36,python36-dbus \
+--release="$REL" --pre-install utils-pre-install \
+--post-install utils-post-install --post-uninstall utils-post-uninstall
 if [ $? -ne 0 ]; then
   echo "build failed"
   exit 1


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- add run time yum packages dependency to cortx-py-utils rpm

# Design
-  added python36 and python36-dbus as dependency in rpm build stage of cortx-py-utils
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
