### PR TITLE
EOS-26043: Implement Expiration time filter for messages for a particular topic

### DIFF
--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -563,3 +563,35 @@ class KafkaMessageBroker(MessageBroker):
             raise MessageBusError(errors.ERR_SERVICE_NOT_INITIALIZED,\
                 "Consumer %s is not initialized.", consumer_id)
         consumer.commit(async=False)
+
+    def set_message_type_expire(self, admin_id: str, message_type: str,
+        expire_time: int):
+        """
+        Sets expiration time for individual messages types
+
+        Parameters:
+        message_type    This is essentially equivalent to the
+                        queue/topic name. For e.g. "Alert"
+        """
+        admin = self._clients['admin'][admin_id]
+        Log.debug(f"Set expire time for message " \
+            f"type {message_type} with admin id {admin_id}")
+
+        for tuned_retry in range(self._max_config_retry_count):
+            self._resource.set_config('retention.ms', expire_time)
+            tuned_params = admin.alter_configs([self._resource])
+            if list(tuned_params.values())[0].result() is not None:
+                if tuned_retry > 1:
+                    Log.error(f"MessageBusError: {errors.ERR_OP_FAILED} " \
+                        f"alter_configs() for resource {self._resource} " \
+                        f"failed using admin {admin} for message type " \
+                        f"{message_type}")
+                    raise MessageBusError(errors.ERR_OP_FAILED, \
+                        "alter_configs() for resource %s failed using admin" +\
+                        "%s for message type %s", self._resource, admin,\
+                        message_type)
+                continue
+            else:
+                break
+        Log.debug("Successfully updated message type expire time.")
+        return 0

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -572,6 +572,7 @@ class KafkaMessageBroker(MessageBroker):
         Parameters:
         message_type    This is essentially equivalent to the
                         queue/topic name. For e.g. "Alert"
+        expire_time     This should be the expire time in milliseconds
         """
         admin = self._clients['admin'][admin_id]
         Log.debug(f"Set expire time for message " \
@@ -583,10 +584,12 @@ class KafkaMessageBroker(MessageBroker):
             if list(tuned_params.values())[0].result() is not None:
                 if tuned_retry > 1:
                     Log.error(f"MessageBusError: {errors.ERR_OP_FAILED} " \
+                        f"Updating message type expire time by "\
                         f"alter_configs() for resource {self._resource} " \
                         f"failed using admin {admin} for message type " \
                         f"{message_type}")
                     raise MessageBusError(errors.ERR_OP_FAILED, \
+                        "Updating message type expire time by "+\
                         "alter_configs() for resource %s failed using admin" +\
                         "%s for message type %s", self._resource, admin,\
                         message_type)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -118,3 +118,9 @@ class MessageBus(metaclass=Singleton):
     def ack(self, client_id: str):
         """ Provides acknowledgement on offset """
         self._broker.ack(client_id)
+
+    def set_message_type_expire(self, client_id: str, message_type: str, \
+        expire_time: int):
+        """ Set expiration time for given message type """
+        self._broker.set_message_type_expire(client_id,message_type, \
+            expire_time)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -121,6 +121,8 @@ class MessageBus(metaclass=Singleton):
 
     def set_message_type_expire(self, client_id: str, message_type: str, \
         expire_time: int):
-        """ Set expiration time for given message type """
+        """
+        Set expiration time for given message type 
+        """
         self._broker.set_message_type_expire(client_id,message_type, \
             expire_time)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -124,5 +124,5 @@ class MessageBus(metaclass=Singleton):
         """
         Set expiration time for given message type 
         """
-        self._broker.set_message_type_expire(client_id,message_type, \
+        self._broker.set_message_type_expire(client_id, message_type, \
             expire_time)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -121,8 +121,6 @@ class MessageBus(metaclass=Singleton):
 
     def set_message_type_expire(self, client_id: str, message_type: str, \
         expire_time: int):
-        """
-        Set expiration time for given message type 
-        """
-        self._broker.set_message_type_expire(client_id, message_type, \
+        """Set expiration time for given message type."""
+        return self._broker.set_message_type_expire(client_id, message_type, \
             expire_time)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -121,15 +121,15 @@ class MessageBusClient:
         client_id = self._get_conf('client_id')
         return self._message_bus.delete(client_id, message_type)
 
-    def set_message_type_expire(self, message_type, expire_time: int):
+    def set_message_type_expire(self, message_type: str, expire_time: int):
         """
         Set expiration time for given message type
         """
         message_type_list = self.list_message_types()
         if message_type not in message_type_list:
-            raise MessageBusError(errno.ENOENT, "Unknow topic: Could not"+\
-            " found the topic %s in topic list %s", message_type, \
-            message_type_list)
+            raise MessageBusError(errno.ENOENT, "Unknown topic: Could not"+\
+                " find the topic %s in topic list %s", message_type, \
+                message_type_list)
         client_id = self._get_conf('client_id')
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, expire_time)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -125,11 +125,6 @@ class MessageBusClient:
         """
         Set expiration time for given message type
         """
-        message_type_list = self.list_message_types()
-        if message_type not in message_type_list:
-            raise MessageBusError(errno.ENOENT, "Unknown topic: Could not"+\
-                " find the topic %s in topic list %s", message_type, \
-                message_type_list)
         client_id = self._get_conf('client_id')
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, expire_time)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -122,9 +122,7 @@ class MessageBusClient:
         return self._message_bus.delete(client_id, message_type)
 
     def set_message_type_expire(self, message_type: str, expire_time: int):
-        """
-        Set expiration time for given message type
-        """
+        """Set expiration time for given message type."""
         client_id = self._get_conf('client_id')
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, expire_time)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -122,7 +122,9 @@ class MessageBusClient:
         return self._message_bus.delete(client_id, message_type)
 
     def set_message_type_expire(self, message_type, expire_time: int):
-        """ Set expiration time for given message type """
+        """
+        Set expiration time for given message type
+        """
         message_type_list = self.list_message_types()
         if message_type not in message_type_list:
             raise MessageBusError(errno.ENOENT, "Unknow topic: Could not"+\

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -121,6 +121,17 @@ class MessageBusClient:
         client_id = self._get_conf('client_id')
         return self._message_bus.delete(client_id, message_type)
 
+    def set_message_type_expire(self, message_type, expire_time: int):
+        """ Set expiration time for given message type """
+        message_type_list = self.list_message_types()
+        if message_type not in message_type_list:
+            raise MessageBusError(errno.ENOENT, "Unknow topic: Could not"+\
+            " found the topic %s in topic list %s", message_type, \
+            message_type_list)
+        client_id = self._get_conf('client_id')
+        return self._message_bus.set_message_type_expire(client_id,\
+            message_type, expire_time)
+
     def receive(self, timeout: float = None) -> list:
         """
         Receives messages from the Message Bus

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -183,8 +183,8 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertEqual(message, b'A simple test message')
 
