### PR TITLE
EOS-27054: handle null value in consul kv

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -424,6 +424,8 @@ class ConsulKvPayload(KvPayload):
         """ Get value for consul key. """
         index, data = self._consul.kv.get(key)
         if isinstance(data, dict):
+            if data['Value'] is None:
+                return ''
             return data['Value'].decode()
         elif data is None:
             return None

--- a/py-utils/test/kv_store/test_consul_kv_store.py
+++ b/py-utils/test/kv_store/test_consul_kv_store.py
@@ -60,6 +60,13 @@ class TestStore(unittest.TestCase):
         out = TestStore.loaded_consul[0].get(['cloud>cloud_type'])
         self.assertEqual([None], out)
 
+    def test_consul_set_value_null(self):
+        """Test consul kv by setting empty string as value."""
+        TestStore.loaded_consul[0].set(['test'],[''])
+        out = TestStore.loaded_consul[0].get(['test'])
+        TestStore.loaded_consul[0].delete(['test'])
+        self.assertEqual([''], out)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- When a blank string as a value is loaded in yaml/json ConfStore, and then copied to consul backend, all the empty strings are converted to null. which is giving error and this needs to be handled.

# Design
-  null/None value is explicitly handled and instead of None, empty string is returned. 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
