### PR TITLE
EOS-26912: Removal of get_unread_count()

### DIFF
--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -348,30 +348,6 @@ class KafkaMessageBroker(MessageBroker):
                 producer.poll(timeout=timeout)
         Log.debug("Successfully Sent list of messages to Kafka cluster")
 
-    def get_log_size(self, message_type: str):
-        """ Gets size of log across all the partitions """
-        total_size = 0
-        cmd = "/opt/kafka/bin/kafka-log-dirs.sh --describe --bootstrap-server "\
-            + self._servers + " --topic-list " + message_type
-        Log.debug(f"Retrieving log size for message_type {message_type}")
-        try:
-            cmd_proc = SimpleProcess(cmd)
-            run_result = cmd_proc.run()
-            decoded_string = run_result[0].decode('utf-8')
-            output_json = json.loads(re.search(r'({.+})', decoded_string).\
-                group(0))
-            for brokers in output_json['brokers']:
-                partition = brokers['logDirs'][0]['partitions']
-                for each_partition in partition:
-                    total_size += each_partition['size']
-            Log.debug(f"Successfully retrived log size {total_size}")
-            return total_size
-        except Exception as e:
-            Log.error(f"MessageBusError:{errors.ERR_OP_FAILED} Command {cmd}" \
-                f" failed for message type {message_type} {e}")
-            raise MessageBusError(errors.ERR_OP_FAILED, "Command %s failed" +\
-                "for message type %s %s", cmd, message_type, e)
-
     def delete(self, admin_id: str, message_type: str):
         """
         Deletes all the messages of given message_type
@@ -420,85 +396,6 @@ class KafkaMessageBroker(MessageBroker):
         Log.debug(f"Successfully deleted all the messages of message_type: " \
             f"{message_type}")
         return 0
-
-    def get_unread_count(self, message_type: str, consumer_group: str):
-        """
-        Gets the count of unread messages from the Kafka message server
-
-        Parameters:
-        message_type    This is essentially equivalent to the
-                        queue/topic name. For e.g. "Alert"
-        consumer_group  A String that represents Consumer Group ID.
-        """
-        table = []
-        Log.debug(f"Getting unread messages count for message_type" \
-            f" {message_type}, with consumer_group {consumer_group}")
-        # Update the offsets if purge was called
-        if self.get_log_size(message_type) == 0:
-            cmd = "/opt/kafka/bin/kafka-consumer-groups.sh \
-                --bootstrap-server " + self._servers + " --group " \
-                + consumer_group + " --topic " + message_type + \
-                " --reset-offsets --to-latest --execute"
-            cmd_proc = SimpleProcess(cmd)
-            res_op, res_err, res_rc = cmd_proc.run()
-            if res_rc != 0:
-                Log.error(f"MessageBusError: {errors.ERR_OP_FAILED}. Command" \
-                    f" {cmd} failed for consumer group {consumer_group}." \
-                    f" {res_err}")
-                raise MessageBusError(errors.ERR_OP_FAILED, "Command %s " +\
-                    "failed for consumer group %s. %s", cmd, consumer_group,\
-                    res_err)
-            decoded_string = res_op.decode("utf-8")
-            if 'Error' in decoded_string:
-                Log.error(f"MessageBusError: {errors.ERR_OP_FAILED}. Command" \
-                    f" {cmd} failed for consumer group {consumer_group}. " \
-                    f"{res_err}")
-                raise MessageBusError(errors.ERR_OP_FAILED, "Command %s" + \
-                    " failed for consumer group %s. %s", cmd, \
-                    consumer_group, res_err)
-        cmd = "/opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server "\
-            + self._servers + " --describe --group " + consumer_group
-        cmd_proc = SimpleProcess(cmd)
-        res_op, res_err, res_rc = cmd_proc.run()
-        if res_rc != 0:
-            Log.error(f"MessageBusError: {errors.ERR_OP_FAILED}. command " \
-                f"{cmd} failed for consumer group {consumer_group}. " \
-                f"{res_err}.")
-            raise MessageBusError(errors.ERR_OP_FAILED, "command %s " + \
-                "failed for consumer group %s. %s.", cmd, consumer_group, \
-                res_err)
-        decoded_string = res_op.decode("utf-8")
-        if decoded_string == "":
-            Log.error(f"MessageBusError: {errno.ENOENT}. No active consumers" \
-                f" in the consumer group, {consumer_group}.")
-            raise MessageBusError(errno.ENOENT, "No active consumers" +\
-                " in the consumer group, %s.", consumer_group)
-        elif 'Error' in decoded_string:
-            Log.error(f"{errors.ERR_OP_FAILED} command  {cmd} failed for " \
-                f"consumer group {consumer_group}. {decoded_string}.")
-            raise MessageBusError(errors.ERR_OP_FAILED, "command %s " +\
-                "failed for consumer group %s. %s.", cmd, consumer_group,\
-                decoded_string)
-        else:
-            split_rows = decoded_string.split("\n")
-            rows = [row.split(' ') for row in split_rows if row != '']
-            for each_row in rows:
-                new_row = [item for item in each_row if item != '']
-                table.append(new_row)
-            message_type_index = table[0].index('TOPIC')
-            lag_index = table[0].index('LAG')
-            unread_count = [int(lag[lag_index]) for lag in table if \
-                lag[lag_index] != 'LAG' and lag[lag_index] != '-' and \
-                lag[message_type_index] == message_type]
-
-            if len(unread_count) == 0:
-                Log.error(f"MessageBusError: {errno.ENOENT}. No active "
-                    f"consumers in the consumer group, {consumer_group}.")
-                raise MessageBusError(errno.ENOENT, "No active " +\
-                    "consumers in the consumer group, %s.", consumer_group)
-        Log.debug(f"Successfully Got the count of unread messages from the" \
-            f" Kafka message server as {unread_count}")
-        return sum(unread_count)
 
     def receive(self, consumer_id: str, timeout: float = None) -> list:
         """

