### PR TITLE
EOS-25257: Enhance Support Bundle interfaces to take cluster.conf file path as input

### DIFF
--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -89,7 +89,7 @@ class GenerateCmd:
             help='Optional, Specified component support bundle will be generated')
         s_parser.add_argument('-t', '--URL', nargs='+', required=True, \
             help="Path- CORTX support bundle will be generated at specified path.")
-        s_parser.add_argument('-cp', '--cluster_path', nargs='+', default='', \
+        s_parser.add_argument('-cp', '--cluster_conf_path', nargs='+', default='', \
             help='Cluster config file path for Support Bundle')
 
 
@@ -111,7 +111,7 @@ class StatusCmd:
         s_parser.set_defaults(func=SupportBundleCli.get_status)
         s_parser.add_argument('-b', '--bundle_id', nargs='+', default='', \
             help='Bundle ID of generated Support Bundle')
-        s_parser.add_argument('-cp', '--cluster_path', nargs='+', default='', \
+        s_parser.add_argument('-cp', '--cluster_conf_path', nargs='+', default='', \
             help='Cluster config file path for Support Bundle')
 
 
@@ -135,8 +135,8 @@ def main():
     # Parse and Process Arguments
     try:
         args = parser.parse_args()
-        cluster_path = args.cluster_path[0] if args.cluster_path else 'yaml:///etc/cortx/cluster.conf'
-        CortxConf.init(cluster_conf=cluster_path)
+        cluster_conf_path = args.cluster_conf_path[0] if args.cluster_conf_path else 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_conf_path)
         log_path = CortxConf.get_log_path('support')
         log_level = CortxConf.get('utils>log_level', 'INFO')
         Log.init('support_bundle', log_path, level=log_level, backup_count=5, \

--- a/py-utils/src/support/support_bundle_cli.py
+++ b/py-utils/src/support/support_bundle_cli.py
@@ -89,6 +89,8 @@ class GenerateCmd:
             help='Optional, Specified component support bundle will be generated')
         s_parser.add_argument('-t', '--URL', nargs='+', required=True, \
             help="Path- CORTX support bundle will be generated at specified path.")
+        s_parser.add_argument('-cp', '--cluster_path', nargs='+', default='', \
+            help='Cluster config file path for Support Bundle')
 
 
 class StatusCmd:
@@ -109,16 +111,14 @@ class StatusCmd:
         s_parser.set_defaults(func=SupportBundleCli.get_status)
         s_parser.add_argument('-b', '--bundle_id', nargs='+', default='', \
             help='Bundle ID of generated Support Bundle')
+        s_parser.add_argument('-cp', '--cluster_path', nargs='+', default='', \
+            help='Cluster config file path for Support Bundle')
 
 
 def main():
     from cortx.utils.log import Log
     from cortx.utils.conf_store import Conf
-    CortxConf.init(cluster_conf='yaml:///etc/cortx/cluster.conf')
-    log_path = CortxConf.get_log_path('support')
-    log_level = CortxConf.get('utils>log_level', 'INFO')
-    Log.init('support_bundle', log_path, level=log_level, backup_count=5, \
-        file_size_in_mb=5, syslog_server='localhost', syslog_port=514)
+    
     # Setup Parser
     parser = argparse.ArgumentParser(description='Support Bundle CLI', \
         formatter_class=RawTextHelpFormatter)
@@ -135,6 +135,12 @@ def main():
     # Parse and Process Arguments
     try:
         args = parser.parse_args()
+        cluster_path = args.cluster_path[0] if args.cluster_path else 'yaml:///etc/cortx/cluster.conf'
+        CortxConf.init(cluster_conf=cluster_path)
+        log_path = CortxConf.get_log_path('support')
+        log_level = CortxConf.get('utils>log_level', 'INFO')
+        Log.init('support_bundle', log_path, level=log_level, backup_count=5, \
+            file_size_in_mb=5, syslog_server='localhost', syslog_port=514)
         out = args.func(args)
         if out is not None and len(out) > 0:
             print(out)

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -28,7 +28,6 @@ from cortx.utils.cli_framework.command import Command
 from cortx.utils.support_framework import const
 from cortx.utils.support_framework import Bundle
 from cortx.utils.support_framework.errors import BundleError
-from cortx.utils.common import CortxConf
 
 
 class SupportBundle:


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- Enhance Support Bundle interfaces to take cluster.conf file path as input

# Design
-  https://jts.seagate.com/browse/EOS-25257

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: Y
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N] NA
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
