### PR TITLE
EOS-25253: Enhance CortxConf class to take cluster.conf file path as input

### DIFF
--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -224,7 +224,10 @@ def main():
     # Get the log path
     tmpl_file = argv[3]
     from cortx.utils.common import CortxConf
-    local_storage_path = CortxConf.get_storage_path('local')
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = '/etc/cortx'
+    local_storage_path = CortxConf.get_storage_path('local', cluster_conf=cluster_conf)
     cortx_config_file = os.path.join(f'{local_storage_path}', 'utils/conf/cortx.conf')
     if not os.path.exists(cortx_config_file):
         import shutil
@@ -238,11 +241,11 @@ def main():
                 cortx_config_file, e)
 
     Conf.load(tmpl_file_index, tmpl_file, skip_reload=True)
-    log_dir = CortxConf.get_storage_path('log')
-    utils_log_path = CortxConf.get_log_path(base_dir=log_dir)
+    log_dir = CortxConf.get_storage_path('log', cluster_conf=cluster_conf)
+    utils_log_path = CortxConf.get_log_path(base_dir=log_dir, cluster_conf=cluster_conf)
 
     # Get the log level
-    log_level = CortxConf.get('utils>log_level', 'INFO')
+    log_level = CortxConf.get('utils>log_level', 'INFO', cluster_conf=cluster_conf)
 
     Log.init('utils_setup', utils_log_path, level=log_level, backup_count=5, \
         file_size_in_mb=5)

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -114,9 +114,12 @@ class StatusCmd:
 def main():
     from cortx.utils.log import Log
     from cortx.utils.conf_store import Conf
-
-    log_path = CortxConf.get_log_path('support')
-    log_level = CortxConf.get('utils>log_level', 'INFO')
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = '/etc/cortx'
+    log_path = CortxConf.get_log_path('support', cluster_conf=cluster_conf)
+    log_level = CortxConf.get('utils>log_level', 'INFO',\
+        cluster_conf=cluster_conf)
     Log.init('support_bundle', log_path, level=log_level, backup_count=5, \
         file_size_in_mb=5, syslog_server='localhost', syslog_port=514)
     # Setup Parser

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -1,5 +1,7 @@
 import os
 import errno
+from pathlib import Path
+from urllib.parse import urlparse
 
 from cortx.utils.conf_store import Conf
 from cortx.utils.conf_store.error import ConfError
@@ -9,24 +11,31 @@ class CortxConf:
     _index = 'config_file'
 
     @staticmethod
-    def _load_config() -> None:
+    def _load_config(cluster_conf: str) -> None:
         """Load cortx.conf file into conf in-memory."""
-        local_storage_path = CortxConf.get_storage_path('local')
+        local_storage_path = CortxConf.get_storage_path('local', cluster_conf)
         Conf.load(CortxConf._index, \
             f"json://{os.path.join(local_storage_path, 'utils/conf/cortx.conf')}", \
             skip_reload=True)
 
     @staticmethod
-    def get_storage_path(key):
+    def get_storage_path(key: str, cluster_conf: str) -> str:
         """Get the config file path."""
-        Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
+        url_spec = urlparse(cluster_conf)
+        store_type = url_spec.scheme
+        store_loc = url_spec.netloc
+        store_path = url_spec.path
+        cluster_path = Path(store_path)
+        if not cluster_path.is_file():
+            raise UtilsError(errno.ENOENT, "Invalid cluster.conf file path")
+        Conf.load('cluster', cluster_conf, skip_reload=True)
         path = Conf.get('cluster', f'cortx>common>storage>{key}')
         if not path:
             raise ConfError(errno.EINVAL, "Invalid key %s", key)
         return path
 
     @staticmethod
-    def get_log_path(component = None, base_dir: str = None) -> str:
+    def get_log_path(component = None, base_dir: str = None, cluster_conf: str = None) -> str:
         """
         Get the log path with machine-id as sub directory
 
@@ -37,21 +46,21 @@ class CortxConf:
                    Default = None
         base_dir: root directory where all the log sub-directories should be create.
         """
-        CortxConf._load_config()
+        CortxConf._load_config(cluster_conf)
         log_dir = base_dir if base_dir else Conf.get(CortxConf._index, 'log_dir')
         return os.path.join(log_dir, f'utils/{Conf.machine_id}'\
             +f'{"/"+component if component else ""}')
 
     @staticmethod
-    def get(key: str, default_val: str = None, **filters):
+    def get(key: str, default_val: str = None, cluster_conf: str = None, **filters):
         """Obtain and return value for the given key."""
-        CortxConf._load_config()
+        CortxConf._load_config(cluster_conf)
         return Conf.get(CortxConf._index, key, default_val, **filters)
 
     @staticmethod
-    def set(key: str, value: str):
+    def set(key: str, value: str, cluster_conf:str = None):
         """Sets the value into conf in-memory at the given key."""
