### PR TITLE
EOS-26737: BUG - /opt/seagate/cortx/motr/bin/motr_setup post_install fails after glusterfs removal

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -259,7 +259,7 @@ class Utils:
         Utils._configure_rsyslog()
 
         # get shared storage from cluster.conf and set it to cortx.conf
-        shared_storage = CortxConf.get_storage_path('shared')
+        shared_storage = CortxConf.get_storage_path('shared', True)
         if shared_storage:
             Utils._set_to_conf_file('support>shared_path', shared_storage)
 

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -259,7 +259,7 @@ class Utils:
         Utils._configure_rsyslog()
 
         # get shared storage from cluster.conf and set it to cortx.conf
-        shared_storage = CortxConf.get_storage_path('shared', True)
+        shared_storage = CortxConf.get_storage_path('shared', none_allowed=True)
         if shared_storage:
             Utils._set_to_conf_file('support>shared_path', shared_storage)
 

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -37,11 +37,12 @@ class CortxConf:
             fail_reload=False)
 
     @staticmethod
-    def get_storage_path(key):
+    def get_storage_path(key, none_allowed: bool = False):
         """Get the config file path."""
         path = Conf.get(CortxConf._cluster_index, f'cortx>common>storage>{key}')
-        if not path:
-            raise ConfError(errno.EINVAL, "Invalid key %s", key)
+        if not none_allowed:
+            if not path:
+                raise ConfError(errno.EINVAL, "Invalid key %s", key)
         return path
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- BUG
- /opt/seagate/cortx/motr/bin/motr_setup post_install fails after glusterfs removal

# Design
-  https://jts.seagate.com/browse/EOS-26737
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]NA
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
