### PR TITLE
EOS-27275: Fix to add log line without timestamp as well to filter lo…

### DIFF
--- a/py-utils/src/utils/support_framework/log_filters.py
+++ b/py-utils/src/utils/support_framework/log_filters.py
@@ -152,7 +152,7 @@ class FilterLog:
     @staticmethod
     def limit_time(src_dir, dest_dir, duration, file_name_reg_ex):
         """
-        filters out log in the src_dir that were not generated between passed
+        Filters out log in the src_dir that were generated between passed
         duration and copies them to dest_dir
 
         Args:
@@ -175,7 +175,8 @@ class FilterLog:
         for file in os.listdir(src_dir):
             op_file = os.path.join(dest_dir, 'tmp_' + file)
             if file.startswith(file_name_reg_ex):
-                with open(os.path.join(src_dir, file), 'r') as fd_in, open(op_file, 'a') as fd_out:
+                in_file = os.path.join(src_dir, file)
+                with open(in_file, 'r') as fd_in, open(op_file, 'a') as fd_out:
                     line = fd_in.readline()
                     while(line):
                         log_duration = line[:20].strip()
@@ -189,6 +190,11 @@ class FilterLog:
                                 elif log_time > end_time and include_lines_without_timestamp:
                                         include_lines_without_timestamp = False
                                         break
+                            # There will be some log lines which lies under passed duration,
+                            # but has no timestamp, those lines will throw ValueError while
+                            # trying to fetch log timestamp,
+                            # to capture such logs, we have set a flag
+                            # include_lines_without_timestamp = True
                             except ValueError:
                                 if include_lines_without_timestamp:
                                     fd_out.write(line)


### PR DESCRIPTION
Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- Support Bundle - Filter logs based on duration not working properly

# Design
-  Fix to add log line without timestamp as well to filter logs at particular range of time.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
