### PR TITLE
EOS-25893: Implement init method for Event_message

### DIFF
--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -19,7 +19,6 @@ import os
 import json
 import time
 import errno
-
 from cortx.utils import errors
 from cortx.template import Singleton
 from cortx.utils.conf_store import Conf
@@ -31,7 +30,7 @@ class EventMessage(metaclass=Singleton):
     """ Event Message framework to generate alerts """
     _producer = None
     _consumer = None
-    
+
     # VALID VALUES for IEC Components
     _SEVERITY_LEVELS = {
         'A': 'alert',
@@ -54,7 +53,7 @@ class EventMessage(metaclass=Singleton):
 
     @classmethod
     def init(cls, component: str, source: str, cluster_id: str, \
-             message_server_endpoints: str, **message_server_kwargs):
+         message_server_endpoints: str, **message_server_kwargs):
         """
         Set the Event Message context
 
@@ -66,10 +65,9 @@ class EventMessage(metaclass=Singleton):
 
         cls._component = component
         cls._source = source
-        machine_id = Conf.machine_id
         cls._site_id = 1
         cls._rack_id = 1
-        cls._node_id = machine_id
+        cls._node_id = Conf.machine_id
         cls._cluster_id = cluster_id
 
         if cls._component is None:
@@ -184,7 +182,7 @@ class EventMessage(metaclass=Singleton):
 
     @classmethod
     def subscribe(cls, component: str,  message_server_endpoints: str, \
-                  **message_server_kwargs):
+        **message_server_kwargs):
         """
         Subscribe to IEM alerts
 

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -19,19 +19,19 @@ import os
 import json
 import time
 import errno
-from cortx.utils.common import CortxConf
+
 from cortx.utils import errors
 from cortx.template import Singleton
 from cortx.utils.conf_store import Conf
 from cortx.utils.iem_framework.error import EventMessageError
-from cortx.utils.message_bus import MessageProducer, MessageConsumer
+from cortx.utils.message_bus import MessageProducer, MessageConsumer, MessageBus
 from cortx.utils.log import Log
-
 
 class EventMessage(metaclass=Singleton):
     """ Event Message framework to generate alerts """
     _producer = None
     _consumer = None
+    _message_server_endpoints = None
 
     # VALID VALUES for IEC Components
     _SEVERITY_LEVELS = {
@@ -52,24 +52,15 @@ class EventMessage(metaclass=Singleton):
         'O': 'OS'
     }
 
-    @staticmethod
-    def _initiate_logger():
-        """Initialize logger if required."""
-        Conf.load('config_file', 'json:///etc/cortx/cortx.conf',
-            skip_reload=True)
-        # if Log.logger is already initialized by some parent process
-        # the same file will be used to log all the messagebus related
-        # logs, else standard iem.log will be used.
-        if not Log.logger:
-            LOG_DIR='/var/log'
-            iem_log_dir = os.path.join(LOG_DIR, 'cortx/utils/iem')
-            log_level = Conf.get('config_file', 'utils>log_level', 'INFO')
-            Log.init('iem', iem_log_dir, level=log_level, \
-                backup_count=5, file_size_in_mb=5)
+    @classmethod
+    def prep(cls, cluster_id: str, message_server_endpoints: str):
+        """Prepare the Event Message with required."""
+        cls._cluster_id = cluster_id
+        cls._message_server_endpoints = message_server_endpoints
+        MessageBus.init(message_server_endpoints)
 
     @classmethod
-    def init(cls, component: str, source: str,\
-        cluster_conf: str = 'yaml:///etc/cortx/cluster.conf'):
+    def init(cls, component: str, source: str):
         """
         Set the Event Message context
 
@@ -77,31 +68,19 @@ class EventMessage(metaclass=Singleton):
         component       Component that generates the IEM. For e.g. 'S3', 'SSPL'
         source          Single character that indicates the type of component.
                         For e.g. H-Hardware, S-Software, F-Firmware, O-OS
-        cluster_conf    ConfStore URL of cluster.conf file
         """