-    def test_015_message_type_read_before_expiry(self):
-        """Test set message type expiry."""
+    def test_015_message_type_read_after_expiry(self):
+        """Test receive expired messages."""
         # Do Purge
         for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
             rc = TestMessageBus._producer.delete()

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -172,7 +172,7 @@ class TestMessageBus(unittest.TestCase):
         self.assertIsNone(message)
 
     def test_014_set_message_type_expiry(self):
-        """ Test set message type expiry """
+        """Test set message type expiry"""
         TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, 1)
         TestMessageBus._producer.send(["A simple test message"])

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -172,23 +172,53 @@ class TestMessageBus(unittest.TestCase):
         self.assertIsNone(message)
 
     def test_014_set_message_type_expiry(self):
-        """Test set message type expiry"""
+        """
+        Test set message type expiry and read before expiry.
+        """
+        # Set expire time to 2 seconds
         TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, 1)
+            TestMessageBus._message_type, 2000)
         TestMessageBus._producer.send(["A simple test message"])
+        # get before expire
         message = TestMessageBus._consumer.receive()
+        self.assertEqual(message, b'A simple test message')
+
+    def test_015_message_type_read_before_expiry(self):
+        """Test set message type expiry."""
+        # Do Purge
+        for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
+            rc = TestMessageBus._producer.delete()
+            if retry_count > TestMessageBus._purge_retry:
+                self.assertIsInstance(rc, MessageBusError)
+            if rc == 0:
+                break
+            time.sleep(2*retry_count)
+        # Set expire time to 3 seconds
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, 3000)
+        for count in range(3):
+            TestMessageBus._producer.send(\
+            [f"A simple test message {count}"])
+        # Wait for message to expire
+        time.sleep(10)
+        _consumer_new = MessageConsumer(consumer_id='receive_new', \
+            consumer_group='test_new', \
+            message_types=[TestMessageBus._message_type], \
+            auto_ack=False, offset='earliest', \
+            cluster_conf = self.cluster_conf_path)
+        message = _consumer_new.receive()
         # Revert back to original timeout
         TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, 604800000)
         self.assertIsNone(message)
 
     @staticmethod
-    def test_015_concurrency():
+    def test_016_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_016_receive_concurrently(self):
+    def test_017_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -229,20 +259,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_017_reduce_concurrency(self):
+    def test_018_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_018_singleton(self):
+    def test_019_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_019_multiple_admins():
+    def test_020_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -172,9 +172,7 @@ class TestMessageBus(unittest.TestCase):
         self.assertIsNone(message)
 
     def test_014_set_message_type_expiry(self):
-        """
-        Test set message type expiry and read before expiry.
-        """
+        """Test set message type expiry and read before expiry."""
         # Set expire time to 2 seconds
         TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, 2000)

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -171,13 +171,24 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertIsNone(message)
 
+    def test_014_set_message_type_expiry(self):
+        """ Test set message type expiry """
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, 1)
+        TestMessageBus._producer.send(["A simple test message"])
+        message = TestMessageBus._consumer.receive()
+        # Revert back to original timeout
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, 604800000)
+        self.assertIsNone(message)
+
     @staticmethod
-    def test_014_concurrency():
+    def test_015_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_015_receive_concurrently(self):
+    def test_016_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -218,20 +229,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_016_reduce_concurrency(self):
+    def test_017_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_017_singleton(self):
+    def test_018_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_018_multiple_admins():
+    def test_019_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)


### PR DESCRIPTION
# Problem Statement
- A message type should have an expiration time, such that if a message was not read within the expiration time, it should get removed from message bus.
- mb_admin.set_message_type_expire('message_type', time_to_expire_in_milli_sec)

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
