### PR TITLE
Update README.md

### DIFF
--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -36,7 +36,7 @@ It will create `cortx-py-utils-1.0.0-1_<git-version>.noarch.rpm` by default. One
 Below command passes version string as 2.0.0 and build number 2, which creates `cortx-py-utils-2.0.0-2_<git-version>.noarch.rpm`
 Run below command from repo root (cortx-utils).
 ```bash
-cd ..
+cd cortx-utils
 ./jenkins/build.sh -v 2.0.0 -b 2
 ```
 


### PR DESCRIPTION
Shouldn't `cd` into the parent folder. If should `cd` into something, then should cd into `cortx-utils`
Signed-off-by: Meng Wang <mengwanguc@gmail.com>


-----
[View rendered py-utils/README.md](https://github.com/mengwanguc/cortx-utils/blob/patch-2/py-utils/README.md)