### PR TITLE
EOS-26982: ConfStore Consul copy-set api changes

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -433,7 +433,7 @@ class ConsulKvPayload(KvPayload):
 
     def _set(self, key: str, val: str, *args, **kwargs) -> Union[bool, None]:
         """ Set the value to the key in consul kv. """
-        return self._consul.kv.put(key, val)
+        return self._consul.kv.put(key, str(val))
 
     def _delete(self, key: str, *args, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """


### PR DESCRIPTION
# Problem Statement
`
$# Error reproduced
$#Load yaml and consul config.
>>> from cortx.utils.conf_store import Conf 
>>> Conf.load('yaml_conf', 'yaml:///root/auto-gen-cfgmap/config.yaml') 
>>> Conf.load('consul_conf', 'consul://ssc-vm-g3-rhev4-2114.colo.seagate.com:8500')

$#Get, set, delete opration on consul
>>> Conf.set('consul_conf', 'test>key', 'val') 
>>> Conf.get('consul_conf', 'test>key') 
>>> 'val' 
>>> Conf.delete('consul_conf', 'test>key') True 
>>> Conf.get('consul_conf', 'test>key') 

$#copy from yaml config to consul config
>>> Conf.copy('yaml_conf', 'consul_conf') 

Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_store.py", line 286, in copy
 Conf._conf.copy(src_index, dst_index, key_list, recurse)
 File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_store.py", line 205, in copy
 self._cache[dst_index].set(key, self._cache[src_index].get(key))
 File "/usr/lib/python3.6/site-packages/cortx/utils/conf_store/conf_cache.py", line 60, in set
 self._data.set(key, val)
 File "/usr/lib/python3.6/site-packages/cortx/utils/kv_store/kv_payload.py", line 192, in set
 self._set(key, val, self._data)
 File "/usr/lib/python3.6/site-packages/cortx/utils/kv_store/kv_store_collection.py", line 436, in _set
 return self._consul.kv.put(key, val)
 File "/usr/local/lib/python3.6/site-packages/consul/base.py", line 603, in put
 "value should be None or a string / binary data"
AssertionError: value should be None or a string/binary data
`
- Consul accepts values only in string format. But since we directly converting yaml into consul kV its fails to accept non string values.

# Design
-  Fixed the issue by converting the value into a string since consule only accepts a string as a value.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]:  Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: NA
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: NA
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
