### PR TITLE
EOS-25113: make path of message_bus.conf file path configurable

### DIFF
--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -18,19 +18,21 @@
 import os
 import stat
 import errno
+
 from cortx.utils.log import Log
-from cortx.utils.message_bus.message_broker import MessageBrokerFactory
-from cortx.utils.message_bus.error import MessageBusError
-from cortx.utils.conf_store import Conf
-from cortx.utils.conf_store.error import ConfError
-from cortx.utils.common import CortxConf
 from cortx.template import Singleton
+from cortx.utils.conf_store import Conf
+from cortx.utils.common import CortxConf
+from cortx.utils.conf_store.error import ConfError
+from cortx.utils.message_bus.error import MessageBusError
+from cortx.utils.message_bus.message_broker import MessageBrokerFactory
 
 
 class MessageBus(metaclass=Singleton):
     """ Message Bus Framework over various types of Message Brokers """
-
-    conf_file = 'json:///etc/cortx/utils/message_bus.conf'
+    local_storage = CortxConf.get_storage_path('local')
+    message_bus_conf = os.path.join(local_storage ,'utils/conf/message_bus.conf')
+    conf_file = f'json://{message_bus_conf}'
 
     def __init__(self):
         """ Initialize a MessageBus and load its configurations """


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- make message_bus.conf file configurable
# Design
-  take base path from CortxConf.get_storage_path('local') instead of using /etc/cortx
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
