### PR TITLE
patch to accept cluster.conf path from end user in utis_setup

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -226,12 +226,12 @@ class Utils:
         return 0
 
     @staticmethod
-    def init():
+    def init(config_path: str):
         """ Perform initialization """
         # Create message_type for Event Message
         from cortx.utils.message_bus import MessageBusAdmin
         try:
-            admin = MessageBusAdmin(admin_id='register')
+            admin = MessageBusAdmin(admin_id='register', cluster_conf=config_path)
             admin.register_message_type(message_types=['IEM'], partitions=1)
         except MessageBusError as e:
             if 'TOPIC_ALREADY_EXISTS' not in e.desc:
@@ -322,14 +322,14 @@ class Utils:
         return 0
 
     @staticmethod
-    def reset():
+    def reset(config_path: str):
         """Remove/Delete all the data/logs that was created by user/testing."""
         import time
         _purge_retry = 20
         try:
             from cortx.utils.message_bus import MessageBusAdmin
-            from cortx.utils.message_bus.message_bus_client import MessageProducer
-            mb = MessageBusAdmin(admin_id='reset')
+            from cortx.utils.message_bus import MessageProducer
+            mb = MessageBusAdmin(admin_id='reset', cluster_conf=config_path)
             message_types_list = mb.list_message_types()
             if message_types_list:
                 for message_type in message_types_list:

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -129,10 +129,11 @@ class InitCmd(Cmd):
 
     def __init__(self, args):
         super().__init__(args)
+        self.config_path = args.config
 
     def process(self):
         Utils.validate('init')
-        rc = Utils.init()
+        rc = Utils.init(self.config_path)
         return rc
 
 
@@ -162,10 +163,11 @@ class ResetCmd(Cmd):
 
     def __init__(self, args):
         super().__init__(args)
+        self.config_path = args.config
 
     def process(self):
         Utils.validate('reset')
-        rc = Utils.reset()
+        rc = Utils.reset(self.config_path)
         return rc
 
 


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Pass config_file path to MessageBusAdmin in untils_setup

# Design
- added config_path parameter to init and reset method to accept template file and pass to MessageBusAdmin class instantiation
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
