### PR TITLE
EOS-26066: REST API to accept webhook information in utils rest server

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -211,12 +211,13 @@ class Utils:
     @staticmethod
     def init(config_path: str):
         """ Perform initialization """
-        # Create message_type for Event Message
+        # Create message_type for Event Message and audit log 
         from cortx.utils.message_bus import MessageBusAdmin
         from cortx.utils.message_bus.error import MessageBusError
         try:
             admin = MessageBusAdmin(admin_id='register', cluster_conf=config_path)
-            admin.register_message_type(message_types=['IEM'], partitions=1)
+            admin.register_message_type(message_types=['IEM', 'audit_log_message'], \
+                partitions=1)
         except MessageBusError as e:
             if 'TOPIC_ALREADY_EXISTS' not in e.desc:
                 raise SetupError(e.rc, "Unable to create message_type. %s", e)

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -211,7 +211,7 @@ class Utils:
     @staticmethod
     def init(config_path: str):
         """ Perform initialization """
-        # Create message_type for Event Message and audit log 
+        # Create message_type for Event Message and audit log
         from cortx.utils.message_bus import MessageBusAdmin
         from cortx.utils.message_bus.error import MessageBusError
         try:

--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -216,7 +216,7 @@ class Utils:
         from cortx.utils.message_bus.error import MessageBusError
         try:
             admin = MessageBusAdmin(admin_id='register', cluster_conf=config_path)
-            admin.register_message_type(message_types=['IEM', 'audit_log_message'], \
+            admin.register_message_type(message_types=['IEM', 'audit_messages'], \
                 partitions=1)
         except MessageBusError as e:
             if 'TOPIC_ALREADY_EXISTS' not in e.desc:

--- a/py-utils/src/utils/audit_log/audit_log_server.py
+++ b/py-utils/src/utils/audit_log/audit_log_server.py
@@ -21,9 +21,13 @@ from aiohttp import web
 from cortx.utils.utils_server import RestServer
 from cortx.utils.audit_log.error import AuditLogError
 from cortx.utils.utils_server.error import RestServerError
+from cortx.utils.message_bus import MessageProducer
+from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
 
 routes = web.RouteTableDef()
+producer = MessageProducer(producer_id='audit_log_send', \
+    message_type='audit_log_message', method='sync')
 
 
 class AuditLogRequestHandler(RestServer):
@@ -34,7 +38,24 @@ class AuditLogRequestHandler(RestServer):
         try:
             payload = await request.json()
             messages = payload['messages']
-            # TODO Store audit logs messages to a persistent storage.
+            Conf.load('webhook_info', 'yaml:///etc/cortx/external_server.conf')
+            external_server_info = Conf.get('webhook_info', 'cortx>external_server_info')
+            # send audit logs messages to to external server provided by webhook
+            if external_server_info:
+                # write Audit Log messages to the webhook server
+                import requests
+
+                data = json.dumps({'messages': messages})
+                headers = {'content-type': 'application/json'}
+                response = requests.post(url=external_server_info, data=data,\
+                    headers=headers)
+                if response.status_code != 200:
+                    # if status code from webhok server is not 200 then store audit
+                    # log message to message bus
+                    producer.send(messages)
+            else:
+                # write the audit log message to message bus
+                producer.send(messages)
         except AuditLogError as e:
             status_code = e.rc
             error_message = e.desc
@@ -55,7 +76,43 @@ class AuditLogRequestHandler(RestServer):
         else:
             status_code = 200  # No exception, Success
             response_obj = {}
-            Log.debug(f"Receiving audit messages using POST method finished with status " \
+            Log.debug(f"Receiving audit messages using POST method finished with status"\
+                f" code: {status_code}")
+            response_obj = {'status_code': status_code, 'status': 'success'}
+        finally:
+            return web.Response(text=json.dumps(response_obj), \
+                status=status_code)
+
+    @staticmethod
+    async def send_webhook_info(request):
+        Log.debug("Received POST request for webhook information")
+        try:
+            external_server_info = await request.json()
+            # write webhook info to the external server
+            Conf.load('webhook_info', 'yaml:///etc/cortx/external_server.conf')
+            Conf.set('webhook_info', 'cortx>external_server_info', external_server_info)
+            Conf.save('webhook_info')
+        except AuditLogError as e:
+            status_code = e.rc
+            error_message = e.desc
+            Log.error(f"Unable to receive audit webhook information, status code: " \
+                f"{status_code}, error: {error_message}")
+            response_obj = {'error_code': status_code, 'exception': \
+                ['AuditLogError', {'message': error_message}]}
+        except Exception as e:
+            exception_key = type(e).__name__
+            exception = RestServerError(exception_key).http_error()
+            status_code = exception[0]
+            error_message = exception[1]
+            Log.error(f"Internal error while receiving webhook info." \
+                f"status code: {status_code}, error: {error_message}")
+            response_obj = {'error_code': status_code, 'exception': \
+                [exception_key, {'message': error_message}]}
+            raise AuditLogError(status_code, error_message) from e
+        else:
+            status_code = 200  # No exception, Success
+            response_obj = {}
+            Log.debug(f"Receiving webhook info using POST method finished with status " \
                 f"code: {status_code}")
             response_obj = {'status_code': status_code, 'status': 'success'}
         finally:

--- a/py-utils/src/utils/audit_log/audit_log_server.py
+++ b/py-utils/src/utils/audit_log/audit_log_server.py
@@ -22,7 +22,6 @@ from cortx.utils.utils_server import RestServer
 from cortx.utils.audit_log.error import AuditLogError
 from cortx.utils.utils_server.error import RestServerError
 from cortx.utils.message_bus import MessageProducer
-from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
 
 routes = web.RouteTableDef()

--- a/py-utils/src/utils/audit_log/audit_log_server.py
+++ b/py-utils/src/utils/audit_log/audit_log_server.py
@@ -26,7 +26,7 @@ from cortx.utils.log import Log
 
 routes = web.RouteTableDef()
 producer = MessageProducer(producer_id='audit_log_send', \
-    message_type='audit_log_message', method='sync')
+    message_type='audit_messages', method='sync')
 
 
 class AuditLogRequestHandler(RestServer):

--- a/py-utils/src/utils/audit_log/audit_log_server.py
+++ b/py-utils/src/utils/audit_log/audit_log_server.py
@@ -32,14 +32,14 @@ producer = MessageProducer(producer_id='audit_log_send', \
 
 class AuditLogRequestHandler(RestServer):
     """Rest interface of Audit log."""
+    webhook_info = None
     @staticmethod
     async def send(request):
         Log.debug("Received POST request for audit message")
         try:
             payload = await request.json()
             messages = payload['messages']
-            Conf.load('webhook_info', 'yaml:///etc/cortx/external_server.conf')
-            external_server_info = Conf.get('webhook_info', 'cortx>external_server_info')
+            external_server_info = AuditLogRequestHandler.webhook_info
             # send audit logs messages to to external server provided by webhook
             if external_server_info:
                 # write Audit Log messages to the webhook server
@@ -89,9 +89,8 @@ class AuditLogRequestHandler(RestServer):
         try:
             external_server_info = await request.json()
             # write webhook info to the external server
-            Conf.load('webhook_info', 'yaml:///etc/cortx/external_server.conf')
-            Conf.set('webhook_info', 'cortx>external_server_info', external_server_info)
-            Conf.save('webhook_info')
+            AuditLogRequestHandler.webhook_info = external_server_info
+            # TODO store webhook_info to persistent storage
         except AuditLogError as e:
             status_code = e.rc
             error_message = e.desc

--- a/py-utils/src/utils/audit_log/audit_log_server.py
+++ b/py-utils/src/utils/audit_log/audit_log_server.py
@@ -31,6 +31,7 @@ producer = MessageProducer(producer_id='audit_log_send', \
 
 class AuditLogRequestHandler(RestServer):
     """Rest interface of Audit log."""
+    # webhook_info will be removed once webhook_info store to persistent storage
     webhook_info = None
     @staticmethod
     async def send(request):

--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -37,7 +37,9 @@ class RestServer:
             web.get('/MessageBus/message/{message_type}', \
             MessageBusRequestHandler.receive),
             web.post('/AuditLog/message/', \
-            AuditLogRequestHandler.send)
+            AuditLogRequestHandler.send),
+            web.post('/AuditLog/webhook/', \
+            AuditLogRequestHandler.send_webhook_info)
             ])
 
         Log.info("Starting Message Server 0.0.0.0 on port 28300")

