### PR TITLE
EOS-26952: SB Framework will accept size limit as compressed size for…

### DIFF
--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -51,16 +51,16 @@ class SupportBundle:
 
     @staticmethod
     def _get_uncompressed_size(size_limit: float):
-        """Calculate the uncompressed size, assuming the tz utility compression to be 80%,
+        """Calculate the uncompressed size, assuming the tz utility compression to be 80%
 
-            Using Formula:
-                Data_Compression_ratio = 1-(compressed_size/uncompressed_size)
-                compressed_size/uncompressed_size = 1-(4/5) = 1/5
-                uncompressed_size = compressed_size * 5
-            Multiplying compressed size limit with 5 to get the uncompressed size limit.
-            For example:
-                say the compressed size limit given is 200MB, 
-                uncompressed size limit = 200MB * 5 = 1000MB
+        Using Formula:
+            Data_Compression_ratio = 1-(compressed_size/uncompressed_size)
+            compressed_size/uncompressed_size = 1-(4/5) = 1/5
+            uncompressed_size = compressed_size * 5
+        Multiplying compressed size limit with 5 to get the uncompressed size limit.
+        For example:
+            say the compressed size limit given is 200MB,
+            uncompressed size limit = 200MB * 5 = 1000MB
         """
         uncompressed_size = ''
         try:

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -50,14 +50,38 @@ class SupportBundle:
         return f"SB{''.join(random.choices(alphabet, k=8))}"
 
     @staticmethod
-    def get_component_size_limit(size_limit, num_components):
+    def _get_uncompressed_size(size_limit: float):
+        """Calculate the uncompressed size, assuming the tz utility compression to be 80%,
+
+            Using Formula:
+                Data_Compression_ratio = 1-(compressed_size/uncompressed_size)
+                compressed_size/uncompressed_size = 1-(4/5) = 1/5
+                uncompressed_size = compressed_size * 5
+            Multiplying compressed size limit with 5 to get the uncompressed size limit.
+            For example:
+                say the compressed size limit given is 200MB, 
+                uncompressed size limit = 200MB * 5 = 1000MB
+        """
+        uncompressed_size = ''
+        try:
+            uncompressed_size = int(size_limit * 5)
+        except ValueError as e:
+            Log.error(f"Failed to get uncompressed size_limit. ERROR:{str(e)}")
+        return uncompressed_size
+
+    @staticmethod
+    def get_component_size_limit(size_limit: str, num_components: int):
         """Returns the size limit per component."""
         units = ['GB', 'MB', 'KB']
         for suffix in units:
             if size_limit.endswith(suffix):
                 num_units = size_limit[:-len(suffix)]
+                # It is assumed that the size limit parsed is the compressed size,
+                # first get the uncompressed size limit, and
+                # then divide it among components.
+                num_units = SupportBundle._get_uncompressed_size(float(num_units))
                 try:
-                    size_limit_per_comp = (int(float(num_units)) / num_components)
+                    size_limit_per_comp = num_units / num_components
                     size_limit_per_comp = str(size_limit_per_comp) + suffix
                 except ValueError as e:
                     Log.error(f"Failed to get size_limit per component for SB. ERROR:{str(e)}")


### PR DESCRIPTION
… a node

Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
-  SB Framework will accept size limit as compressed size for a node

# Design
-  """Calculate the uncompressed size, assuming the tz utility compression to be 80%,

            Using Formula:
                Data_Compression_ratio = 1-(compressed_size/uncompressed_size)
                compressed_size/uncompressed_size = 1-(4/5) = 1/5
                uncompressed_size = compressed_size * 5
            Multiplying compressed size limit with 5 to get the uncompressed size limit.
            For example:
                say the compressed size limit given is 200MB, 
                uncompressed size limit = 200MB * 5 = 1000MB
        """ 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/749076684/Node+level+Support+Bundle+Collection