### PR TITLE
MappedConf - Delete: Added save option after each MappedConf delete operations

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -386,4 +386,6 @@ class MappedConf:
 
     def delete(self, key: str):
         """Delete key from CORTX confstore."""
-        Conf.delete(self._conf_idx, key)
+        is_deleted = Conf.delete(self._conf_idx, key)
+        if is_deleted:
+            Conf.save(self._conf_idx)


### PR DESCRIPTION
Signed-off-by: suryakumar.kumaravelan <suryakumar.kumaravelan@seagate.com>

# Problem Statement
- After every change in MappedConf class we do save the changes back to the conf backend. Set API works as expected but delete API does not save the changes after a delete operation.

# Design
-  Added conf save API after every MappedConf delete API.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: N
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: NA
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: NA
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