-        utils_index = 'utils_ind'
-        CortxConf.init(cluster_conf=cluster_conf)
-        local_storage = CortxConf.get_storage_path('local')
-        utils_conf = os.path.join(local_storage, 'utils/conf/utils.conf')
-        cls._conf_file = f'json://{utils_conf}'
+        if cls._message_server_endpoints is None:
+            Log.error("Call IEM.prep() method before calling IEM.init()")
+            raise EventMessageError(errors.ERR_SERVICE_NOT_INITIALIZED, \
+                "Call IEM prep() before calling init()")
 
         cls._component = component
         cls._source = source
-
-        cls._initiate_logger()
-
-        try:
-            Conf.load(utils_index, cls._conf_file, skip_reload=True)
-            machine_id = Conf.machine_id
-            ids = Conf.get(utils_index, f'node>{machine_id}')
-            cls._site_id = ids['site_id']
-            cls._rack_id = ids['rack_id']
-            cls._node_id = machine_id
-            cls._cluster_id = ids['cluster_id']
-        except Exception as e:
-            Log.error("Invalid config in %s." % cls._conf_file)
-            raise EventMessageError(errno.EINVAL, "Invalid config in %s. %s", \
-                cls._conf_file, e)
+        machine_id = Conf.machine_id
+        cls._site_id = 1
+        cls._rack_id = 1
+        cls._node_id = machine_id
+        cls._cluster_id = cls._cluster_id
 
         if cls._component is None:
             Log.error("Invalid component type: %s" % cls._component )
@@ -112,9 +91,8 @@ class EventMessage(metaclass=Singleton):
             Log.error("Invalid source type: %s" % cls._source)
             raise EventMessageError(errno.EINVAL, "Invalid source type: %s", \
                 cls._source)
-
         cls._producer = MessageProducer(producer_id='event_producer', \
-            message_type='IEM', method='sync', cluster_conf=cluster_conf)
+            message_type='IEM', method='sync')
         Log.info("IEM Producer initialized for component %s and source %s" % \
              (cls._component, cls._source))
 
@@ -149,7 +127,6 @@ class EventMessage(metaclass=Singleton):
         import socket
         sender_host = socket.gethostname()
 
-        cls._initiate_logger()
         if cls._producer is None:
             Log.error("IEM Producer not initialized.")
             raise EventMessageError(errors.ERR_SERVICE_NOT_INITIALIZED, \
@@ -215,30 +192,26 @@ class EventMessage(metaclass=Singleton):
         Log.debug("alert sent: %s" % alert)
 
     @classmethod
-    def subscribe(cls, component: str,\
-        cluster_conf: str = 'yaml:///etc/cortx/cluster.conf', **filters):
+    def subscribe(cls, component: str, **filters):
         """
         Subscribe to IEM alerts
 
         Parameters:
         component       Component that generates the IEM. For e.g. 'S3', 'SSPL'
-        cluster_conf    ConfStore URL of cluster.conf file
         """
         if component is None:
             Log.error("Invalid component type: %s" % component)
             raise EventMessageError(errno.EINVAL, "Invalid component type: %s", \
                component)
-
         cls._consumer = MessageConsumer(consumer_id='event_consumer', \
             consumer_group=component, message_types=['IEM'], \
-            auto_ack=True, offset='earliest', cluster_conf=cluster_conf)
+            auto_ack=True, offset='earliest')
         Log.info("IEM Consumer initialized for component: %s" % component)
 
 
     @classmethod
     def receive(cls):
         """ Receive IEM alert message """
