### PR TITLE
EOS-25035 : Fix blank lines in kafka mini provisioning cleanup phase

### DIFF
--- a/py-utils/src/utils/setup/kafka/kafka.py
+++ b/py-utils/src/utils/setup/kafka/kafka.py
@@ -134,7 +134,7 @@ class Kafka:
                 # inplace=True argument redirects print output to file
                 for line in fp:
                     if line.startswith(key + '=') or line.startswith('server.'):
-                        print('')  # deletes the line
+                        print('', end='')  # deletes the line
                     else:
                         print(line, end='')
 

--- a/py-utils/src/utils/setup/kafka/setup.yaml
+++ b/py-utils/src/utils/setup/kafka/setup.yaml
@@ -38,3 +38,7 @@ kafka:
         cmd: /opt/seagate/cortx/utils/bin/kafka_setup reset
         args: --config $URL
 
+    cleanup:
+        cmd: /opt/seagate/cortx/utils/bin/kafka_setup cleanup
+        args: --config $URL  --cluster_conf $URL
+


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Cleanup phase added blank lines where the config was deleted
# Design
-  The default value of end in print is '\n', hence added end='' to print which deletes the line instead of replacing it with a blank line

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
