### PR TITLE
EOS-26723: Support upgrade phase in utils mini-provisioner

### DIFF
--- a/py-utils/src/setup/setup.yaml
+++ b/py-utils/src/setup/setup.yaml
@@ -43,6 +43,8 @@ utils:
         args: --config $URL [--pre-factory]
 
     upgrade:
+        cmd: /opt/seagate/cortx/utils/bin/utils_setup upgrade
+        args: --config $URL
 
         post:
             args: --config $URL

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -385,6 +385,14 @@ class Utils:
         return 0
 
     @staticmethod
+    def upgrade(config_path: str):
+        """Perform upgrade steps."""
+        # ToDo - in future, for utils/message server config changes may be
+        # required during upgrade phase.
+        # Currently no config changes required.
+        return 0
+
+    @staticmethod
     def pre_upgrade(level: str):
         """ pre upgrade hook for node and cluster level """
         if level == 'node':

--- a/py-utils/src/setup/utils_setup.py
+++ b/py-utils/src/setup/utils_setup.py
@@ -194,6 +194,20 @@ class CleanupCmd(Cmd):
         return rc
 
 
+class UpgradeCmd(Cmd):
+    """Upgrade Setup Cmd."""
+    name = 'upgrade'
+
+    def __init__(self, args: dict):
+        super().__init__(args)
+        self.config_path = args.config
+
+    def process(self):
+        Utils.validate('upgrade')
+        rc = Utils.upgrade(self.config_path)
+        return rc
+
+
 class PreUpgradeCmd(Cmd):
     """ Manages post upgrade config changes """
     name = 'pre_upgrade'
@@ -202,7 +216,7 @@ class PreUpgradeCmd(Cmd):
         super().__init__(args)
 
     def process(self):
-        Utils.validate('post_upgrade')
+        Utils.validate('pre_upgrade')
         rc = Utils.pre_upgrade(self.args[0])
         return rc
 


### PR DESCRIPTION
# Problem Statement
- Utils mini-provisioner should support "upgrade" phase

# Design
-  As utils has no direct dependency on configuration files, this phase will be simply pass-through, no action will be required.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [X] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [X] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [X] Confirm Testing was performed with installed RPM [Y/N]: Y

# Review Checklist 
  Before posting the PR please ensure
- [X] PR is self reviewed
- [X] Is there a change in filename/package/module or signature [Y/N]: N
- [X] If yes for above point, Is a notification sent to all other cortx components [Y/N] : NA
- [X] Jira is updated
- [X] Check if the description is clear and explained. 
- [X] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
