### PR TITLE
EOS-25329: Utils Setup - mini provisioning cluster.conf as input variable

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -31,8 +31,6 @@ from cortx.utils.process import SimpleProcess
 from cortx.utils.validator.error import VError
 from cortx.utils.validator.v_confkeys import ConfKeysV
 from cortx.utils.service.service_handler import Service
-from cortx.utils.message_bus.error import MessageBusError
-from cortx.utils.message_bus import MessageBrokerFactory
 from cortx.utils.common import CortxConf
 
 
@@ -230,6 +228,7 @@ class Utils:
         """ Perform initialization """
         # Create message_type for Event Message
         from cortx.utils.message_bus import MessageBusAdmin
+        from cortx.utils.message_bus.error import MessageBusError
         try:
             admin = MessageBusAdmin(admin_id='register')
             admin.register_message_type(message_types=['IEM'], partitions=1)
@@ -253,6 +252,7 @@ class Utils:
 
         # Create message_bus config
         try:
+            from cortx.utils.message_bus import MessageBrokerFactory
             server_list, port_list, config = \
                 MessageBrokerFactory.get_server_list(config_template_index)
         except SetupError:
@@ -325,6 +325,7 @@ class Utils:
     def reset():
         """Remove/Delete all the data/logs that was created by user/testing."""
         import time
+        from cortx.utils.message_bus.error import MessageBusError
         _purge_retry = 20
         try:
             from cortx.utils.message_bus import MessageBusAdmin
@@ -373,6 +374,7 @@ class Utils:
 
         if os.path.exists(message_bus_conf):
             # delete message_types
+            from cortx.utils.message_bus.error import MessageBusError
             try:
                 from cortx.utils.message_bus import MessageBusAdmin
                 mb = MessageBusAdmin(admin_id='cleanup')

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -224,8 +224,8 @@ def main():
     # Get the log path
     tmpl_file = argv[3]
     from cortx.utils.common import CortxConf
-    CortxConf.init(cluster_conf=tmpl_file)
-    local_storage_path = CortxConf.get_storage_path('local')
+    Conf.load(tmpl_file_index, tmpl_file, skip_reload=True)
+    local_storage_path = Conf.get(tmpl_file_index, 'cortx>common>storage>local')
     cortx_config_file = os.path.join(f'{local_storage_path}', 'utils/conf/cortx.conf')
     if not os.path.exists(cortx_config_file):
         import shutil
@@ -238,7 +238,7 @@ def main():
             raise SetupError(e.errno, "Failed to create %s %s", \
                 cortx_config_file, e)
 
-    Conf.load(tmpl_file_index, tmpl_file, skip_reload=True)
+    CortxConf.init(cluster_conf=tmpl_file)
     log_dir = CortxConf.get_storage_path('log')
     utils_log_path = CortxConf.get_log_path(base_dir=log_dir)
 


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- Uitls mini provisioning code changes for accepting cluster.conf as input variable
- Lazy load messagebus classes

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
