### PR TITLE
EOS-26899: Message bus server common init in utils server

### DIFF
--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -26,13 +26,13 @@ from cortx.utils.errors import UtilsError
 from cortx.utils.message_bus import MessageBus
 
 class UtilsServerError(UtilsError):
-    """ UtilsServerError exception with error code and output """
+    """UtilsServerError exception with error code and output."""
 
     def __init__(self, rc, message, *args):
         super().__init__(rc, message, *args)
 
 class RestServer:
-    """ Base class for Cortx Rest Server implementation """
+    """Base class for Cortx Rest Server implementation."""
 
     def __init__(self, message_server_endpoints):
         app = web.Application()

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -64,9 +64,10 @@ if __name__ == '__main__':
         default='yaml:///etc/cortx/cluster.conf')
     args=parser.parse_args()
     cluster_conf = args.cluster_conf
+    Conf.load('config', cluster_conf, skip_reload=True)
     CortxConf.init(cluster_conf=cluster_conf)
     # Get the log path
-    log_dir = CortxConf.get('log_dir')
+    log_dir = Conf.get('config','cortx>common>storage>log')
     if not log_dir:
         raise UtilsServerError(errno.EINVAL, "Fail to initialize logger."+\
             " Unable to find log_dir path entry")
@@ -76,7 +77,6 @@ if __name__ == '__main__':
 
     Log.init('utils_server', utils_log_path, level=log_level, backup_count=5, \
         file_size_in_mb=5)
-    Conf.load('config', cluster_conf, skip_reload=True)
     message_server_endpoints = Conf.get('config',\
             'cortx>external>kafka>endpoints')
     RestServer(message_server_endpoints)

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -16,25 +16,30 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import argparse
+import errno
 from argparse import RawTextHelpFormatter
 from aiohttp import web
 from cortx.utils.log import Log
 from cortx.utils.common import CortxConf
 from cortx.utils.conf_store import Conf
+from cortx.utils.errors import UtilsError
 from cortx.utils.message_bus import MessageBus
+
+class UtilsServerError(UtilsError):
+    """ UtilsServerError exception with error code and output """
+
+    def __init__(self, rc, message, *args):
+        super().__init__(rc, message, *args)
 
 class RestServer:
     """ Base class for Cortx Rest Server implementation """
 
-    def __init__(self):
+    def __init__(self, message_server_endpoints):
         app = web.Application()
         from cortx.utils.iem_framework import IemRequestHandler
         from cortx.utils.message_bus import MessageBusRequestHandler
         from cortx.utils.audit_log import AuditLogRequestHandler