-        CortxConf._load_config()
+        CortxConf._load_config(cluster_conf)
         return Conf.set(CortxConf._index, key, value)
 
     @staticmethod

--- a/py-utils/src/utils/discovery/request_handler.py
+++ b/py-utils/src/utils/discovery/request_handler.py
@@ -30,7 +30,10 @@ from cortx.utils.common import CortxConf
 
 # Load cortx common config
 store_type = "json"
-local_storage_path = CortxConf.get_storage_path('local')
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = '/etc/cortx'
+local_storage_path = CortxConf.get_storage_path('local', cluster_conf=cluster_conf)
 config_url = "%s://%s" % (store_type, os.path.join(local_storage_path, 'utils/conf/cortx.conf'))
 common_config = KvStoreFactory.get_instance(config_url)
 common_config.load()

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -30,8 +30,11 @@ from cortx.utils.log import Log
 
 class EventMessage(metaclass=Singleton):
     """ Event Message framework to generate alerts """
-
-    local_storage = CortxConf.get_storage_path('local')
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = '/etc/cortx'
+    local_storage = CortxConf.get_storage_path('local',\
+        cluster_conf=cluster_conf)
     iem_conf = os.path.join(local_storage, 'utils/conf/iem.conf')
     _conf_file = f'json://{iem_conf}'
     _producer = None
@@ -73,8 +76,13 @@ class EventMessage(metaclass=Singleton):
         # the same file will be used to log all the messagebus related
         # logs, else standard iem.log will be used.
         if not Log.logger:
-            iem_log_dir = CortxConf.get_log_path('iem')
-            log_level = CortxConf.get('utils>log_level', 'INFO')
+            cluster_conf = None
+            if not cluster_conf:
+                cluster_conf = '/etc/cortx'
+            iem_log_dir = CortxConf.get_log_path('iem',\
+                cluster_conf=cluster_conf)
+            log_level = CortxConf.get('utils>log_level', 'INFO',\
+                cluster_conf=cluster_conf)
             Log.init('iem', iem_log_dir, level=log_level, \
                 backup_count=5, file_size_in_mb=5)
 

--- a/py-utils/src/utils/message_bus/message_broker.py
+++ b/py-utils/src/utils/message_bus/message_broker.py
@@ -96,9 +96,11 @@ class MessageBrokerFactory:
             Log.error(f"Missing config entry {key_list} in input file")
             raise SetupError(errno.EINVAL, \
                 "Missing config entry %s in config", key_list)
-
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = '/etc/cortx'
         # Read the default config
-        config = CortxConf.get('message_bus')
+        config = CortxConf.get('message_bus', cluster_conf=cluster_conf)
         return message_server_list, port_list, config
 
 

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -30,21 +30,32 @@ from cortx.utils.message_bus.message_broker import MessageBrokerFactory
 
 class MessageBus(metaclass=Singleton):
     """ Message Bus Framework over various types of Message Brokers """
-    local_storage = CortxConf.get_storage_path('local')
-    message_bus_conf = os.path.join(local_storage ,'utils/conf/message_bus.conf')
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = '/etc/cortx'
+    local_storage = CortxConf.get_storage_path('local',\
+        cluster_conf=cluster_conf)
+    message_bus_conf = os.path.join(local_storage ,\
+        'utils/conf/message_bus.conf')
     conf_file = f'json://{message_bus_conf}'
 
     def __init__(self):
         """ Initialize a MessageBus and load its configurations """
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = '/etc/cortx'
         # Get the log path
-        log_dir = CortxConf.get('log_dir', '/var/log')
-        utils_log_path = CortxConf.get_log_path('message_bus', base_dir=log_dir)
+        log_dir = CortxConf.get('log_dir', '/var/log',\
+            cluster_conf=cluster_conf)
+        utils_log_path = CortxConf.get_log_path('message_bus', base_dir=log_dir,\
+            cluster_conf=cluster_conf)
 
         # if Log.logger is already initialized by some parent process
         # the same file will be used to log all the messagebus related
         # logs, else standard message_bus.log will be used.
         if not Log.logger:
-            log_level = CortxConf.get('utils>log_level', 'INFO')
+            log_level = CortxConf.get('utils>log_level', 'INFO',\
+                cluster_conf=cluster_conf)
             Log.init('message_bus', utils_log_path, level=log_level, \
                 backup_count=5, file_size_in_mb=5)
 

--- a/py-utils/src/utils/setup/openldap/setupcmd.py
+++ b/py-utils/src/utils/setup/openldap/setupcmd.py
@@ -51,8 +51,10 @@ class SetupCmd(object):
   rootdn_pass_key = 'cluster_config>rootdn_password'
   cluster_id_key = 'cluster_config>cluster_id'
   Log.init('OpenldapProvisioning','/var/log/cortx/utils/openldap',level='DEBUG')
