### PR TITLE
MessageBus library code should not refer any conf file

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -212,10 +212,20 @@ class Utils:
     def init(config_path: str):
         """ Perform initialization """
         # Create message_type for Event Message
-        from cortx.utils.message_bus import MessageBusAdmin
+        from cortx.utils.message_bus import MessageBus, MessageBusAdmin
         from cortx.utils.message_bus.error import MessageBusError
         try:
-            admin = MessageBusAdmin(admin_id='register', cluster_conf=config_path)
+            # Read the config values
+            CortxConf.init(cluster_conf=config_path)
+            local_storage = CortxConf.get_storage_path('local')
+            utils_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
+            conf_file = f'json://{utils_conf}'
+            Conf.load('utils_ind', conf_file, skip_reload=True)
+            config_params = {'message_broker': Conf.get('utils_ind', \
+                'message_broker')}
+            MessageBus.init(json.loads(json.dumps(config_params)))
+
+            admin = MessageBusAdmin(admin_id='register')
             admin.register_message_type(message_types=['IEM'], partitions=1)
         except MessageBusError as e:
             if 'TOPIC_ALREADY_EXISTS' not in e.desc:

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -118,10 +118,9 @@ class Utils:
         Conf.save('cluster')
 
     @staticmethod
-    def _create_utils_config(server_info: dict, machine_id: str, message_server_list: list, port_list: list, config: dict):
-        """
-        Create the utils config file required for message_bus and iem
-        """
+    def _create_utils_config(server_info: dict, machine_id: str, \
+        message_server_list: list, config: dict):
+        """Create the utils config file required for message_bus and iem."""
         utils_index = 'utils_ind'
         local_path = CortxConf.get_storage_path('local')
         utils_conf = os.path.join(local_path, 'utils/conf/utils.conf')
@@ -139,10 +138,7 @@ class Utils:
         Conf.set(utils_index, f'node>{machine_id}>node_id', machine_id)
         # Message bus conf
         Conf.set(utils_index, 'message_broker>type', 'kafka')
-        for i in range(len(message_server_list)):
-            Conf.set(utils_index, f'message_broker>cluster[{i}]>server', \
-                     message_server_list[i])
-            Conf.set(utils_index, f'message_broker>cluster[{i}]>port', port_list[i])
+        Conf.set(utils_index, 'message_broker>cluster', message_server_list)
         Conf.set(utils_index, 'message_broker>message_bus',  config)
         Conf.save(utils_index)
 
@@ -248,8 +244,10 @@ class Utils:
         # Add message_bus config to utils conf
         try:
             from cortx.utils.message_bus import MessageBrokerFactory
-            server_list, port_list, config = \
-                MessageBrokerFactory.get_server_list(config_template_index)
+            message_server_endpoints = Conf.get(config_template_index, \
+                'cortx>external>kafka>endpoints')
+            message_server_list = \
+                MessageBrokerFactory.get_server_list(message_server_endpoints)
         except SetupError:
             Log.error(f"Could not find server information in {config_template}")
             raise SetupError(errno.EINVAL, \
@@ -262,7 +260,9 @@ class Utils:
             Log.error(f"Could not find server information in {config_template}")
             raise SetupError(errno.EINVAL, "Could not find server " +\
                 "information in %s", config_template)
-        Utils._create_utils_config(server_info, machine_id, server_list, port_list, config)
+        config = CortxConf.get('message_bus')
+        Utils._create_utils_config(server_info, machine_id, \
+            message_server_list, config)
 
         # set cluster nodename:hostname mapping to cluster.conf
         Utils._copy_cluster_map(config_template_index)

--- a/py-utils/src/utils/message_bus/message_broker.py
+++ b/py-utils/src/utils/message_bus/message_broker.py
@@ -54,51 +54,32 @@ class MessageBrokerFactory:
             "Invalid service name %s.", broker_type)
 
     @staticmethod
-    def get_server_list(cluster_conf_index: str) -> tuple:
-        """Fetches info of nodes in cluster from passed template file.
+    def get_server_list(message_server_endpoints: list) -> tuple:
+        """Fetches info of nodes in cluster from list of endpoints.
 
         Args:
-            cluster_conf_index (str): index for loaded input template file
-
-        Raises:
-            SetupError: if message bus type not kafka or missing required keys
+            message_server_endpoints: list of endpoints
 
         Returns:
-            tuple: ([server_list], [port_list])
+            list: ([message_server_list])
         """
-        key_list = ['cortx>utils>message_bus_backend', \
-            'cortx>external>kafka>endpoints']
-
-        ConfKeysV().validate('exists', cluster_conf_index, key_list)
-        msg_bus_type = Conf.get(cluster_conf_index, key_list[0])
-
-        if msg_bus_type != 'kafka':
-            Log.error(f"Message bus type {msg_bus_type} is not supported")
-            raise SetupError(errno.EINVAL, \
-                "Message bus type %s is not supported", msg_bus_type)
-
-        all_servers = Conf.get(cluster_conf_index, key_list[1])
         message_server_list = []
-        port_list = []
+        server_info = {}
 
-        for server in all_servers:
+        for server in message_server_endpoints:
             # Value of server can be <server_fqdn:port> or <server_fqdn>
             if ':' in server:
                 endpoints = server.split('//')[1]
                 server_fqdn, port = endpoints.split(':')
-                message_server_list.append(server_fqdn)
-                port_list.append(port)
+                server_info['server'] = server_fqdn
+                server_info['port'] = port
             else:
-                message_server_list.append(server)
-                port_list.append('9092')   # 90992 is default kafka server port
+                server_info['server'] = server
+                server_info['port'] = '9092'  # 9092 is default kafka server port
 
-        if not message_server_list:
-            Log.error(f"Missing config entry {key_list} in input file")
-            raise SetupError(errno.EINVAL, \
-                "Missing config entry %s in config", key_list)
-        # Read the default config
-        config = CortxConf.get('message_bus')
-        return message_server_list, port_list, config
+            message_server_list.append(server_info)
+
+        return message_server_list
 
 
 class MessageBroker:

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -53,13 +53,13 @@ class KafkaMessageBroker(MessageBroker):
 
         # Polling timeout
         self._recv_message_timeout = \
-            broker_conf['message_bus']['recv_message_timeout']
+            broker_conf['message_bus']['receive_timeout']
         # Socket timeout
         self._controller_socket_timeout = \
-            broker_conf['message_bus']['controller_socket_timeout']
+            broker_conf['message_bus']['socket_timeout']
         # Message timeout
         self._send_message_timeout = \
-            broker_conf['message_bus']['send_message_timeout']
+            broker_conf['message_bus']['send_timeout']
 
     def init_client(self, client_type: str, **client_conf: dict):
         """ Obtain Kafka based Producer/Consumer """

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -27,6 +27,10 @@ from cortx.utils.message_bus.message_broker import MessageBrokerFactory
 class MessageBus(metaclass=Singleton):
     """ Message Bus Framework over various types of Message Brokers """
     _load_config = False
+    _broker_type = 'kafka'
+    _receive_timeout = 2
+    _socket_timeout = 15000
+    _send_timeout = 5000
 
     def __init__(self):
         """ Initialize a MessageBus and load its configurations """
@@ -59,18 +63,32 @@ class MessageBus(metaclass=Singleton):
             self._broker_conf)
 
     @staticmethod
-    def init(config: dict):
-        import json
-        from cortx.utils.validator.v_confkeys import ConfKeysV
+    def init(message_server_endpoints: list, **message_server_params_kwargs: dict):
 
-        Conf.load('utils_ind', f'dict:{json.dumps(config)}', \
-            skip_reload=True)
-        config_keys = ['message_broker>type', 'message_broker>cluster[0]>server', \
-            'message_broker>cluster[0]>port', \
-            'message_broker>message_bus>recv_message_timeout', \
-            'message_broker>message_bus>controller_socket_timeout', \
-            'message_broker>message_bus>send_message_timeout']
-        ConfKeysV().validate('exists', 'utils_ind', config_keys)
+        utils_index = 'utils_ind'
+        Conf.load(utils_index, 'dict:{}', skip_reload=True)
+        message_server_keys = message_server_params_kwargs.keys()
+
+        endpoints = MessageBrokerFactory.get_server_list(message_server_endpoints)
+        broker_type = message_server_params_kwargs['broker_type'] if \
+            'broker_type' in message_server_keys else MessageBus._broker_type
+        receive_timeout = message_server_params_kwargs['receive_timeout'] if \
+            'receive_timeout' in message_server_keys else MessageBus._receive_timeout
+        socket_timeout = message_server_params_kwargs['socket_timeout'] if \
+            'socket_timeout' in message_server_keys else MessageBus._socket_timeout
+        send_timeout = message_server_params_kwargs['send_timeout'] if \
+            'send_timeout' in message_server_keys else MessageBus._send_timeout
+
+        Conf.set(utils_index, 'message_broker>type', broker_type)
+        Conf.set(utils_index, 'message_broker>cluster', endpoints)
+        Conf.set(utils_index, 'message_broker>message_bus>receive_timeout', \
+            receive_timeout)
+        Conf.set(utils_index, 'message_broker>message_bus>socket_timeout', \
+            socket_timeout)
+        Conf.set(utils_index, 'message_broker>message_bus>send_timeout', \
+            send_timeout)
+        Conf.save(utils_index)
+
         MessageBus._load_config = True
 
     def init_client(self, client_type: str, **client_conf: dict):

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -15,14 +15,10 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-import os
-import stat
 import errno
-
 from cortx.utils.log import Log
 from cortx.template import Singleton
 from cortx.utils.conf_store import Conf
-from cortx.utils.common import CortxConf
 from cortx.utils.conf_store.error import ConfError
 from cortx.utils.message_bus.error import MessageBusError
 from cortx.utils.message_bus.message_broker import MessageBrokerFactory
@@ -30,44 +26,52 @@ from cortx.utils.message_bus.message_broker import MessageBrokerFactory
 
 class MessageBus(metaclass=Singleton):
     """ Message Bus Framework over various types of Message Brokers """
+    _load_config = False
 
-    def __init__(self, cluster_conf='yaml:///etc/cortx/cluster.conf'):
+    def __init__(self):
         """ Initialize a MessageBus and load its configurations """
-        utils_index = 'utils_ind'
-        CortxConf.init(cluster_conf=cluster_conf)
-        local_storage = CortxConf.get_storage_path('local')
-        utils_conf = os.path.join(local_storage ,'utils/conf/utils.conf')
-        self.conf_file = f'json://{utils_conf}'
-        # Get the log path
-        log_dir = CortxConf.get('log_dir', '/var/log')
-        utils_log_path = CortxConf.get_log_path('message_bus', base_dir=log_dir)
 
         # if Log.logger is already initialized by some parent process
         # the same file will be used to log all the messagebus related
         # logs, else standard message_bus.log will be used.
+        if not self._load_config:
+            raise MessageBusError(errno.EINVAL, "Config is not loaded")
+
         if not Log.logger:
-            log_level = CortxConf.get('utils>log_level', 'INFO')
-            Log.init('message_bus', utils_log_path, level=log_level, \
-                backup_count=5, file_size_in_mb=5)
+            raise MessageBusError(errno.ENOSYS, "Logger is not initialized")
 
         try:
-            Conf.load(utils_index, self.conf_file, skip_reload=True)
-            self._broker_conf = Conf.get(utils_index, 'message_broker')
+            self._broker_conf = Conf.get('utils_ind', 'message_broker')
             broker_type = self._broker_conf['type']
             Log.info(f"MessageBus initialized as {broker_type}")
         except ConfError as e:
             Log.error(f"MessageBusError: {e.rc} Error while parsing" \
-                f" configuration file {self.conf_file}. {e}.")
+                f" configuration. {e}.")
             raise MessageBusError(e.rc, "Error while parsing " + \
-                "configuration file %s. %s.", self.conf_file, e)
+                "configuration %s. ", e)
         except Exception as e:
-            Log.error(f"MessageBusError: {e.rc} Error while parsing" \
-                f" configuration file {self.conf_file}. {e}.")
+            Log.error(f"MessageBusError: {errno.ENOENT} Error while parsing" \
+                f" configuration. {e}.")
             raise MessageBusError(errno.ENOENT, "Error while parsing " + \
-                "configuration file %s. %s.", self.conf_file, e)
+                "configuration %s. ", e)
 
         self._broker = MessageBrokerFactory.get_instance(broker_type, \
             self._broker_conf)
+
+    @staticmethod
+    def init(config: dict):
+        import json
+        from cortx.utils.validator.v_confkeys import ConfKeysV
+
+        Conf.load('utils_ind', f'dict:{json.dumps(config)}', \
+            skip_reload=True)
+        config_keys = ['message_broker>type', 'message_broker>cluster[0]>server', \
+            'message_broker>cluster[0]>port', \
+            'message_broker>message_bus>recv_message_timeout', \
+            'message_broker>message_bus>controller_socket_timeout', \
+            'message_broker>message_bus>send_message_timeout']
+        ConfKeysV().validate('exists', 'utils_ind', config_keys)
+        MessageBus._load_config = True
 
     def init_client(self, client_type: str, **client_conf: dict):
         """ To create producer/consumer client based on the configurations """

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -25,8 +25,8 @@ from cortx.utils.message_bus.error import MessageBusError
 class MessageBusClient:
     """ common infrastructure for producer and consumer """
 
-    def __init__(self, client_type: str, cluster_conf: str, **client_conf: dict):
-        self._message_bus = MessageBus(cluster_conf) if 'message_bus' not in \
+    def __init__(self, client_type: str, **client_conf: dict):
+        self._message_bus = MessageBus() if 'message_bus' not in \
             client_conf.keys() or client_conf['message_bus'] is None else \
             client_conf['message_bus']
         self._message_bus.init_client(client_type, **client_conf)
@@ -146,24 +146,22 @@ class MessageBusClient:
 class MessageBusAdmin(MessageBusClient):
     """ A client that do admin jobs """
 
-    def __init__(self, admin_id: str, message_bus: MessageBus = None, \
-         cluster_conf: str = 'yaml:///etc/cortx/cluster.conf'):
+    def __init__(self, admin_id: str, message_bus: MessageBus = None):
         """ Initialize a Message Admin
 
         Parameters:
         message_bus    An instance of message bus class.
         admin_id       A String that represents Admin client ID.
         """
-        super().__init__(client_type='admin', cluster_conf=cluster_conf, \
-            client_id=admin_id, message_bus=message_bus)
+        super().__init__(client_type='admin',client_id=admin_id, \
+            message_bus=message_bus)
 
 
 class MessageProducer(MessageBusClient):
     """ A client that publishes messages """
 
     def __init__(self, producer_id: str, message_type: str,
-        message_bus: MessageBus = None, method: str = None,
-        cluster_conf: str = 'yaml:///etc/cortx/cluster.conf'):
+        message_bus: MessageBus = None, method: str = None):
         """ Initialize a Message Producer
 
         Parameters:
