### PR TITLE
Updated message_bus tests to take cluster.conf path as input and get kafka endpoints from conf.

### DIFF
--- a/py-utils/test/message_bus/test_kvpayload_message.py
+++ b/py-utils/test/message_bus/test_kvpayload_message.py
@@ -18,6 +18,7 @@
 
 import unittest
 from cortx.utils.log import Log
+from cortx.utils.conf_store import Conf
 from cortx.utils.kv_store import KvPayload
 from cortx.utils.message_bus.error import MessageBusError
 from cortx.utils.message_bus import MessageBus, MessageBusAdmin, \
@@ -29,14 +30,22 @@ class TestKVPayloadMessage(unittest.TestCase):
     """Test Send/Receive KvPayload as message."""
 
     _message_type = 'kv_payloads'
-    _endpoints = ''
+    _cluster_conf_path = ''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, \
+        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
         """Register the test message_type."""
+        if TestKVPayloadMessage._cluster_conf_path:
+            cls.cluster_conf_path = TestKVPayloadMessage._cluster_conf_path
+        else:
+            cls.cluster_conf_path = cluster_conf_path
+        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
+        message_server_endpoints = Conf.get('config',\
+                'cortx>external>kafka>endpoints')
         Log.init('message_bus', '/var/log', level='INFO', \
                  backup_count=5, file_size_in_mb=5)
-        MessageBus.init(TestKVPayloadMessage._endpoints.split(','))
+        MessageBus.init(message_server_endpoints=message_server_endpoints)
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestKVPayloadMessage._message_type], partitions=1)
@@ -104,5 +113,5 @@ class TestKVPayloadMessage(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestKVPayloadMessage._endpoints = sys.argv.pop()
+        TestKVPayloadMessage._cluster_conf_path = sys.argv.pop()
     unittest.main()

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -19,6 +19,7 @@
 import time
 import unittest
 from cortx.utils.log import Log
+from cortx.utils.conf_store import Conf
 from cortx.utils.message_bus.error import MessageBusError
 from cortx.utils.message_bus import MessageBus, MessageBusAdmin, \
     MessageProducer, MessageConsumer
@@ -37,15 +38,22 @@ class TestMessageBus(unittest.TestCase):
     _purge_retry = 20
     _producer = None
     _consumer = None
-    _endpoints = ''
+    _cluster_conf_path = ''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, \
+        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
         """Register the test message_type."""
-
+        if TestMessageBus._cluster_conf_path:
+            cls.cluster_conf_path = TestMessageBus._cluster_conf_path
+        else:
+            cls.cluster_conf_path = cluster_conf_path
+        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
+        message_server_endpoints = Conf.get('config',\
+                'cortx>external>kafka>endpoints')
         Log.init('message_bus', '/var/log', level='INFO', \
             backup_count=5, file_size_in_mb=5)
-        MessageBus.init(TestMessageBus._endpoints.split(','))
+        MessageBus.init(message_server_endpoints=message_server_endpoints)
         cls._admin = MessageBusAdmin(admin_id='register')
         cls._admin.register_message_type(message_types= \
             [TestMessageBus._message_type], partitions=1)
@@ -290,5 +298,5 @@ class TestMessageBus(unittest.TestCase):
 if __name__ == '__main__':
     import sys
     if len(sys.argv) >= 2:
-        TestMessageBus._endpoints = sys.argv.pop()
+        TestMessageBus._cluster_conf_path = sys.argv.pop()
     unittest.main()


### PR DESCRIPTION

# Problem Statement
- Update message_bus tests to take cluster.conf path as input and get kafka endpoints from conf.

# Design
-  https://jts.seagate.com/browse/EOS-27045 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: N

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