--- a/py-utils/src/utils/message_bus/message_broker_collection.py
+++ b/py-utils/src/utils/message_bus/message_broker_collection.py
@@ -374,7 +374,7 @@ class KafkaMessageBroker(MessageBroker):
 
     def delete(self, admin_id: str, message_type: str):
         """
-        Deletes all the messages from Kafka cluster(s)
+        Deletes all the messages of given message_type
 
         Parameters:
         message_type    This is essentially equivalent to the
@@ -402,19 +402,8 @@ class KafkaMessageBroker(MessageBroker):
             else:
                 break
 
-        for retry_count in range(1, (self._max_purge_retry_count + 2)):
-            if retry_count > self._max_purge_retry_count:
-                Log.error(f"MessageBusError: {errors.ERR_OP_FAILED} Unable" \
-                    f" to delete messages for message type {message_type}" \
-                    f" using admin {admin} after {retry_count} retries")
-                return MessageBusError(errors.ERR_OP_FAILED,\
-                    "Unable to delete messages for message type %s using " +\
-                    "admin %s after %d retries", message_type, admin,\
-                    retry_count)
-            time.sleep(0.1*retry_count)
-            log_size = self.get_log_size(message_type)
-            if log_size == 0:
-                break
+        # Sleep for a second to delete the messages
+        time.sleep(1)
 
         for default_retry in range(self._max_config_retry_count):
             self._resource.set_config('retention.ms', self._saved_retention)
@@ -428,7 +417,8 @@ class KafkaMessageBroker(MessageBroker):
                 continue
             else:
                 break
-        Log.debug("Successfully Deleted all the messages from Kafka cluster.")
+        Log.debug(f"Successfully deleted all the messages of message_type: " \
+            f"{message_type}")
         return 0
 
     def get_unread_count(self, message_type: str, consumer_group: str):

--- a/py-utils/src/utils/message_bus/message_bus.py
+++ b/py-utils/src/utils/message_bus/message_bus.py
@@ -104,13 +104,6 @@ class MessageBus(metaclass=Singleton):
         """ Deletes all the messages from the configured message broker """
         return self._broker.delete(client_id, message_type)
 
-    def get_unread_count(self, message_type: str, consumer_group: str):
-        """
-        Gets the count of unread messages from the configured message
-        broker
-        """
-        return self._broker.get_unread_count(message_type, consumer_group)
-
     def receive(self, client_id: str, timeout: float = None) -> list:
         """ Receives messages from the configured message broker """
         return self._broker.receive(client_id, timeout)

--- a/py-utils/src/utils/message_bus/message_bus_client.py
+++ b/py-utils/src/utils/message_bus/message_bus_client.py
@@ -179,16 +179,6 @@ class MessageProducer(MessageBusClient):
             client_id=producer_id, message_type=message_type, method=method, \
             message_bus=message_bus)
 
-    def get_unread_count(self, consumer_group: str):
-        """
-        Gets the count of unread messages from the Message Bus
-
-        Parameters:
-        consumer_group  A String that represents Consumer Group ID.
-        """
-        message_type = self._get_conf("message_type")
-        return self._message_bus.get_unread_count(message_type, consumer_group)
-
 
 class MessageConsumer(MessageBusClient):
     """ A client that consumes messages """
@@ -214,14 +204,3 @@ class MessageConsumer(MessageBusClient):
             client_id=consumer_id, consumer_group=consumer_group, \
             message_types=message_types, auto_ack=auto_ack, offset=offset, \
             message_bus=message_bus)
-
-    def get_unread_count(self, message_type: str):
-        """
-        Gets the count of unread messages from the Message Bus
-
-        Parameters:
-        message_type    This is essentially equivalent to the
-                        queue/topic name. For e.g. "Alert"
-        """
-        consumer_group = self._get_conf("consumer_group")
-        return self._message_bus.get_unread_count(message_type, consumer_group)

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -92,29 +92,7 @@ class TestMessageBus(unittest.TestCase):
             messages.append("Test Message " + str(msg_num))
         TestMessageBus._producer.send(messages)
 
-    def test_006_producer_unread_count(self):
-        """Test unread message count from producer."""
-        unread_count = TestMessageBus._producer.get_unread_count(\
-            consumer_group='test')
-        self.assertEqual(unread_count, TestMessageBus._bulk_count)
-
-    def test_007_consumer_unread_count(self):
-        """Test unread message count from consumer."""
-        read_count = 0
-        while True:
-            message = TestMessageBus._consumer.receive(timeout=0)
-            if message is not None:
-                read_count += 1
-                TestMessageBus._consumer.ack()
-            if read_count == TestMessageBus._receive_limit:
-                break
-
-        unread_count = TestMessageBus._consumer.get_unread_count\
-            (message_type=TestMessageBus._message_type)
-        self.assertEqual(unread_count, (TestMessageBus._bulk_count - \
-            TestMessageBus._receive_limit))
-
-    def test_008_receive_bulk(self):
+    def test_006_receive_bulk(self):
         """Test receive bulk messages."""
         count = 0
         while True:
@@ -126,7 +104,7 @@ class TestMessageBus(unittest.TestCase):
         self.assertEqual(count, (TestMessageBus._bulk_count - \
             TestMessageBus._receive_limit))
 
-    def test_009_receive_different_consumer_group(self):
+    def test_007_receive_different_consumer_group(self):
         """Test receive from different consumer_group."""
         consumer_group = ['group_1', 'group2']
         for cg in consumer_group:
@@ -142,32 +120,32 @@ class TestMessageBus(unittest.TestCase):
                 count += 1
             self.assertEqual(count, (TestMessageBus._bulk_count + 1))
 
-    def test_010_register_message_type_exist(self):
+    def test_008_register_message_type_exist(self):
         """Test register existing message type."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.register_message_type(message_types=\
                 [TestMessageBus._message_type], partitions=1)
 
