### PR TITLE
EOS-27348: Refactor - move Configstore -> MappedConf to cortx-utils

### DIFF
--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -81,35 +81,3 @@ class CortxConf:
         if CortxConf._cluster_conf is None:
             raise ConfError(errno.ENOENT, "Path for config file, cluster.conf, not provided")
         return CortxConf._cluster_conf
-
-
-class ConfigStore:
-
-    """ CORTX Config Store """
-
-    _conf_idx = "cortx_conf"
-
-    def __init__(self, conf_url):
-        """ Initialize with the CONF URL."""
-        self._conf_url = conf_url
-        Conf.load(self._conf_idx, self._conf_url, skip_reload=True)
-
-    def set_kvs(self, kvs: list):
-        """
-        Parameters:
-        kvs - List of KV tuple, e.g. [('k1','v1'),('k2','v2')]
-        """
-
-        for key, val in kvs:
-            Conf.set(self._conf_idx, key, val)
-        Conf.save(self._conf_idx)
-
-    def set(self, key: str, val: str):
-        """Sets the value into conf in-memory at the given key."""
-        Conf.set(self._conf_idx, key, val)
-        Conf.save(self._conf_idx)
-
-    def get(self, key: str) -> str:
-        """ Returns value for the given key """
-
-        return Conf.get(self._conf_idx, key)

--- a/py-utils/src/utils/conf_store/__init__.py
+++ b/py-utils/src/utils/conf_store/__init__.py
@@ -15,7 +15,8 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-from cortx.utils.conf_store.conf_store import ConfStore
-from cortx.utils.conf_store.conf_store import Conf
-from cortx.utils.conf_store.conf_cache import ConfCache
 from cortx.utils.conf_store.error import ConfError
+from cortx.utils.conf_store.conf_store import Conf
+from cortx.utils.conf_store.conf_store import ConfStore
+from cortx.utils.conf_store.conf_cache import ConfCache
+from cortx.utils.conf_store.conf_store import MappedConf

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -330,3 +330,60 @@ class Conf:
         Returns list of keys that matched the creteria (i.e. has given value)
         """
         return Conf._conf.search(index, parent_key, search_key, search_val)
+
+
+class MappedConf:
+    """CORTX Config Store with fixed target."""
+
+    _conf_idx = "cortx_conf"
+
+    def __init__(self, conf_url):
+        """Initialize with the CONF URL."""
+        self._conf_url = conf_url
+        Conf.load(self._conf_idx, self._conf_url, skip_reload=True)
+
+    def set_kvs(self, kvs: list):
+        """
+        Parameters:
+        kvs - List of KV tuple, e.g. [('k1','v1'),('k2','v2')]
+        Where, k1, k2 - is full key path till the leaf key.
+        """
+
+        for key, val in kvs:
+            try:
+                Conf.set(self._conf_idx, key, val)
+            except (AssertionError, ConfError) as e:
+                raise ConfError(errno.EINVAL,
+                    f'Error occurred while adding key {key} and value {val}'
+                    f' in confstore. {e}')
+        Conf.save(self._conf_idx)
+
+    def set(self, key: str, val: str):
+        """Save key-value in CORTX confstore."""
+        try:
+            Conf.set(self._conf_idx, key, val)
+            Conf.save(self._conf_idx)
+        except (AssertionError, ConfError) as e:
+            raise ConfError(errno.EINVAL,
+                f'Error occurred while adding key {key} and value {val}'
+                f' in confstore. {e}')
+
+    def copy(self, src_index: str, key_list: list):
+        """Copy src_index config into CORTX confstore file."""
+        try:
+            Conf.copy(src_index, self._conf_idx, key_list)
+        except (AssertionError, ConfError) as e:
+            raise ConfError(errno.EINVAL,
+                f'Error occurred while copying config into confstore. {e}')
+
+    def search(self, parent_key, search_key, value):
+        """Search for given key under parent key in CORTX confstore."""
+        return Conf.search(self._conf_idx, parent_key, search_key, value)
+
+    def get(self, key: str) -> str:
+        """Returns value for the given key."""
+        return Conf.get(self._conf_idx, key)
+
+    def delete(self, key: str):
+        """Delete key from CORTX confstore."""
+        Conf.delete(self._conf_idx, key)

--- a/py-utils/src/utils/support_framework/support_bundle.py
+++ b/py-utils/src/utils/support_framework/support_bundle.py
@@ -29,8 +29,7 @@ from datetime import datetime, timedelta
 from cortx.utils.log import Log
 from cortx.utils.schema.providers import Response
 from cortx.utils.errors import OPERATION_SUCESSFUL, ERR_OP_FAILED
-from cortx.utils.conf_store.conf_store import Conf
-from cortx.utils.common.common import ConfigStore
+from cortx.utils.conf_store.conf_store import Conf, MappedConf
 from cortx.utils.cli_framework.command import Command
 from cortx.utils.support_framework import const
 from cortx.utils.support_framework import Bundle
@@ -144,7 +143,7 @@ class SupportBundle:
             raise BundleError(errno.EINVAL, "Bundle ID already exists,"
                 "Please use Unique Bundle ID")
 
-        cortx_config_store = ConfigStore(config_url)
+        cortx_config_store = MappedConf(config_url)
         # Get Node ID
         node_id = Conf.machine_id
         if node_id is None:


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Refactoring code for Confstore 
moved ConfigStore class from https://github.com/Seagate/cortx-prvsnr/blob/main/src/provisioner/config_store.py to https://github.com/Seagate/cortx-utils/blob/main/py-utils/src/utils/conf_store/conf_store.py
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
