### PR TITLE
WIP: EOS-25253: Enhance CortxConf class to take cluster.conf file path as input

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -192,7 +192,10 @@ class Utils:
     @staticmethod
     def post_install(post_install_template: str):
         """ Performs post install operations """
-
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         # Check required python packages
         install_path = Utils._get_from_conf_file('install_path')
         utils_path = install_path + '/cortx/utils'
@@ -243,7 +246,10 @@ class Utils:
     @staticmethod
     def config(config_template: str):
         """Performs configurations."""
-
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         # Load required files
         config_template_index = 'config'
         Conf.load(config_template_index, config_template)
@@ -306,6 +312,10 @@ class Utils:
         try:
             Log.info("Validating cortx-py-utils-test rpm")
             PkgV().validate('rpms', ['cortx-py-utils-test'])
+            cluster_conf = None
+            if not cluster_conf:
+                cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+            CortxConf.init(cluster_conf=cluster_conf)
             utils_path = Utils._get_utils_path()
             import cortx.utils.test as test_dir
             plan_path = os.path.join(os.path.dirname(test_dir.__file__), \
@@ -355,6 +365,10 @@ class Utils:
         except Exception as e:
             raise SetupError(errors.ERR_OP_FAILED, "Internal error, can not \
                 reset Message Bus. %s", e)
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         # Clear the logs
         utils_log_path = CortxConf.get_log_path()
         if os.path.exists(utils_log_path):
@@ -369,6 +383,10 @@ class Utils:
     @staticmethod
     def cleanup(pre_factory: bool):
         """Remove/Delete all the data that was created after post install."""
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         local_path = CortxConf.get_storage_path('local')
         message_bus_conf = os.path.join(local_path, 'utils/conf/message_bus.conf')
         iem_conf = os.path.join(local_path, 'utils/conf/iem.conf')

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -224,6 +224,10 @@ def main():
     # Get the log path
     tmpl_file = argv[3]
     from cortx.utils.common import CortxConf
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+    CortxConf.init(cluster_conf=cluster_conf)
     local_storage_path = CortxConf.get_storage_path('local')
     cortx_config_file = os.path.join(f'{local_storage_path}', 'utils/conf/cortx.conf')
     if not os.path.exists(cortx_config_file):

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -114,7 +114,10 @@ class StatusCmd:
 def main():
     from cortx.utils.log import Log
     from cortx.utils.conf_store import Conf
-
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+    CortxConf.init(cluster_conf=cluster_conf)
     log_path = CortxConf.get_log_path('support')
     log_level = CortxConf.get('utils>log_level', 'INFO')
     Log.init('support_bundle', log_path, level=log_level, backup_count=5, \

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -7,6 +7,19 @@ from cortx.utils.conf_store.error import ConfError
 
 class CortxConf:
     _index = 'config_file'
+    _cluster_index = 'cluster'
+    _conf = None
+    _cluster_conf = None
+
+    @staticmethod
+    def init(**kwargs):
+        """ static init for initialising and setting attributes """
+        if CortxConf._conf is None:
+            for key, val in kwargs.items():
+                setattr(CortxConf, f"_{key}", val)
+            CortxConf._conf = Conf
+            CortxConf._load_cluster_conf()
+            CortxConf._load_config()
 
     @staticmethod
     def _load_config() -> None:
@@ -17,10 +30,13 @@ class CortxConf:
             skip_reload=True)
 
     @staticmethod
+    def _load_cluster_conf():
+        CortxConf._conf.load(CortxConf._cluster_index, CortxConf._cluster_conf)
+
+    @staticmethod
     def get_storage_path(key):
         """Get the config file path."""
-        Conf.load('cluster', 'yaml:///etc/cortx/cluster.conf', skip_reload=True)
-        path = Conf.get('cluster', f'cortx>common>storage>{key}')
+        path = Conf.get(CortxConf._cluster_index, f'cortx>common>storage>{key}')
         if not path:
             raise ConfError(errno.EINVAL, "Invalid key %s", key)
         return path
@@ -37,7 +53,6 @@ class CortxConf:
                    Default = None
         base_dir: root directory where all the log sub-directories should be create.
         """
-        CortxConf._load_config()
         log_dir = base_dir if base_dir else Conf.get(CortxConf._index, 'log_dir')
         return os.path.join(log_dir, f'utils/{Conf.machine_id}'\
             +f'{"/"+component if component else ""}')
@@ -45,13 +60,11 @@ class CortxConf:
     @staticmethod
     def get(key: str, default_val: str = None, **filters):
         """Obtain and return value for the given key."""
-        CortxConf._load_config()
         return Conf.get(CortxConf._index, key, default_val, **filters)
 
     @staticmethod
     def set(key: str, value: str):
         """Sets the value into conf in-memory at the given key."""
-        CortxConf._load_config()
         return Conf.set(CortxConf._index, key, value)
 
     @staticmethod

--- a/py-utils/src/utils/discovery/request_handler.py
+++ b/py-utils/src/utils/discovery/request_handler.py
@@ -30,6 +30,10 @@ from cortx.utils.common import CortxConf
 
 # Load cortx common config
 store_type = "json"
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+CortxConf.init(cluster_conf=cluster_conf)
 local_storage_path = CortxConf.get_storage_path('local')
 config_url = "%s://%s" % (store_type, os.path.join(local_storage_path, 'utils/conf/cortx.conf'))
 common_config = KvStoreFactory.get_instance(config_url)

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -30,7 +30,10 @@ from cortx.utils.log import Log
 
 class EventMessage(metaclass=Singleton):
     """ Event Message framework to generate alerts """
-
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+    CortxConf.init(cluster_conf=cluster_conf)
     local_storage = CortxConf.get_storage_path('local')
     iem_conf = os.path.join(local_storage, 'utils/conf/iem.conf')
     _conf_file = f'json://{iem_conf}'

--- a/py-utils/src/utils/message_bus/message_broker.py
+++ b/py-utils/src/utils/message_bus/message_broker.py
@@ -96,7 +96,10 @@ class MessageBrokerFactory:
             Log.error(f"Missing config entry {key_list} in input file")
             raise SetupError(errno.EINVAL, \
                 "Missing config entry %s in config", key_list)
-
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         # Read the default config
         config = CortxConf.get('message_bus')
         return message_server_list, port_list, config

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -30,6 +30,10 @@ from cortx.utils.message_bus.message_broker import MessageBrokerFactory
 
 class MessageBus(metaclass=Singleton):
     """ Message Bus Framework over various types of Message Brokers """
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+    CortxConf.init(cluster_conf=cluster_conf)
     local_storage = CortxConf.get_storage_path('local')
     message_bus_conf = os.path.join(local_storage ,'utils/conf/message_bus.conf')
     conf_file = f'json://{message_bus_conf}'

--- a/py-utils/src/utils/setup/openldap/setupcmd.py
+++ b/py-utils/src/utils/setup/openldap/setupcmd.py
@@ -51,7 +51,10 @@ class SetupCmd(object):
   rootdn_pass_key = 'cluster_config>rootdn_password'
   cluster_id_key = 'cluster_config>cluster_id'
   Log.init('OpenldapProvisioning','/var/log/cortx/utils/openldap',level='DEBUG')
-
+  cluster_conf = None
+  if not cluster_conf:
+      cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+  CortxConf.init(cluster_conf=cluster_conf)
   util_install_path = CortxConf.get('install_path')
   openldap_prov_config = path.join(util_install_path, "cortx/utils/conf", "openldap_prov_config.yaml")
   openldap_config_file = path.join(util_install_path, "cortx/utils/conf", "openldap_config.yaml")

--- a/py-utils/src/utils/shared_storage/shared_storage.py
+++ b/py-utils/src/utils/shared_storage/shared_storage.py
@@ -27,7 +27,10 @@ class Storage:
 
     def __init__(self):
         """ Initialize and load shared storage backend """
-
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         self.shared_storage_url = CortxConf.get('support>shared_path')
         if self.shared_storage_url is not None:
             self.shared_storage_agent = SharedStorageFactory.get_instance( \

--- a/py-utils/src/utils/support_framework/bundle_generate.py
+++ b/py-utils/src/utils/support_framework/bundle_generate.py
@@ -113,6 +113,10 @@ class ComponentsBundle:
         command:        cli Command Object :type: command
         return:         None
         """
+        cluster_conf = None
+        if not cluster_conf:
+            cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf)
         log_path = CortxConf.get_log_path('support')
         log_level = CortxConf.get('utils>log_level', 'INFO')
         Log.init('support_bundle_node', log_path, level=log_level, \

--- a/py-utils/src/utils/support_framework/const.py
+++ b/py-utils/src/utils/support_framework/const.py
@@ -14,7 +14,10 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 from cortx.utils.common.common import CortxConf
-
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+CortxConf.init(cluster_conf=cluster_conf)
 LOG_DIR = CortxConf.get_storage_path('log')
 LOCAL_DIR = CortxConf.get_storage_path('local')
 SB_DIR_LIST = [LOG_DIR, LOCAL_DIR]

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -41,6 +41,10 @@ class RestServer:
 if __name__ == '__main__':
     import os
     from cortx.utils.conf_store import Conf
+    cluster_conf = None
+    if not cluster_conf:
+        cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+    CortxConf.init(cluster_conf=cluster_conf)
     # Get the log path
     log_dir = CortxConf.get('log_dir', '/var/log')
     utils_log_path = CortxConf.get_log_path('utils_server', base_dir=log_dir)

--- a/py-utils/test/discovery/test_discovery.py
+++ b/py-utils/test/discovery/test_discovery.py
@@ -27,6 +27,10 @@ from cortx.utils.common import CortxConf
 
 # Load cortx common config
 store_type = "json"
+cluster_conf = None
+if not cluster_conf:
+    cluster_conf = 'yaml:///etc/cortx/cluster.conf'
+CortxConf.init(cluster_conf=cluster_conf)
 local_storage_path = CortxConf.get_storage_path('local')
 config_url = "%s://%s" % (store_type, os.path.join(local_storage_path, 'utils/conf/cortx.conf'))
 common_config = KvStoreFactory.get_instance(config_url)


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- Cluster.conf path will be treated as dynamic.
- Added static init method in CortxConf class for passing cluster.conf path and initializing it.


# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