-
-  util_install_path = CortxConf.get('install_path')
+  cluster_conf = None
+  if not cluster_conf:
+      cluster_conf = '/etc/cortx'
+  util_install_path = CortxConf.get('install_path', cluster_conf=cluster_conf)
   openldap_prov_config = path.join(util_install_path, "cortx/utils/conf", "openldap_prov_config.yaml")
   openldap_config_file = path.join(util_install_path, "cortx/utils/conf", "openldap_config.yaml")
   utils_tmp_dir = path.join(util_install_path, "cortx/utils/tmp")

--- a/py-utils/src/utils/shared_storage/shared_storage.py
+++ b/py-utils/src/utils/shared_storage/shared_storage.py
@@ -27,8 +27,11 @@ class Storage:
 
     def __init__(self):
         """ Initialize and load shared storage backend """
-
-        self.shared_storage_url = CortxConf.get('support>shared_path')
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = '/etc/cortx'
+        self.shared_storage_url = CortxConf.get('support>shared_path',\
+            cluster_conf=cluster_conf)
         if self.shared_storage_url is not None:
             self.shared_storage_agent = SharedStorageFactory.get_instance( \
                 self.shared_storage_url)

--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -113,8 +113,11 @@ class ComponentsBundle:
         command:        cli Command Object :type: command
         return:         None
         """
-        log_path = CortxConf.get_log_path('support')
-        log_level = CortxConf.get('utils>log_level', 'INFO')
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = '/etc/cortx'
+        log_path = CortxConf.get_log_path('support', cluster_conf=cluster_conf)
+        log_level = CortxConf.get('utils>log_level', 'INFO', cluster_conf=cluster_conf)
         Log.init('support_bundle_node', log_path, level=log_level, \
             backup_count=5, file_size_in_mb=5)
         bundle_id = command.options.get(const.SB_BUNDLE_ID, '')
@@ -126,8 +129,8 @@ class ComponentsBundle:
             f"{node_name}, {const.SB_COMMENT}: {comment}, "
             f"{const.SB_COMPONENTS}: {components}, {const.SOS_COMP}"))
         # Read support_bundle.Yaml and Check's If It Exists.
-        cmd_setup_file = os.path.join(CortxConf.get('install_path'),\
-            'cortx/utils/conf/support_bundle.yaml')
+        cmd_setup_file = os.path.join(CortxConf.get('install_path',\
+            cluster_conf=cluster_conf), 'cortx/utils/conf/support_bundle.yaml')
         try:
             support_bundle_config = Yaml(cmd_setup_file).load()
         except Exception as e:

--- a/py-utils/src/utils/support_framework/const.py
+++ b/py-utils/src/utils/support_framework/const.py
@@ -14,9 +14,11 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 from cortx.utils.common.common import CortxConf
-
-LOG_DIR = CortxConf.get_storage_path('log')
-LOCAL_DIR = CortxConf.get_storage_path('local')
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = '/etc/cortx'
+LOG_DIR = CortxConf.get_storage_path('log', cluster_conf=cluster_conf)
+LOCAL_DIR = CortxConf.get_storage_path('local', cluster_conf=cluster_conf)
 SB_DIR_LIST = [LOG_DIR, LOCAL_DIR]
 SUPPORT_BUNDLE_TAG = 'support_bundle;'
 SUPPORT_BUNDLE = 'SUPPORT_BUNDLE'

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -41,11 +41,16 @@ class RestServer:
 if __name__ == '__main__':
     import os
     from cortx.utils.conf_store import Conf
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = '/etc/cortx'
     # Get the log path
-    log_dir = CortxConf.get('log_dir', '/var/log')
-    utils_log_path = CortxConf.get_log_path('utils_server', base_dir=log_dir)
+    log_dir = CortxConf.get('log_dir', '/var/log', cluster_conf=cluster_conf)
+    utils_log_path = CortxConf.get_log_path('utils_server', base_dir=log_dir,\
+        cluster_conf=cluster_conf)
     # Get the log level
-    log_level = CortxConf.get('utils>log_level', 'INFO')
+    log_level = CortxConf.get('utils>log_level', 'INFO',\
+        cluster_conf=cluster_conf)
 
     Log.init('utils_server', utils_log_path, level=log_level, backup_count=5, \
         file_size_in_mb=5)

--- a/py-utils/test/discovery/test_discovery.py
+++ b/py-utils/test/discovery/test_discovery.py
@@ -27,7 +27,11 @@ from cortx.utils.common import CortxConf
 
 # Load cortx common config
 store_type = "json"
-local_storage_path = CortxConf.get_storage_path('local')
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = '/etc/cortx'
+local_storage_path = CortxConf.get_storage_path('local',\
+    cluster_conf=cluster_conf)
 config_url = "%s://%s" % (store_type, os.path.join(local_storage_path, 'utils/conf/cortx.conf'))
 common_config = KvStoreFactory.get_instance(config_url)
 common_config.load()


### PR DESCRIPTION
# Problem Statement
- Enhance CortxConf class to take cluster.conf file path as input

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