@@ -172,9 +170,8 @@ class MessageProducer(MessageBusClient):
         message_type    This is essentially equivalent to the
                         queue/topic name. For e.g. "Alert"
         """
-        super().__init__(client_type='producer', cluster_conf=cluster_conf, \
-            client_id=producer_id, message_type=message_type, method=method, \
-            message_bus=message_bus)
+        super().__init__(client_type='producer', client_id=producer_id, \
+            message_type=message_type, method=method, message_bus=message_bus)
 
     def get_unread_count(self, consumer_group: str):
         """
@@ -191,8 +188,7 @@ class MessageConsumer(MessageBusClient):
     """ A client that consumes messages """
 
     def __init__(self, consumer_id: str, consumer_group: str, auto_ack: str,
-        message_types: list, offset: str, message_bus: MessageBus = None,
-        cluster_conf: str = 'yaml:///etc/cortx/cluster.conf'):
+        message_types: list, offset: str, message_bus: MessageBus = None):
         """ Initialize a Message Consumer
 
         Parameters:
@@ -207,10 +203,9 @@ class MessageConsumer(MessageBusClient):
                         ("earliest" will cause messages to be read from the
                         beginning)
         """
-        super().__init__(client_type='consumer', cluster_conf=cluster_conf, \
-            client_id=consumer_id, consumer_group=consumer_group, \
-            message_types=message_types, auto_ack=auto_ack, offset=offset, \
-            message_bus=message_bus)
+        super().__init__(client_type='consumer', client_id=consumer_id, \
+            consumer_group=consumer_group, message_types=message_types, \
+            auto_ack=auto_ack, offset=offset, message_bus=message_bus)
 
     def get_unread_count(self, message_type: str):
         """

--- a/py-utils/src/utils/message_bus/message_bus_server.py
+++ b/py-utils/src/utils/message_bus/message_bus_server.py
@@ -21,9 +21,10 @@ from aiohttp import web
 from cortx.utils.utils_server import RestServer
 from cortx.utils.message_bus.error import MessageBusError
 from cortx.utils.utils_server.error import RestServerError
-from cortx.utils.message_bus import MessageConsumer, MessageProducer
+from cortx.utils.message_bus import MessageConsumer, MessageProducer, MessageBus
 from cortx.utils.log import Log
 from cortx.utils.common import CortxConf
+from cortx.utils.conf_store import Conf
 
 routes = web.RouteTableDef()
 
@@ -40,9 +41,12 @@ class MessageBusRequestHandler(RestServer):
             payload = await request.json()
             messages = payload['messages']
             cluster_conf = CortxConf.get_cluster_conf_path()
+            Conf.load('config', cluster_conf, skip_reload=True)
+            message_server_endpoints = Conf.get('config',\
+                    'cortx>external>kafka>endpoints')
+            MessageBus.init(message_server_endpoints=message_server_endpoints)
             producer = MessageProducer(producer_id='rest_producer', \
-                message_type=message_type, method='sync',\
-                cluster_conf=cluster_conf)
+                message_type=message_type, method='sync')
 
             producer.send(messages)
         except MessageBusError as e:
@@ -82,9 +86,13 @@ class MessageBusRequestHandler(RestServer):
             message_types = str(request.match_info['message_type']).split('&')
             consumer_group = request.rel_url.query['consumer_group']
             cluster_conf = CortxConf.get_cluster_conf_path()
+            Conf.load('config', cluster_conf, skip_reload=True)
+            message_server_endpoints = Conf.get('config',\
+                    'cortx>external>kafka>endpoints')
+            MessageBus.init(message_server_endpoints=message_server_endpoints)
             consumer = MessageConsumer(consumer_id='rest_consumer', \
                 consumer_group=consumer_group, message_types=message_types, \
-                auto_ack=True, offset='latest', cluster_conf=cluster_conf)
+                auto_ack=True, offset='latest')
 
             message = consumer.receive()
         except MessageBusError as e:

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -44,25 +44,12 @@ class TestMessageBus(unittest.TestCase):
     _cluster_conf_path = ''
 
     @classmethod
-    def setUpClass(cls, cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
+    def setUpClass(cls):
         """Register the test message_type."""
-        if TestMessageBus._cluster_conf_path:
-            cls.cluster_conf_path = TestMessageBus._cluster_conf_path
-        else:
-            cls.cluster_conf_path = cluster_conf_path
-
-        # Read the config values
-        CortxConf.init(cluster_conf=cls.cluster_conf_path)
-        local_storage = CortxConf.get_storage_path('local')
-        utils_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
-        conf_file = f'json://{utils_conf}'
-        Conf.load('utils_ind', conf_file, skip_reload=True)
-        config_params = {'message_broker': Conf.get('utils_ind', \
-            'message_broker')}
 
         Log.init('message_bus', '/var/log', level='INFO', \
             backup_count=5, file_size_in_mb=5)
-        MessageBus.init(json.loads(json.dumps(config_params)))
+        MessageBus.init(TestMessageBus._endpoints.split(','))
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestMessageBus._message_type], partitions=1)
@@ -308,5 +295,5 @@ class TestMessageBus(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestMessageBus._cluster_conf_path = sys.argv.pop()
+        TestMessageBus._endpoints = sys.argv.pop()
     unittest.main()

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -16,13 +16,9 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-import os
 import time
-import json
 import unittest
 from cortx.utils.log import Log
-from cortx.utils.conf_store import Conf
-from cortx.utils.common import CortxConf
 from cortx.utils.message_bus.error import MessageBusError
 from cortx.utils.message_bus import MessageBus, MessageBusAdmin, \
     MessageProducer, MessageConsumer


### PR DESCRIPTION
# Problem Statement
- MessageBus code is a library code. This code is currently referring to config file (utils.conf & cluster.conf) for its execution. This  is incorrect, and the code should not rely on any config files.

# Design
-  Added a new method "MessageBus.init()" which takes care of information read from conf files.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [X] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [X] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [X] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [X] PR is self reviewed
- [X] Is there a change in filename/package/module or signature [Y/N]: Y
- [X] If yes for above point, Is a notification sent to all other cortx components [Y/N] Y
- [] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [X] Changes done to WIKI / Confluence page