-    def test_011_deregister_message_type_not_exist(self):
+    def test_009_deregister_message_type_not_exist(self):
         """Test deregister not existing message type."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.deregister_message_type(message_types=\
                 [''])
 
-    def test_012_purge_messages(self):
-        """Test fail purge messages."""
+    def test_010_purge_messages(self):
+        """Test purge messages."""
         rc = TestMessageBus._producer.delete()
         self.assertEqual(rc, 0)
         message = TestMessageBus._consumer.receive()
         self.assertIsNone(message)
 
     @staticmethod
-    def test_013_concurrency():
+    def test_011_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_014_receive_concurrently(self):
+    def test_012_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -208,20 +186,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_015_reduce_concurrency(self):
+    def test_013_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_016_singleton(self):
+    def test_014_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_017_multiple_admins():
+    def test_015_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)
@@ -233,7 +211,7 @@ class TestMessageBus(unittest.TestCase):
                     cluster_conf = TestMessageBus.cluster_conf_path)
                 producer.delete()
 
-    def test_018_set_message_type_expiry(self):
+    def test_016_set_message_type_expiry(self):
         """Test set message type expiry and read before expiry."""
         # Set expire time to 2 seconds
         TestMessageBus._admin.set_message_type_expire(\
@@ -244,7 +222,7 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertEqual(message, b'A simple test message')
 
-    def test_019_message_type_read_after_expiry(self):
+    def test_017_message_type_read_after_expiry(self):
         """Test receive expired messages."""
         # Do Purge
         for retry_count in range(1, (TestMessageBus._purge_retry + 2)):

--- a/py-utils/test/message_bus/test_message_bus.py
+++ b/py-utils/test/message_bus/test_message_bus.py
@@ -154,30 +154,20 @@ class TestMessageBus(unittest.TestCase):
             TestMessageBus._admin.deregister_message_type(message_types=\
                 [''])
 
-    def test_012_purge_fail(self):
+    def test_012_purge_messages(self):
         """Test fail purge messages."""
         rc = TestMessageBus._producer.delete()
-        self.assertIsInstance(rc, MessageBusError)
-
-    def test_013_purge_messages(self):
-        """Test purge messages."""
-        for retry_count in range(1, (TestMessageBus._purge_retry + 2)):
-            rc = TestMessageBus._producer.delete()
-            if retry_count > TestMessageBus._purge_retry:
-                self.assertIsInstance(rc, MessageBusError)
-            if rc == 0:
-                break
-            time.sleep(2*retry_count)
+        self.assertEqual(rc, 0)
         message = TestMessageBus._consumer.receive()
         self.assertIsNone(message)
 
     @staticmethod
-    def test_014_concurrency():
+    def test_013_concurrency():
         """Test add concurrency count."""
         TestMessageBus._admin.add_concurrency(message_type=\
             TestMessageBus._message_type, concurrency_count=5)
 
-    def test_015_receive_concurrently(self):
+    def test_014_receive_concurrently(self):
         """Test receive concurrently."""
         messages = []
         for msg_num in range(0, TestMessageBus._bulk_count):
@@ -218,20 +208,20 @@ class TestMessageBus(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(total, TestMessageBus._bulk_count)
 
-    def test_016_reduce_concurrency(self):
+    def test_015_reduce_concurrency(self):
         """Test reduce concurrency count."""
         with self.assertRaises(MessageBusError):
             TestMessageBus._admin.add_concurrency(message_type=\
                 TestMessageBus._message_type, concurrency_count=2)
 
-    def test_017_singleton(self):
+    def test_016_singleton(self):
         """Test instance of message_bus."""
         message_bus_1 = MessageBus()
         message_bus_2 = MessageBus()
         self.assertTrue(message_bus_1 is message_bus_2)
 
     @staticmethod
-    def test_018_multiple_admins():
+    def test_017_multiple_admins():
         """Test multiple instances of admin interface."""
         message_types_list = TestMessageBus._admin.list_message_types()
         message_types_list.remove(TestMessageBus._message_type)
@@ -243,7 +233,7 @@ class TestMessageBus(unittest.TestCase):
                     cluster_conf = TestMessageBus.cluster_conf_path)
                 producer.delete()
 
-    def test_019_set_message_type_expiry(self):
+    def test_018_set_message_type_expiry(self):
         """Test set message type expiry and read before expiry."""
         # Set expire time to 2 seconds
         TestMessageBus._admin.set_message_type_expire(\
@@ -254,7 +244,7 @@ class TestMessageBus(unittest.TestCase):
         message = TestMessageBus._consumer.receive()
         self.assertEqual(message, b'A simple test message')
 
-    def test_020_message_type_read_after_expiry(self):
+    def test_019_message_type_read_after_expiry(self):
         """Test receive expired messages."""
         # Do Purge
         for retry_count in range(1, (TestMessageBus._purge_retry + 2)):


### PR DESCRIPTION
# Problem Statement
- Message bus code should not use kafka binaries for get_unread_count.

# Design
-  Removed code that uses kafka binaries

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page


-----
[View rendered py-utils/src/test_framework/README.md](https://github.com/selvakumaar5496/cortx-utils/blob/mb_unread/py-utils/src/test_framework/README.md)