-        cluster_conf = CortxConf.get_cluster_conf_path()
-        Conf.load('config', cluster_conf, skip_reload=True)
-        message_server_endpoints = Conf.get('config',\
-                'cortx>external>kafka>endpoints')
+
         MessageBus.init(message_server_endpoints=message_server_endpoints)
         app.add_routes([web.post('/EventMessage/event', IemRequestHandler.send), \
             web.get('/EventMessage/event', IemRequestHandler.receive), \
@@ -51,7 +56,6 @@ class RestServer:
 
 
 if __name__ == '__main__':
-    import os
     from cortx.utils.conf_store import Conf
     parser = argparse.ArgumentParser(description='Utils server CLI',
         formatter_class=RawTextHelpFormatter)
@@ -59,14 +63,20 @@ if __name__ == '__main__':
         help="Cluster config file path for Support Bundle",\
         default='yaml:///etc/cortx/cluster.conf')
     args=parser.parse_args()
-
-    CortxConf.init(cluster_conf=args.cluster_conf)
+    cluster_conf = args.cluster_conf
+    CortxConf.init(cluster_conf=cluster_conf)
     # Get the log path
-    log_dir = CortxConf.get('log_dir', '/var/log')
+    log_dir = CortxConf.get('log_dir')
+    if not log_dir:
+        raise UtilsServerError(errno.EINVAL, "Fail to initialize logger."+\
+            " Unable to find log_dir path entry")
     utils_log_path = CortxConf.get_log_path('utils_server', base_dir=log_dir)
     # Get the log level
     log_level = CortxConf.get('utils>log_level', 'INFO')
 
     Log.init('utils_server', utils_log_path, level=log_level, backup_count=5, \
         file_size_in_mb=5)
-    RestServer()
+    Conf.load('config', cluster_conf, skip_reload=True)
+    message_server_endpoints = Conf.get('config',\
+            'cortx>external>kafka>endpoints')
+    RestServer(message_server_endpoints)

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -20,7 +20,8 @@ from argparse import RawTextHelpFormatter
 from aiohttp import web
 from cortx.utils.log import Log
 from cortx.utils.common import CortxConf
-
+from cortx.utils.conf_store import Conf
+from cortx.utils.message_bus import MessageBus
 
 class RestServer:
     """ Base class for Cortx Rest Server implementation """
@@ -30,6 +31,11 @@ class RestServer:
         from cortx.utils.iem_framework import IemRequestHandler
         from cortx.utils.message_bus import MessageBusRequestHandler
         from cortx.utils.audit_log import AuditLogRequestHandler
+        cluster_conf = CortxConf.get_cluster_conf_path()
+        Conf.load('config', cluster_conf, skip_reload=True)
+        message_server_endpoints = Conf.get('config',\
+                'cortx>external>kafka>endpoints')
+        MessageBus.init(message_server_endpoints=message_server_endpoints)
         app.add_routes([web.post('/EventMessage/event', IemRequestHandler.send), \
             web.get('/EventMessage/event', IemRequestHandler.receive), \
             web.post('/MessageBus/message/{message_type}', \

--- a/py-utils/test/message_bus/test_message_bus_server.py
+++ b/py-utils/test/message_bus/test_message_bus_server.py
@@ -29,24 +29,16 @@ class TestMessage(unittest.TestCase):
     """Test MessageBus rest server functionality."""
 
     _base_url = 'http://0.0.0.0:28300/MessageBus/message/'
-    _message_type = 'test'
+    _message_type = 'testit12'
     _consumer_group = 'receive'
-    _cluster_conf_path = ''
+    _endpoints = ''
 
     @classmethod
-    def setUpClass(cls,\
-        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
+    def setUpClass(cls):
         """Register the test message_type."""
-        if TestMessage._cluster_conf_path:
-            cls.cluster_conf_path = TestMessage._cluster_conf_path
-        else:
-            cls.cluster_conf_path = cluster_conf_path
-        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
-        message_server_endpoints = Conf.get('config',\
-                'cortx>external>kafka>endpoints')
         Log.init('message_bus', '/var/log', level='INFO', \
             backup_count=5, file_size_in_mb=5)
-        MessageBus.init(message_server_endpoints=message_server_endpoints)
+        MessageBus.init(TestMessage._endpoints.split(','))
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestMessage._message_type], partitions=1)
@@ -79,5 +71,5 @@ class TestMessage(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestMessage._cluster_conf_path = sys.argv.pop()
+        TestMessage._endpoints = sys.argv.pop()
     unittest.main()

--- a/py-utils/test/message_bus/test_message_bus_server.py
+++ b/py-utils/test/message_bus/test_message_bus_server.py
@@ -31,14 +31,22 @@ class TestMessage(unittest.TestCase):
     _base_url = 'http://0.0.0.0:28300/MessageBus/message/'
     _message_type = 'test'
     _consumer_group = 'receive'
-    _endpoints = ''
+    _cluster_conf_path = ''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls,\
+        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
         """Register the test message_type."""
+        if TestMessage._cluster_conf_path:
+            cls.cluster_conf_path = TestMessage._cluster_conf_path
+        else:
+            cls.cluster_conf_path = cluster_conf_path
+        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
+        message_server_endpoints = Conf.get('config',\
+                'cortx>external>kafka>endpoints')
         Log.init('message_bus', '/var/log', level='INFO', \
             backup_count=5, file_size_in_mb=5)
-        MessageBus.init(TestMessage._endpoints.split(','))
+        MessageBus.init(message_server_endpoints=message_server_endpoints)
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestMessage._message_type], partitions=1)
@@ -71,5 +79,5 @@ class TestMessage(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestMessage._endpoints = sys.argv.pop()
+        TestMessage._cluster_conf_path = sys.argv.pop()
     unittest.main()

--- a/py-utils/test/message_bus/test_message_bus_server.py
+++ b/py-utils/test/message_bus/test_message_bus_server.py
@@ -29,7 +29,7 @@ class TestMessage(unittest.TestCase):
     """Test MessageBus rest server functionality."""
 
     _base_url = 'http://0.0.0.0:28300/MessageBus/message/'
-    _message_type = 'testit12'
+    _message_type = 'test'
     _consumer_group = 'receive'
     _endpoints = ''
 

--- a/py-utils/test/message_bus/test_message_bus_server.py
+++ b/py-utils/test/message_bus/test_message_bus_server.py
@@ -31,22 +31,14 @@ class TestMessage(unittest.TestCase):
     _base_url = 'http://0.0.0.0:28300/MessageBus/message/'
     _message_type = 'test'
     _consumer_group = 'receive'
-    _cluster_conf_path = ''
+    _endpoints = ''
 
     @classmethod
-    def setUpClass(cls,\
-        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
+    def setUpClass(cls):
         """Register the test message_type."""
-        if TestMessage._cluster_conf_path:
-            cls.cluster_conf_path = TestMessage._cluster_conf_path
-        else:
-            cls.cluster_conf_path = cluster_conf_path
-        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
-        message_server_endpoints = Conf.get('config',\
-                'cortx>external>kafka>endpoints')
         Log.init('message_bus', '/var/log', level='INFO', \
             backup_count=5, file_size_in_mb=5)
-        MessageBus.init(message_server_endpoints=message_server_endpoints)
+        MessageBus.init(TestMessage._endpoints.split(','))
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestMessage._message_type], partitions=1)
@@ -79,5 +71,5 @@ class TestMessage(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestMessage._cluster_conf_path = sys.argv.pop()
+        TestMessage._endpoints = sys.argv.pop()
     unittest.main()


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- Make message bus init  call inside utils server itself so that other URLs method defined in utils routs can able to access the message config

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
