### PR TITLE
EOS-26730: Test case update for customization of message type API

### DIFF
--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -171,53 +171,13 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertIsNone(message)
 
-    def test_014_set_message_type_expiry(self):
-        """Test set message type expiry and read before expiry."""
-        # Set expire time to 2 seconds
-        TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, 2000)
-        TestMessageBus._producer.send(["A simple test message"])
-        # get before expire
-        message = TestMessageBus._consumer.receive()
-        self.assertEqual(message, b'A simple test message')
-
-    def test_015_message_type_read_after_expiry(self):
-        """Test receive expired messages."""
-        # Do Purge
-        for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
-            rc = TestMessageBus._producer.delete()
-            if retry_count > TestMessageBus._purge_retry:
-                self.assertIsInstance(rc, MessageBusError)
-            if rc == 0:
-                break
-            time.sleep(2*retry_count)
-        # Set expire time to 3 seconds
-        TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, expire_time_ms=5000,\
-                data_limit_bytes=10000)
-        for count in range(3):
-            TestMessageBus._producer.send(\
-            [f"A simple test message {count}"])
-        # Wait for message to expire
-        time.sleep(10)
-        _consumer_new = MessageConsumer(consumer_id='receive_new', \
-            consumer_group='test_new', \
-            message_types=[TestMessageBus._message_type], \
-            auto_ack=False, offset='earliest', \
-            cluster_conf = self.cluster_conf_path)
-        message = _consumer_new.receive()
-        # Revert back to original timeout to 604800000 (7 days)
-        TestMessageBus._admin.set_message_type_expire(\
-            TestMessageBus._message_type, expire_time_ms=604800000)
-        self.assertIsNone(message)
-
     @staticmethod
-    def test_016_concurrency():
+    def test_014_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_017_receive_concurrently(self):
+    def test_015_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -258,20 +218,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_018_reduce_concurrency(self):
+    def test_016_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_019_singleton(self):
+    def test_017_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_020_multiple_admins():
+    def test_018_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)
@@ -282,6 +242,49 @@ class TestMessageBus(unittest.TestCase):
                     message_type=message_type, method='sync', \
                     cluster_conf = TestMessageBus.cluster_conf_path)
                 producer.delete()
+
+    def test_019_set_message_type_expiry(self):
+        """Test set message type expiry and read before expiry."""
+        # Set expire time to 2 seconds
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, expire_time_ms=2000,\
+                data_limit_bytes=10000)
+        TestMessageBus._producer.send(["A simple test message"])
+        # get before expire
+        message = TestMessageBus._consumer.receive()
+        self.assertEqual(message, b'A simple test message')
+
+    def test_020_message_type_read_after_expiry(self):
+        """Test receive expired messages."""
+        # Do Purge
+        for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
+            rc = TestMessageBus._producer.delete()
+            if retry_count > TestMessageBus._purge_retry:
+                self.assertIsInstance(rc, MessageBusError)
+            if rc == 0:
+                break
+            time.sleep(2*retry_count)
+        # Set expire time to 3 seconds
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, expire_time_ms=5000,\
+                data_limit_bytes=10000)
+        for count in range(3):
+            TestMessageBus._producer.send(\
+            [f"A simple test message {count}"])
+        # Wait for message to expire
+        time.sleep(10)
+        _consumer_new = MessageConsumer(consumer_id='receive_new', \
+            consumer_group='test_new', \
+            message_types=[TestMessageBus._message_type], \
+            auto_ack=False, offset='earliest', \
+            cluster_conf = self.cluster_conf_path)
+        message = _consumer_new.receive()
+        # Revert back to original timeout to 604800000 (7 days)
+        #  and data log size to 1073741824 (1 Gb)
+        TestMessageBus._admin.set_message_type_expire(\
+            TestMessageBus._message_type, expire_time_ms=604800000,\
+                data_limit_bytes=1073741824 )
+        self.assertIsNone(message)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- Messagebus testcase changes to address set_message_type_expire() parameters api changes
- set_message_type_expire accept message_type, expire_time_ms and data_limit_bytes as parameters
- Since existing test code doesn't handle following params: expire_time_ms and data_limit_bytes

# Design
-  Updated position of test cases to ensure other test case values not affected.
- Fixed test cases of expire changes
- handled and passed message_type, expire_time_ms and data_limit_bytes as arguments to set_message_type_expire() method

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
