### PR TITLE
EOS-26912: Purge without using kafka binaries

### DIFF
--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -374,7 +374,7 @@ class KafkaMessageBroker(MessageBroker):
 
     def delete(self, admin_id: str, message_type: str):
         """
-        Deletes all the messages from Kafka cluster(s)
+        Deletes all the messages of given message_type
 
         Parameters:
         message_type    This is essentially equivalent to the
@@ -402,19 +402,8 @@ class KafkaMessageBroker(MessageBroker):
             else:
                 break
 
-        for retry_count in range(1, (self._max_purge_retry_count + 2)):
-            if retry_count > self._max_purge_retry_count:
-                Log.error(f"MessageBusError: {errors.ERR_OP_FAILED} Unable" \
-                    f" to delete messages for message type {message_type}" \
-                    f" using admin {admin} after {retry_count} retries")
-                return MessageBusError(errors.ERR_OP_FAILED,\
-                    "Unable to delete messages for message type %s using " +\
-                    "admin %s after %d retries", message_type, admin,\
-                    retry_count)
-            time.sleep(0.1*retry_count)
-            log_size = self.get_log_size(message_type)
-            if log_size == 0:
-                break
+        # Sleep for a second to delete the messages
+        time.sleep(1)
 
         for default_retry in range(self._max_config_retry_count):
             self._resource.set_config('retention.ms', self._saved_retention)
@@ -428,7 +417,8 @@ class KafkaMessageBroker(MessageBroker):
                 continue
             else:
                 break
-        Log.debug("Successfully Deleted all the messages from Kafka cluster.")
+        Log.debug(f"Successfully deleted all the messages of message_type: " \
+            f"{message_type}")
         return 0
 
     def get_unread_count(self, message_type: str, consumer_group: str):

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -154,30 +154,20 @@ class TestMessageBus(unittest.TestCase):
             TestMessageBus._admin.deregister_message_type(message_types=\
                 [''])
 
-    def test_012_purge_fail(self):
+    def test_012_purge_messages(self):
         """Test fail purge messages."""
         rc = TestMessageBus._producer.delete()
-        self.assertIsInstance(rc, MessageBusError)
-
-    def test_013_purge_messages(self):
-        """Test purge messages."""
-        for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
-            rc = TestMessageBus._producer.delete()
-            if retry_count > TestMessageBus._purge_retry:
-                self.assertIsInstance(rc, MessageBusError)
-            if rc == 0:
-                break
-            time.sleep(2*retry_count)
+        self.assertEqual(rc, 0)
         message = TestMessageBus._consumer.receive()
         self.assertIsNone(message)
 
     @staticmethod
-    def test_014_concurrency():
+    def test_013_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_015_receive_concurrently(self):
+    def test_014_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -218,20 +208,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_016_reduce_concurrency(self):
+    def test_015_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_017_singleton(self):
+    def test_016_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_018_multiple_admins():
+    def test_017_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)
@@ -243,7 +233,7 @@ class TestMessageBus(unittest.TestCase):
                     cluster_conf = TestMessageBus.cluster_conf_path)
                 producer.delete()
 
-    def test_019_set_message_type_expiry(self):
+    def test_018_set_message_type_expiry(self):
         """Test set message type expiry and read before expiry."""
         # Set expire time to 2 seconds
         TestMessageBus._admin.set_message_type_expire(\
@@ -254,7 +244,7 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertEqual(message, b'A simple test message')
 
-    def test_020_message_type_read_after_expiry(self):
+    def test_019_message_type_read_after_expiry(self):
         """Test receive expired messages."""
         # Do Purge
         for retry_count in range(1, (TestMessageBus._purge_retry + 2)):


### PR DESCRIPTION
Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>

# Problem Statement
- Message bus code should not use kafka binaries for Purge.

# Design
-  Removed code that uses kafka binaries 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
