### PR TITLE
EOS-25744: Merged message bus and iem conf into single utils conf file utils.conf

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -91,31 +91,31 @@ class Utils:
 
         return val
 
-    @staticmethod
-    def _create_msg_bus_config(message_server_list: list, port_list: list, \
-        config: dict):
-        """ Create the config file required for message bus """
-        mb_index = 'mb_index'
-        local_path = CortxConf.get_storage_path('local')
-        message_bus_conf = os.path.join(local_path, 'utils/conf/message_bus.conf')
-        message_bus_conf_sample = message_bus_conf + '.sample'
-        with open(message_bus_conf_sample, 'w+') as file:
-            json.dump({}, file, indent=2)
-        Conf.load(mb_index, f'json://{message_bus_conf_sample}')
-        Conf.set(mb_index, 'message_broker>type', 'kafka')
-        for i in range(len(message_server_list)):
-            Conf.set(mb_index, f'message_broker>cluster[{i}]>server', \
-                     message_server_list[i])
-            Conf.set(mb_index, f'message_broker>cluster[{i}]>port', port_list[i])
-        Conf.set(mb_index, 'message_broker>message_bus',  config)
-        Conf.save(mb_index)
+    # @staticmethod
+    # def _create_msg_bus_config(message_server_list: list, port_list: list, \
+    #     config: dict):
+    #     """ Create the config file required for message bus """
+    #     mb_index = 'mb_index'
+    #     local_path = CortxConf.get_storage_path('local')
+    #     message_bus_conf = os.path.join(local_path, 'utils/conf/message_bus.conf')
+    #     message_bus_conf_sample = message_bus_conf + '.sample'
+    #     with open(message_bus_conf_sample, 'w+') as file:
+    #         json.dump({}, file, indent=2)
+    #     Conf.load(mb_index, f'json://{message_bus_conf_sample}')
+    #     Conf.set(mb_index, 'message_broker>type', 'kafka')
+    #     for i in range(len(message_server_list)):
+    #         Conf.set(mb_index, f'message_broker>cluster[{i}]>server', \
+    #                  message_server_list[i])
+    #         Conf.set(mb_index, f'message_broker>cluster[{i}]>port', port_list[i])
+    #     Conf.set(mb_index, 'message_broker>message_bus',  config)
+    #     Conf.save(mb_index)
 
-        # copy this conf file as message_bus.conf
-        try:
-            os.rename(message_bus_conf_sample, message_bus_conf)
-        except OSError as e:
-            raise SetupError(e.errno, "Failed to create %s %s", \
-                message_bus_conf, e)
+    #     # copy this conf file as message_bus.conf
+    #     try:
+    #         os.rename(message_bus_conf_sample, message_bus_conf)
+    #     except OSError as e:
+    #         raise SetupError(e.errno, "Failed to create %s %s", \
+    #             message_bus_conf, e)
 
     @staticmethod
     def _get_server_info(conf_url_index: str, machine_id: str) -> dict:
@@ -144,30 +144,37 @@ class Utils:
         Conf.save('cluster')
 
     @staticmethod
-    def _create_iem_config(server_info: dict, machine_id: str):
-        """ Create the config file required for Event Message """
-        iem_index = 'iem'
+    def _create_utils_config(server_info: dict, machine_id: str, message_server_list: list, port_list: list, config: dict):
+        utils_index = 'utils_ind'
         local_path = CortxConf.get_storage_path('local')
-        iem_conf = os.path.join(local_path, 'utils/conf/iem.conf')
-        iem_conf_sample = iem_conf + '.sample'
-        with open(iem_conf_sample, 'w+') as file:
+        utils_conf = os.path.join(local_path, 'utils/conf/utils.conf')
+        utils_conf_sample = utils_conf + '.sample'
+        with open(utils_conf_sample, 'w+') as file:
             json.dump({}, file, indent=2)
+        # IEM
         for _id in ['site_id', 'rack_id']:
             if _id not in server_info.keys():
                 server_info[_id] = 1
