### PR TITLE
EOS-24442: Updated K8 log path for utils

### DIFF
--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -26,7 +26,7 @@ class CortxConf:
         """
         CortxConf._load_config()
         log_dir = base_dir if base_dir else Conf.get(CortxConf._index, 'log_dir')
-        return os.path.join(log_dir, f'cortx/utils/{Conf.machine_id}'\
+        return os.path.join(log_dir, f'utils/{Conf.machine_id}'\
             +f'{"/"+component if component else ""}')
 
     @staticmethod


### PR DESCRIPTION
# Problem Statement
- In the current k8 utils log files are created inside "/shared/log/**cortx/cortx**/utils/message_bus". 
- Fixed by updating and binding the log path from utils.

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
