### PR TITLE
EOS-27348: add default val_args to MappedConf.get

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -185,8 +185,8 @@ class ConfStore:
         Copies one config domain to the other and saves
 
         Parameters:
-        src_index Source Index 
-        dst_index Destination Index 
+        src_index Source Index
+        dst_index Destination Index
         """
         if src_index not in self._cache.keys():
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
@@ -380,9 +380,9 @@ class MappedConf:
         """Search for given key under parent key in CORTX confstore."""
         return Conf.search(self._conf_idx, parent_key, search_key, value)
 
-    def get(self, key: str) -> str:
+    def get(self, key: str, default_val: str = None) -> str:
         """Returns value for the given key."""
-        return Conf.get(self._conf_idx, key)
+        return Conf.get(self._conf_idx, key, default_val)
 
     def delete(self, key: str):
         """Delete key from CORTX confstore."""


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Patch to accept default_val in MappedConf.get

# Design
-  Added default_val arg in MappedConf
- 
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