-        cls._initiate_logger()
         if cls._consumer is None:
             Log.error("IEM Consumer is not subscribed")
             raise EventMessageError(errors.ERR_SERVICE_NOT_INITIALIZED, \

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -183,7 +183,8 @@ class EventMessage(metaclass=Singleton):
         Log.debug("alert sent: %s" % alert)
 
     @classmethod
-    def subscribe(cls, component: str, **filters):
+    def subscribe(cls, component: str,  message_server_endpoints: str, \
+                  **message_server_kwargs):
         """
         Subscribe to IEM alerts
 
@@ -194,6 +195,7 @@ class EventMessage(metaclass=Singleton):
             Log.error("Invalid component type: %s" % component)
             raise EventMessageError(errno.EINVAL, "Invalid component type: %s", \
                component)
+        MessageBus.init(message_server_endpoints, message_server_kwargs)
         cls._consumer = MessageConsumer(consumer_id='event_consumer', \
             consumer_group=component, message_types=['IEM'], \
             auto_ack=True, offset='earliest')

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -79,7 +79,7 @@ class EventMessage(metaclass=Singleton):
             Log.error("Invalid source type: %s" % cls._source)
             raise EventMessageError(errno.EINVAL, "Invalid source type: %s", \
                 cls._source)
-        MessageBus.init(message_server_endpoints, message_server_kwargs)
+        MessageBus.init(message_server_endpoints, **message_server_kwargs)
         cls._producer = MessageProducer(producer_id='event_producer', \
             message_type='IEM', method='sync')
         Log.info("IEM Producer initialized for component %s and source %s" % \
@@ -193,7 +193,7 @@ class EventMessage(metaclass=Singleton):
             Log.error("Invalid component type: %s" % component)
             raise EventMessageError(errno.EINVAL, "Invalid component type: %s", \
                component)
-        MessageBus.init(message_server_endpoints, message_server_kwargs)
+        MessageBus.init(message_server_endpoints, **message_server_kwargs)
         cls._consumer = MessageConsumer(consumer_id='event_consumer', \
             consumer_group=component, message_types=['IEM'], \
             auto_ack=True, offset='earliest')

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -52,15 +52,9 @@ class EventMessage(metaclass=Singleton):
         'O': 'OS'
     }
 
-    @classmethod
-    def prep(cls, cluster_id: str, message_server_endpoints: str):
-        """Prepare the Event Message with required."""
-        cls._cluster_id = cluster_id
-        cls._message_server_endpoints = message_server_endpoints
-        MessageBus.init(message_server_endpoints)
 
     @classmethod
-    def init(cls, component: str, source: str):
+    def init(cls, component: str, source: str, cluster_id: str, message_server_endpoints: str, **message_server_kwargs):
         """
         Set the Event Message context
 
@@ -80,7 +74,7 @@ class EventMessage(metaclass=Singleton):
         cls._site_id = 1
         cls._rack_id = 1
         cls._node_id = machine_id
-        cls._cluster_id = cls._cluster_id
+        cls._cluster_id = cluster_id
 
         if cls._component is None:
             Log.error("Invalid component type: %s" % cls._component )
@@ -91,6 +85,7 @@ class EventMessage(metaclass=Singleton):
             Log.error("Invalid source type: %s" % cls._source)
             raise EventMessageError(errno.EINVAL, "Invalid source type: %s", \
                 cls._source)
+        MessageBus.init(message_server_endpoints, message_server_kwargs)
         cls._producer = MessageProducer(producer_id='event_producer', \
             message_type='IEM', method='sync')
         Log.info("IEM Producer initialized for component %s and source %s" % \

--- a/py-utils/src/utils/iem_framework/event_message.py
+++ b/py-utils/src/utils/iem_framework/event_message.py
@@ -31,8 +31,7 @@ class EventMessage(metaclass=Singleton):
     """ Event Message framework to generate alerts """
     _producer = None
     _consumer = None
-    _message_server_endpoints = None
-
+    
     # VALID VALUES for IEC Components
     _SEVERITY_LEVELS = {
         'A': 'alert',
@@ -54,7 +53,8 @@ class EventMessage(metaclass=Singleton):
 
 
     @classmethod
-    def init(cls, component: str, source: str, cluster_id: str, message_server_endpoints: str, **message_server_kwargs):
+    def init(cls, component: str, source: str, cluster_id: str, \
+             message_server_endpoints: str, **message_server_kwargs):
         """
         Set the Event Message context
 
@@ -63,10 +63,6 @@ class EventMessage(metaclass=Singleton):
         source          Single character that indicates the type of component.
                         For e.g. H-Hardware, S-Software, F-Firmware, O-OS
         """
-        if cls._message_server_endpoints is None:
-            Log.error("Call IEM.prep() method before calling IEM.init()")
-            raise EventMessageError(errors.ERR_SERVICE_NOT_INITIALIZED, \
-                "Call IEM prep() before calling init()")
 
         cls._component = component
         cls._source = source

--- a/py-utils/test/iem_framework/test_iem.py
+++ b/py-utils/test/iem_framework/test_iem.py
@@ -19,6 +19,7 @@
 import unittest
 from cortx.utils.iem_framework import EventMessage
 from cortx.utils.iem_framework.error import EventMessageError
+from cortx.utils.conf_store import Conf
 
 
 class TestMessage(unittest.TestCase):
@@ -31,29 +32,34 @@ class TestMessage(unittest.TestCase):
             cls.cluster_conf_path = TestMessage._cluster_conf_path
         else:
             cls.cluster_conf_path = cluster_conf_path
+        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
+        cls.cluster_id = Conf.get('config', 'cluster>id')
+        cls.message_server_endpoints = Conf.get('config',\
+            'cortx>external>kafka>endpoints')
+        EventMessage.prep(cls.cluster_id, cls.message_server_endpoints)
 
     def test_alert_send(self):
         """ Test send alerts """
-        EventMessage.init(component='cmp', source='H', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.init(component='cmp', source='H')
         EventMessage.send(module='mod', event_id='500', severity='B', \
             message_blob='This is message')
 
     def test_alert_verify_receive(self):
         """ Test receive alerts """
-        EventMessage.subscribe(component='cmp', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.subscribe(component='cmp')
         alert = EventMessage.receive()
         self.assertIs(type(alert), dict)
 
     def test_bulk_alert_send(self):
         """ Test bulk send alerts """
-        EventMessage.init(component='cmp', source='H', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.init(component='cmp', source='H')
         for alert_count in range(0, 1000):
             EventMessage.send(module='mod', event_id='500', severity='B', \
                 message_blob='This is message' + str(alert_count))
 
     def test_bulk_verify_receive(self):
         """ Test bulk receive alerts """
-        EventMessage.subscribe(component='cmp', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.subscribe(component='cmp')
         count = 0
         while True:
             alert = EventMessage.receive()
@@ -76,15 +82,15 @@ class TestMessage(unittest.TestCase):
 
     def test_receive_without_send(self):
         """ Receive message without send """
-        EventMessage.subscribe(component='cmp', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.subscribe(component='cmp')
         alert = EventMessage.receive()
         self.assertIsNone(alert)
 
     def test_init_validation(self):
         """ Validate init attributes """
         with self.assertRaises(EventMessageError):
-            EventMessage.init(component=None, source='H', cluster_conf=TestMessage.cluster_conf_path)
-            EventMessage.init(component='cmp', source='I', cluster_conf=TestMessage.cluster_conf_path)
+            EventMessage.init(component=None, source='H')
+            EventMessage.init(component='cmp', source='I')
 
     def test_send_validation(self):
         """ Validate send attributes """
@@ -100,17 +106,17 @@ class TestMessage(unittest.TestCase):
 
     def test_subscribe_validation(self):
         with self.assertRaises(EventMessageError):
-            EventMessage.subscribe(component=None, cluster_conf=TestMessage.cluster_conf_path)
+            EventMessage.subscribe(component=None)
 
     def test_json_alert_send(self):
         """ Test send json as message description """
-        EventMessage.init(component='cmp', source='H', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.init(component='cmp', source='H')
         EventMessage.send(module='mod', event_id='500', severity='B', \
             message_blob={'input': 'This is message'})
 
     def test_json_verify_receive(self):
         """ Test receive json as message description """
-        EventMessage.subscribe(component='cmp', cluster_conf=TestMessage.cluster_conf_path)
+        EventMessage.subscribe(component='cmp')
         alert = EventMessage.receive()
         self.assertIs(type(alert), dict)
 

--- a/py-utils/test/iem_framework/test_iem.py
+++ b/py-utils/test/iem_framework/test_iem.py
@@ -42,27 +42,31 @@ class TestMessage(unittest.TestCase):
     def test_alert_send(self):
         """ Test send alerts """
         EventMessage.init(component='cmp', source='H', \
-            TestMessage._cluster_id, TestMessage._message_server_endpoints)
+            cluster_id=TestMessage._cluster_id, \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         EventMessage.send(module='mod', event_id='500', severity='B', \
             message_blob='This is message')
 
     def test_alert_verify_receive(self):
         """ Test receive alerts """
-        EventMessage.subscribe(component='cmp', TestMessage._message_server_endpoints)
+        EventMessage.subscribe(component='cmp', \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         alert = EventMessage.receive()
         self.assertIs(type(alert), dict)
 
     def test_bulk_alert_send(self):
         """ Test bulk send alerts """
         EventMessage.init(component='cmp', source='H', \
-               TestMessage._cluster_id, TestMessage._message_server_endpoints)
+            cluster_id=TestMessage._cluster_id, \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         for alert_count in range(0, 1000):
             EventMessage.send(module='mod', event_id='500', severity='B', \
                 message_blob='This is message' + str(alert_count))
 
     def test_bulk_verify_receive(self):
         """ Test bulk receive alerts """
-        EventMessage.subscribe(component='cmp', TestMessage._message_server_endpoints)
+        EventMessage.subscribe(component='cmp', \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         count = 0
         while True:
             alert = EventMessage.receive()
@@ -85,7 +89,8 @@ class TestMessage(unittest.TestCase):
 
     def test_receive_without_send(self):
         """ Receive message without send """
-        EventMessage.subscribe(component='cmp', TestMessage._message_server_endpoints)
+        EventMessage.subscribe(component='cmp', \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         alert = EventMessage.receive()
         self.assertIsNone(alert)
 
@@ -93,9 +98,11 @@ class TestMessage(unittest.TestCase):
         """ Validate init attributes """
         with self.assertRaises(EventMessageError):
             EventMessage.init(component=None, source='H', \
-              TestMessage._cluster_id, TestMessage._message_server_endpoints)
-            EventMessage.init(component='cmp', source='I', \
-                       TestMessage._cluster_id, TestMessage._message_server_endpoints)
+                cluster_id=TestMessage._cluster_id, \
+                message_server_endpoints=TestMessage._message_server_endpoints)
+            EventMessage.init(component=None, source='I', \
+                cluster_id=TestMessage._cluster_id, \
+                message_server_endpoints=TestMessage._message_server_endpoints)
 
     def test_send_validation(self):
         """ Validate send attributes """
@@ -111,18 +118,21 @@ class TestMessage(unittest.TestCase):
 
     def test_subscribe_validation(self):
         with self.assertRaises(EventMessageError):
-            EventMessage.subscribe(component=None)
+            EventMessage.subscribe(component=None, \
+                message_server_endpoints=TestMessage._message_server_endpoints)
 
     def test_json_alert_send(self):
         """ Test send json as message description """
         EventMessage.init(component='cmp', source='H', \
-                    TestMessage._cluster_id, TestMessage._message_server_endpoints)
+            cluster_id=TestMessage._cluster_id, \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         EventMessage.send(module='mod', event_id='500', severity='B', \
             message_blob={'input': 'This is message'})
 
     def test_json_verify_receive(self):
         """ Test receive json as message description """
-        EventMessage.subscribe(component='cmp', TestMessage._message_server_endpoints)
+        EventMessage.subscribe(component='cmp', \
+            message_server_endpoints=TestMessage._message_server_endpoints)
         alert = EventMessage.receive()
         self.assertIs(type(alert), dict)
 


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- DoD:
- Implement IEM prep() and init() method
- Update the code not to refer to any config file
- Update test cases to make use of the prep(), init () method & initialize log files

# Design
-  Implemented new iem.prep() method that will get cluster_id and server endpoints as input.
- iem.prep() should be invoked before iem.init().
- iem.prep() will internally initialize message bus init method.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
