### PR TITLE
EOS25102- openldap config causing access rights issues

### DIFF
--- a/py-utils/src/utils/setup/openldap/base_configure_ldap.py
+++ b/py-utils/src/utils/setup/openldap/base_configure_ldap.py
@@ -151,11 +151,15 @@ class BaseConfig:
         except Exception:
             Log.error('Error while modifying olcDbMaxSize attribute for olcDatabase={2}mdb')
             raise Exception('Error while modifying olcDbMaxSize attribute for olcDatabase={2}mdb')
-        ldap_conn.unbind_s()
         BaseConfig.modify_attribute(dn, 'olcRootPW', pwd)
-        BaseConfig.modify_attribute(dn, 'olcAccess', '{0}to attrs=userPassword by self write by dn.base="'+config_values.get('bind_base_dn')+'" write by anonymous auth by * none')
-        BaseConfig.modify_attribute(dn, 'olcAccess', '{1}to * by dn.base="'+config_values.get('bind_base_dn')+'" write by self write by * none')
-
+        BaseConfig.modify_attribute(dn, 'olcAccess', '{0}to attrs=userPassword by self write by dn.children="'+config_values.get('base_dn')+'" write by anonymous auth by * none')
+        mod_attrs = [( ldap.MOD_ADD, 'olcAccess', bytes(str('{1}to * by dn.base="'+config_values.get('bind_base_dn')+'" write by self write by * none') , 'utf-8') )]
+        try:
+            ldap_conn.modify_s(dn, mod_attrs)
+        except Exception:
+            Log.error('Error while modifying olcAccess attribute for olcDatabase={2}mdb')
+            raise Exception('Error while modifying olcAccess attribute for olcDatabase={2}mdb')
+        ldap_conn.unbind_s()
         #add_s - init.ldif
         base = config_values.get('base_dn').split(',')[0].split('=')[1]
         add_record = [


### PR DESCRIPTION
# Problem Statement
userpassword entry was getting overwritten in base config as a result other component's config were failing

# Design
Added the userpassword instead of replacing it

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]:  NA
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]:  NA
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  NA

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
