### PR TITLE
EOS-26878: add cortx.const in utils for defining constants of service name and components

### DIFF
--- a/py-utils/setup.py
+++ b/py-utils/setup.py
@@ -113,7 +113,8 @@ setup(name='cortx-py-utils',
                 'cortx.utils.discovery', 'cortx.utils.common',
                 'cortx.utils.shared_storage', 'cortx.utils.support_framework',
                 'cortx.utils.manifest', 'cortx.utils.setup.openldap',
-                'cortx.utils.setup.consul', 'cortx.utils.setup.elasticsearch'
+                'cortx.utils.setup.consul', 'cortx.utils.setup.elasticsearch',
+                'cortx.utils.cortx'
                 ],
       package_data={
         'cortx': ['py.typed'],

--- a/py-utils/src/utils/cortx/__init__.py
+++ b/py-utils/src/utils/cortx/__init__.py
@@ -1,0 +1,23 @@
+#!/bin/python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+"""Package for common cortx definations."""
+
+from cortx.utils.cortx.const import Const
+
+# Adds all above defined packages in import *
+__all__ = ('Const')

--- a/py-utils/src/utils/cortx/const.py
+++ b/py-utils/src/utils/cortx/const.py
@@ -1,0 +1,48 @@
+#!/bin/python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from enum import Enum
+
+class Const(Enum):
+    """Enum class to define constants for components and service names."""
+
+    # Active Components
+    COMPONENT_UTILS        = 'utils'
+    COMPONENT_MOTR         = 'motr'
+    COMPONENT_HARE         = 'hare'
+    COMPONENT_S3           = 's3'
+    COMPONENT_HA           = 'ha'
+    COMPONENT_CSM          = 'csm'
+
+    # Active Services
+    SERVICE_MOTR_IO         = 'io'
+    SERVICE_MOTR_FSM        = 'fsm'
+    SERVICE_HARE_HAX        = 'hax'
+    SERVICE_S3_SERVER       = 's3server'
+    SERVICE_S3_HAPROXY      = 'haproxy'
+    SERVICE_S3_AUTHSERVER   = 'authserver'
+    SERVICE_S3_BGWORKER     = 'bgworker'
+    SERVICE_S3_BGSCHEDULER  = 'bgscheduler'
+    SERVICE_CSM_AGENT       = 'agent'
+    SERVICE_UTILS_MESSAGE   = "message"
+
+    # Deprecated services
+    SERVICE_S3_IO          = 'io'
+    SERVICE_S3_AUTH        = 'auth'
+    SERVICE_S3_BGCONSUMER  = 'bg_consumer'
+    SERVICE_S3_BGPRODUCER  = 'bg_producer'
+    SERVICE_S3_OPENLDAP    = 'openldap'


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- Added cortx constants for service names and component names

# Design
-  Added a new subpackage.module -> cortx.utils.cortx.const.py
- To import const class -> `from cortx.utils.cortx import Const` OR `from cortx.utils.cortx.const import Const`

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: N/A
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: N/A
- [x] Confirm Testing was performed with installed RPM [Y/N]:  N/A

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
