### PR TITLE
EOS-26730: Customization of message type

### DIFF
--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -623,6 +623,8 @@ class KafkaMessageBroker(MessageBroker):
         data_limit_bytes This should be the max size of log files
                          for individual message_type.
         """
-        if 'expire_time_ms' in kwargs.keys() and 'data_limit_bytes' in kwargs.keys():
-            raise MessageBusError(errno.EINVAL, "Invalid message_type retention config keys.")
-        self._configure_message_type(admin_id, message_type, **kwargs)
+        if 'expire_time_ms' not in kwargs.keys()\
+            and 'data_limit_bytes' not in kwargs.keys():
+            raise MessageBusError(errno.EINVAL,\
+                "Invalid message_type retention config keys.")
+        return self._configure_message_type(admin_id, message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -583,14 +583,13 @@ class KafkaMessageBroker(MessageBroker):
                          for individual message_type.
         """
         admin = self._clients['admin'][admin_id]
-        Log.debug(f"Set configuration for message " \
+        Log.debug(f"New configuration for message " \
             f"type {message_type} with admin id {admin_id}")
         # check for message_type exist or not
         message_type_list = self.list_message_types(admin_id)
         if message_type not in message_type_list:
-            raise MessageBusError(errno.ENOENT, "Unknown Message type: Could"+\
-                " not find the Message type %s in created Message type list %s",
-                message_type, message_type_list)
+            raise MessageBusError(errno.ENOENT, "Unknown Message type:"+\
+                " not listed in %s", message_type_list)
         topic_resource = ConfigResource('topic', message_type)
         for tuned_retry in range(self._max_config_retry_count):
             for key, val in kwargs.items():
@@ -611,7 +610,8 @@ class KafkaMessageBroker(MessageBroker):
                 continue
             else:
                 break
-        Log.debug("Successfully updated message type configurations.")
+        Log.debug("Successfully updated message type with new"+\
+            " configuration configurations.")
         return 0
 
     def set_message_type_expire(self, admin_id: str, message_type: str,\

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -611,7 +611,7 @@ class KafkaMessageBroker(MessageBroker):
             else:
                 break
         Log.debug("Successfully updated message type with new"+\
-            " configuration configurations.")
+            " configuration.")
         return 0
 
     def set_message_type_expire(self, admin_id: str, message_type: str,\

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -43,7 +43,7 @@ class KafkaMessageBroker(MessageBroker):
     _max_config_retry_count = 3
     _max_purge_retry_count = 5
     _max_list_message_type_count = 15
-    _config_prop_map={
+    _config_prop_map = {
         'expire_time_ms': 'retention.ms',
         'data_limit_bytes': 'segment.bytes',
         'file_delete_ms': 'file.delete.delay.ms',
@@ -593,6 +593,10 @@ class KafkaMessageBroker(MessageBroker):
         topic_resource = ConfigResource('topic', message_type)
         for tuned_retry in range(self._max_config_retry_count):
             for key, val in kwargs.items():
+                if key not in self._config_prop_map:
+                    raise MessageBusError(errno.EINVAL,\
+                    "Invalid configuration %s for message_type %s.", key,\
+                    message_type)
                 topic_resource.set_config(self._config_prop_map[key], val)
             tuned_params = admin.alter_configs([topic_resource])
             if list(tuned_params.values())[0].result() is not None:

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -630,7 +630,7 @@ class KafkaMessageBroker(MessageBroker):
         """
         Log.debug(f"Set expiration for message " \
             f"type {message_type} with admin id {admin_id}")
-        
+
         for config_property in ['expire_time_ms', 'data_limit_bytes']:
             if config_property not in kwargs.keys():
                 raise MessageBusError(errno.EINVAL,\

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -595,8 +595,8 @@ class KafkaMessageBroker(MessageBroker):
             for key, val in kwargs.items():
                 if key not in self._config_prop_map:
                     raise MessageBusError(errno.EINVAL,\
-                    "Invalid configuration %s for message_type %s.", key,\
-                    message_type)
+                        "Invalid configuration %s for message_type %s.", key,\
+                        message_type)
                 topic_resource.set_config(self._config_prop_map[key], val)
             tuned_params = admin.alter_configs([topic_resource])
             if list(tuned_params.values())[0].result() is not None:

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -564,8 +564,7 @@ class KafkaMessageBroker(MessageBroker):
                 "Consumer %s is not initialized.", consumer_id)
         consumer.commit(async=False)
 
-
-    def configure_message_type(self, admin_id: str, message_type: str, **kwargs):
+    def _configure_message_type(self, admin_id: str, message_type: str, **kwargs):
         """
         Sets expiration time for individual messages types
 
@@ -613,3 +612,17 @@ class KafkaMessageBroker(MessageBroker):
                 break
         Log.debug("Successfully updated message type configurations.")
         return 0
+
+    def set_message_type_expire(self, admin_id: str, message_type: str,\
+        **kwargs):
+        """
+        Set message type expire with combinational unit of time and size.
+        Kwargs:
+        expire_time_ms  This should be the expire time of message_type
+                        in milliseconds.
+        data_limit_bytes This should be the max size of log files
+                         for individual message_type.
+        """
+        if 'expire_time_ms' in kwargs.keys() and 'data_limit_bytes' in kwargs.keys():
+            raise MessageBusError(errno.EINVAL, "Invalid message_type retention config keys.")
+        self._configure_message_type(admin_id, message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -119,14 +119,8 @@ class MessageBus(metaclass=Singleton):
         """ Provides acknowledgement on offset """
         self._broker.ack(client_id)
 
-    def set_message_type_expire(self, client_id: str, message_type: str, \
-        expire_time: int):
+    def configure_message_type(self, client_id: str, message_type: str,\
+        **kwargs):
         """Set expiration time for given message type."""
-        return self._broker.set_message_type_expire(client_id, message_type, \
-            expire_time)
-
-    def set_message_type_retention(self, client_id: str, message_type: str, \
-        retention_type: str, value: int):
-        """Set expiration time for given message type."""
-        return self._broker.set_message_type_retention(client_id, message_type, \
-            retention_type, value)
+        return self._broker.configure_message_type(client_id,\
+            message_type, kwargs)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -123,4 +123,4 @@ class MessageBus(metaclass=Singleton):
         **kwargs):
         """Set expiration time for given message type."""
         return self._broker.configure_message_type(client_id,\
-            message_type, kwargs)
+            message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -119,8 +119,8 @@ class MessageBus(metaclass=Singleton):
         """ Provides acknowledgement on offset """
         self._broker.ack(client_id)
 
-    def configure_message_type(self, client_id: str, message_type: str,\
+    def set_message_type_expire(self, client_id: str, message_type: str,\
         **kwargs):
         """Set expiration time for given message type."""
-        return self._broker.configure_message_type(client_id,\
+        return self._broker.set_message_type_expire(client_id,\
             message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -124,3 +124,9 @@ class MessageBus(metaclass=Singleton):
         """Set expiration time for given message type."""
         return self._broker.set_message_type_expire(client_id, message_type, \
             expire_time)
+
+    def set_message_type_retention(self, client_id: str, message_type: str, \
+        retention_type: str, value: int):
+        """Set expiration time for given message type."""
+        return self._broker.set_message_type_retention(client_id, message_type, \
+            retention_type, value)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -121,17 +121,11 @@ class MessageBusClient:
         client_id = self._get_conf('client_id')
         return self._message_bus.delete(client_id, message_type)
 
-    def set_message_type_expire(self, message_type: str, expire_time: int):
-        """Set expiration time for given message type."""
+    def configure_message_type(self, message_type: str, **kwargs):
+        """Set configuration for given message type."""
         client_id = self._get_conf('client_id')
-        return self._message_bus.set_message_type_expire(client_id,\
-            message_type, expire_time)
-
-    def set_message_type_retention(self, message_type: str, retention_type: str ,value: int):
-        """Set expiration time for given message type."""
-        client_id = self._get_conf('client_id')
-        return self._message_bus.set_message_type_expire(client_id,\
-            message_type, retention_type, value)
+        return self._message_bus.configure_message_type(client_id,\
+            message_type, kwargs)
 
     def receive(self, timeout: float = None) -> list:
         """

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -125,7 +125,7 @@ class MessageBusClient:
         """Set configuration for given message type."""
         client_id = self._get_conf('client_id')
         return self._message_bus.configure_message_type(client_id,\
-            message_type, kwargs)
+            message_type, **kwargs)
 
     def receive(self, timeout: float = None) -> list:
         """

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -127,6 +127,12 @@ class MessageBusClient:
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, expire_time)
 
+    def set_message_type_retention(self, message_type: str, retention_type: str ,value: int):
+        """Set expiration time for given message type."""
+        client_id = self._get_conf('client_id')
+        return self._message_bus.set_message_type_expire(client_id,\
+            message_type, retention_type, value)
+
     def receive(self, timeout: float = None) -> list:
         """
         Receives messages from the Message Bus

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -124,8 +124,11 @@ class MessageBusClient:
     def set_message_type_expire(self, message_type: str, **kwargs):
         """Set expiration time for given message type."""
         client_id = self._get_conf('client_id')
-        return self._message_bus.set_message_type_expire(client_id,\
+        status = self._message_bus.set_message_type_expire(client_id,\
             message_type, **kwargs)
+        Log.info(f"Successfully updated {message_type} with new"+\
+            " configuration.")
+        return status
 
     def receive(self, timeout: float = None) -> list:
         """

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -122,7 +122,7 @@ class MessageBusClient:
         return self._message_bus.delete(client_id, message_type)
 
     def set_message_type_expire(self, message_type: str, **kwargs):
-        """Set message_type expiration for given message type."""
+        """Set expiration time for given message type."""
         client_id = self._get_conf('client_id')
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -122,7 +122,7 @@ class MessageBusClient:
         return self._message_bus.delete(client_id, message_type)
 
     def set_message_type_expire(self, message_type: str, **kwargs):
-        """Set configuration for given message type."""
+        """Set message_type expiration for given message type."""
         client_id = self._get_conf('client_id')
         return self._message_bus.set_message_type_expire(client_id,\
             message_type, **kwargs)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -121,10 +121,10 @@ class MessageBusClient:
         client_id = self._get_conf('client_id')
         return self._message_bus.delete(client_id, message_type)
 
-    def configure_message_type(self, message_type: str, **kwargs):
+    def set_message_type_expire(self, message_type: str, **kwargs):
         """Set configuration for given message type."""
         client_id = self._get_conf('client_id')
-        return self._message_bus.configure_message_type(client_id,\
+        return self._message_bus.set_message_type_expire(client_id,\
             message_type, **kwargs)
 
     def receive(self, timeout: float = None) -> list:

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -206,7 +206,7 @@ class TestMessageBus(unittest.TestCase):
             auto_ack=False, offset='earliest', \
             cluster_conf = self.cluster_conf_path)
         message = _consumer_new.receive()
-        # Revert back to original timeout
+        # Revert back to original timeout to 604800000 (7 days)
         TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, expire_time_ms=604800000)
         self.assertIsNone(message)

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -192,7 +192,7 @@ class TestMessageBus(unittest.TestCase):
                 break
             time.sleep(2*retry_count)
         # Set expire time to 3 seconds
-        TestMessageBus._admin.configure_message_type(\
+        TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, expire_time_ms=5000,\
                 data_limit_bytes=10000)
         for count in range(3):
@@ -207,7 +207,7 @@ class TestMessageBus(unittest.TestCase):
             cluster_conf = self.cluster_conf_path)
         message = _consumer_new.receive()
         # Revert back to original timeout
-        TestMessageBus._admin.configure_message_type(\
+        TestMessageBus._admin.set_message_type_expire(\
             TestMessageBus._message_type, expire_time_ms=604800000)
         self.assertIsNone(message)
 

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -193,8 +193,8 @@ class TestMessageBus(unittest.TestCase):
             time.sleep(2*retry_count)
         # Set expire time to 3 seconds
         TestMessageBus._admin.configure_message_type(\
-            TestMessageBus._message_type, {'expire_time_ms': 5000,\
-            'data_limit_bytes': 1000})
+            TestMessageBus._message_type, expire_time_ms=5000,\
+                data_limit_bytes=10000)
         for count in range(3):
             TestMessageBus._producer.send(\
             [f"A simple test message {count}"])
@@ -207,8 +207,8 @@ class TestMessageBus(unittest.TestCase):
             cluster_conf = self.cluster_conf_path)
         message = _consumer_new.receive()
         # Revert back to original timeout
-        TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, 604800000)
+        TestMessageBus._admin.configure_message_type(\
+            TestMessageBus._message_type, expire_time_ms=604800000)
         self.assertIsNone(message)
 
     @staticmethod

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -192,8 +192,9 @@ class TestMessageBus(unittest.TestCase):
                 break
             time.sleep(2*retry_count)
         # Set expire time to 3 seconds
-        TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, 3000)
+        TestMessageBus._admin.configure_message_type(\
+            TestMessageBus._message_type, {'expire_time_ms': 5000,\
+            'data_limit_bytes': 1000})
         for count in range(3):
             TestMessageBus._producer.send(\
             [f"A simple test message {count}"])


### PR DESCRIPTION
# Problem Statement
- Analyze and work on existing expiration time argument per topic basis,

From the consumer side, work on a message filter that should skip expired messages for a given topic.

Existing:

Users can define an expiration time for messages under individual topics dynamically by the below statement.
Example:
admin.set_message_type_expire(message_type, time_out_period)
Current timeout logic will clean the offset after expire time of the entire message logs. In this way, the new consumer joins after the log cleanup won't receive the old message.
Need to be done:

The next step needs to sketch a logic to ensure that the existing consumer who try to read messages that already passed their expiration period must not receive any old message logs.

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]:  Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: Y
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: Y
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