-        Conf.load(iem_index, f'json://{iem_conf_sample}', skip_reload=True)
-        Conf.set(iem_index, f'node>{machine_id}>cluster_id', \
-            server_info['cluster_id'])
-        Conf.set(iem_index, f'node>{machine_id}>site_id', server_info['site_id'])
-        Conf.set(iem_index, f'node>{machine_id}>rack_id', server_info['rack_id'])
-        Conf.set(iem_index, f'node>{machine_id}>node_id', machine_id)
-        Conf.save(iem_index)
+        Conf.load(utils_index, f'json://{utils_conf_sample}', skip_reload=True)
+        Conf.set(utils_index, f'node>{machine_id}>cluster_id', server_info['cluster_id'])
+        Conf.set(utils_index, f'node>{machine_id}>site_id', server_info['site_id'])
+        Conf.set(utils_index, f'node>{machine_id}>rack_id', server_info['rack_id'])
+        Conf.set(utils_index, f'node>{machine_id}>node_id', machine_id)
+        # Message bus conf
+        Conf.set(utils_index, 'message_broker>type', 'kafka')
+        for i in range(len(message_server_list)):
+            Conf.set(utils_index, f'message_broker>cluster[{i}]>server', \
+                     message_server_list[i])
+            Conf.set(utils_index, f'message_broker>cluster[{i}]>port', port_list[i])
+        Conf.set(utils_index, 'message_broker>message_bus',  config)
+        Conf.save(utils_index)
+
 
         # copy this sample conf file as iem.conf
         try:
-            os.rename(iem_conf_sample, iem_conf)
+            os.rename(utils_conf_sample, utils_conf)
         except OSError as e:
-            raise SetupError(e.errno, "Failed to create %s. %s", iem_conf, e)
+            raise SetupError(e.errno, "Failed to create %s. %s", utils_conf, e)
 
     @staticmethod
     def _configure_rsyslog():
@@ -260,7 +267,6 @@ class Utils:
             Log.error(f"Could not find server information in {config_template}")
             raise SetupError(errno.EINVAL, \
                 "Could not find server information in %s", config_template)
-        Utils._create_msg_bus_config(server_list, port_list, config)
 
         # Create iem config
         machine_id = Conf.machine_id
@@ -269,7 +275,7 @@ class Utils:
             Log.error(f"Could not find server information in {config_template}")
             raise SetupError(errno.EINVAL, "Could not find server " +\
                 "information in %s", config_template)
-        Utils._create_iem_config(server_info, machine_id)
+        Utils._create_utils_config(server_info, machine_id, server_list, port_list, config)
 
         # set cluster nodename:hostname mapping to cluster.conf
         Utils._copy_cluster_map(config_template_index)

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -119,6 +119,9 @@ class Utils:
 
     @staticmethod
     def _create_utils_config(server_info: dict, machine_id: str, message_server_list: list, port_list: list, config: dict):
+        """
+        Create the utils config file required for message_bus and iem
+        """
         utils_index = 'utils_ind'
         local_path = CortxConf.get_storage_path('local')
         utils_conf = os.path.join(local_path, 'utils/conf/utils.conf')

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -91,32 +91,6 @@ class Utils:
 
         return val
 