--- a/py-utils/test/audit_log/test_audit_log_server.py
+++ b/py-utils/test/audit_log/test_audit_log_server.py
@@ -24,12 +24,22 @@ import requests
 
 class TestAuditLog(unittest.TestCase):
     """Test AuditLog rest server functionality."""
-    _base_url = 'http://127.0.0.1:28300/AuditLog/message/'
+    _base_url = 'http://0.0.0.0:28300/AuditLog/'
 
     def test_send_audit_log(self):
         """Send Audit log message."""
-        url = self._base_url
+        url = self._base_url + 'message/'
         data = json.dumps({'messages': ['Hello', 'How are you?']})
+        headers = {'content-type': 'application/json'}
+        response = requests.post(url=url, data=data, headers=headers)
+        self.assertEqual(response.json()['status'], 'success')
+        self.assertEqual(response.status_code, 200)
+
+    def test_send_webhook_info(self):
+        """Send Audit log message."""
+        url = self._base_url + 'webhook/'
+        data = json.dumps({'external_server_info':\
+            'external_server.com:port_no/AuditLog/webhook/'})
         headers = {'content-type': 'application/json'}
         response = requests.post(url=url, data=data, headers=headers)
         self.assertEqual(response.json()['status'], 'success')


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Problem Statement
- REST API to accept webhook information in utils rest server

# Design
-  https://jts.seagate.com/browse/EOS-26066

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N] NA
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
