### PR TITLE
EOS-25118: Make path of cortx.conf file path configurable for utils

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -242,8 +242,7 @@ class Utils:
         config_template_index = 'config'
         Conf.load(config_template_index, config_template)
         # Configure log_dir for utils
-        log_dir = Conf.get(config_template_index, \
-            'cortx>common>storage>log')
+        log_dir = CortxConf.get_storage_path('log')
         if log_dir is not None:
             CortxConf.set('log_dir', log_dir)
             CortxConf.save()
@@ -272,8 +271,7 @@ class Utils:
         Utils._configure_rsyslog()
 
         # get shared storage from cluster.conf and set it to cortx.conf
-        shared_storage = Conf.get(config_template_index, \
-            'cortx>common>storage>shared')
+        shared_storage = CortxConf.get_storage_path('shared')
         if shared_storage:
             Utils._set_to_conf_file('support>shared_path', shared_storage)
 

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -69,7 +69,6 @@ class Utils:
             raise SetupError(errno.EINVAL, "install_path not found in %s",\
                 const.CORTX_CONF_FILE)
 
-    @staticmethod
     def _set_to_conf_file(key, value):
         """ Add key value pair to cortx.conf file """
         CortxConf.set(key, value)

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -242,7 +242,8 @@ class Utils:
         config_template_index = 'config'
         Conf.load(config_template_index, config_template)
         # Configure log_dir for utils
-        log_dir = CortxConf.get_storage_path('log')
+        log_dir = Conf.get(config_template_index, \
+            'cortx>common>storage>log')
         if log_dir is not None:
             CortxConf.set('log_dir', log_dir)
             CortxConf.save()
@@ -271,7 +272,8 @@ class Utils:
         Utils._configure_rsyslog()
 
         # get shared storage from cluster.conf and set it to cortx.conf
-        shared_storage = CortxConf.get_storage_path('shared')
+        shared_storage = Conf.get(config_template_index, \
+            'cortx>common>storage>shared')
         if shared_storage:
             Utils._set_to_conf_file('support>shared_path', shared_storage)
 

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -69,6 +69,7 @@ class Utils:
             raise SetupError(errno.EINVAL, "install_path not found in %s",\
                 const.CORTX_CONF_FILE)
 
+    @staticmethod
     def _set_to_conf_file(key, value):
         """ Add key value pair to cortx.conf file """
         CortxConf.set(key, value)
@@ -242,8 +243,7 @@ class Utils:
         config_template_index = 'config'
         Conf.load(config_template_index, config_template)
         # Configure log_dir for utils
-        log_dir = Conf.get(config_template_index, \
-            'cortx>common>storage>log')
+        log_dir = CortxConf.get_storage_path('log')
         if log_dir is not None:
             CortxConf.set('log_dir', log_dir)
             CortxConf.save()
@@ -272,8 +272,7 @@ class Utils:
         Utils._configure_rsyslog()
 
         # get shared storage from cluster.conf and set it to cortx.conf
-        shared_storage = Conf.get(config_template_index, \
-            'cortx>common>storage>shared')
+        shared_storage = CortxConf.get_storage_path('shared')
         if shared_storage:
             Utils._set_to_conf_file('support>shared_path', shared_storage)
 

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -239,7 +239,7 @@ def main():
 
     Conf.load(tmpl_file_index, tmpl_file, skip_reload=True)
     log_dir = CortxConf.get_storage_path('log')
-    utils_log_path = os.path.join(log_dir, 'cortx/utils')
+    utils_log_path = CortxConf.get_log_path(base_dir=log_dir)
 
     # Get the log level
     log_level = CortxConf.get('utils>log_level', 'INFO')

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -9,8 +9,20 @@ class CortxConf:
     @staticmethod
     def _load_config() -> None:
         """Load cortx.conf file into conf in-memory."""
-        Conf.load(CortxConf._index, f'json://{const.CORTX_CONF_FILE}',
+        local_storage_path = CortxConf.get_storage_path('local')
+        Conf.load(CortxConf._index, \
+            f"json://{os.path.join(local_storage_path, 'utils/conf/cortx.conf')}", \
             skip_reload=True)
+
+    @staticmethod
+    def get_storage_path(key):
+        """ Get the config file path """
+        Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
+        return Conf.get('cluster', f'cortx>common>storage>{key}')
+        # if not path:
+        #     # raise Error ??
+        #     pass
+        # return path
 
     @staticmethod
     def get_log_path(component = None, base_dir: str = None) -> str:

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -18,7 +18,7 @@ class CortxConf:
 
     @staticmethod
     def get_storage_path(key):
-        """ Get the config file path """
+        """Get the config file path."""
         Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
         path = Conf.get('cluster', f'cortx>common>storage>{key}')
         if not path:

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -1,5 +1,8 @@
 import os
+import errno
+
 from cortx.utils.conf_store import Conf
+from cortx.utils.conf_store.error import ConfError
 
 
 class CortxConf:
@@ -17,7 +20,10 @@ class CortxConf:
     def get_storage_path(key):
         """ Get the config file path """
         Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
-        return Conf.get('cluster', f'cortx>common>storage>{key}')
+        path = Conf.get('cluster', f'cortx>common>storage>{key}')
+        if not path:
+            raise ConfError(errno.EINVAL, "Invalid key %s", key)
+        return path
 
     @staticmethod
     def get_log_path(component = None, base_dir: str = None) -> str:

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -1,5 +1,4 @@
 import os
-from cortx.utils import const
 from cortx.utils.conf_store import Conf
 
 
@@ -19,10 +18,6 @@ class CortxConf:
         """ Get the config file path """
         Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
         return Conf.get('cluster', f'cortx>common>storage>{key}')
-        # if not path:
-        #     # raise Error ??
-        #     pass
-        # return path
 
     @staticmethod
     def get_log_path(component = None, base_dir: str = None) -> str:


### PR DESCRIPTION
# Problem Statement
- Make path of cortx.conf file path configurable for utils

# Design
-  https://jts.seagate.com/browse/EOS-25118

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N] NA
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