-    # @staticmethod
-    # def _create_msg_bus_config(message_server_list: list, port_list: list, \
-    #     config: dict):
-    #     """ Create the config file required for message bus """
-    #     mb_index = 'mb_index'
-    #     local_path = CortxConf.get_storage_path('local')
-    #     message_bus_conf = os.path.join(local_path, 'utils/conf/message_bus.conf')
-    #     message_bus_conf_sample = message_bus_conf + '.sample'
-    #     with open(message_bus_conf_sample, 'w+') as file:
-    #         json.dump({}, file, indent=2)
-    #     Conf.load(mb_index, f'json://{message_bus_conf_sample}')
-    #     Conf.set(mb_index, 'message_broker>type', 'kafka')
-    #     for i in range(len(message_server_list)):
-    #         Conf.set(mb_index, f'message_broker>cluster[{i}]>server', \
-    #                  message_server_list[i])
-    #         Conf.set(mb_index, f'message_broker>cluster[{i}]>port', port_list[i])
-    #     Conf.set(mb_index, 'message_broker>message_bus',  config)
-    #     Conf.save(mb_index)
-
-    #     # copy this conf file as message_bus.conf
-    #     try:
-    #         os.rename(message_bus_conf_sample, message_bus_conf)
-    #     except OSError as e:
-    #         raise SetupError(e.errno, "Failed to create %s %s", \
-    #             message_bus_conf, e)
-
     @staticmethod
     def _get_server_info(conf_url_index: str, machine_id: str) -> dict:
         """Reads the ConfStore and derives keys related to Event Message.

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -66,7 +66,7 @@ class EventMessage(metaclass=Singleton):
         """
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
-        iem_conf = os.path.join(local_storage, 'utils/conf/iem.conf')
+        iem_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
         cls._conf_file = f'json://{iem_conf}'
 
         cls._component = component

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -64,6 +64,7 @@ class EventMessage(metaclass=Singleton):
                         For e.g. H-Hardware, S-Software, F-Firmware, O-OS
         cluster_conf    ConfStore URL of cluster.conf file
         """
+        utils_index = 'utils_ind'
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
         utils_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
@@ -81,9 +82,9 @@ class EventMessage(metaclass=Singleton):
                 backup_count=5, file_size_in_mb=5)
 
         try:
-            Conf.load('iem_cluster', cls._conf_file, skip_reload=True)
+            Conf.load(utils_index, cls._conf_file, skip_reload=True)
             machine_id = Conf.machine_id
-            ids = Conf.get('iem_cluster', f'node>{machine_id}')
+            ids = Conf.get(utils_index, f'node>{machine_id}')
             cls._site_id = ids['site_id']
             cls._rack_id = ids['rack_id']
             cls._node_id = machine_id

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -66,8 +66,8 @@ class EventMessage(metaclass=Singleton):
         """
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
-        iem_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
-        cls._conf_file = f'json://{iem_conf}'
+        utils_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
+        cls._conf_file = f'json://{utils_conf}'
 
         cls._component = component
         cls._source = source

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -35,8 +35,8 @@ class MessageBus(metaclass=Singleton):
         """ Initialize a MessageBus and load its configurations """
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
-        message_bus_conf = os.path.join(local_storage ,'utils/conf/utils.conf')
-        self.conf_file = f'json://{message_bus_conf}'
+        utils_conf = os.path.join(local_storage ,'utils/conf/utils.conf')
+        self.conf_file = f'json://{utils_conf}'
         # Get the log path
         log_dir = CortxConf.get('log_dir', '/var/log')
         utils_log_path = CortxConf.get_log_path('message_bus', base_dir=log_dir)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -35,7 +35,7 @@ class MessageBus(metaclass=Singleton):
         """ Initialize a MessageBus and load its configurations """
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
-        message_bus_conf = os.path.join(local_storage ,'utils/conf/message_bus.conf')
+        message_bus_conf = os.path.join(local_storage ,'utils/conf/utils.conf')
         self.conf_file = f'json://{message_bus_conf}'
         # Get the log path
         log_dir = CortxConf.get('log_dir', '/var/log')

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -33,6 +33,7 @@ class MessageBus(metaclass=Singleton):
 
     def __init__(self, cluster_conf='yaml:///etc/cortx/cluster.conf'):
         """ Initialize a MessageBus and load its configurations """
+        utils_index = 'utils_ind'
         CortxConf.init(cluster_conf=cluster_conf)
         local_storage = CortxConf.get_storage_path('local')
         utils_conf = os.path.join(local_storage ,'utils/conf/utils.conf')
@@ -50,8 +51,8 @@ class MessageBus(metaclass=Singleton):
                 backup_count=5, file_size_in_mb=5)
 
         try:
-            Conf.load('message_bus', self.conf_file, skip_reload=True)
-            self._broker_conf = Conf.get('message_bus', 'message_broker')
+            Conf.load(utils_index, self.conf_file, skip_reload=True)
+            self._broker_conf = Conf.get(utils_index, 'message_broker')
             broker_type = self._broker_conf['type']
             Log.info(f"MessageBus initialized as {broker_type}")
         except ConfError as e:


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- We need to move away from messagebus.conf and iem.conf and merge them both into a single file, utils.conf.

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
