### PR TITLE
EOS-28411: Support bundle not getting generated

### DIFF
--- a/py-utils/src/support/cortx_support_bundle.py
+++ b/py-utils/src/support/cortx_support_bundle.py
@@ -178,7 +178,7 @@ def main():
         args = parser.parse_args()
         cluster_conf_path = args.cluster_conf_path[0] if args.cluster_conf_path else CLUSTER_CONF
         cluster_conf = MappedConf(cluster_conf_path)
-        log_path = os.path.join(cluster_conf.get('log_dir'), \
+        log_path = os.path.join(cluster_conf.get('cortx>common>storage>log'), \
             f'utils/{Conf.machine_id}/support')
         log_level = cluster_conf.get('utils>log_level', 'INFO')
         Log.init('support_bundle', log_path, level=log_level, backup_count=5, \


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- changed cortx support bundle to fetch log directory from `cortx>common>storage>log`  key instead of `log_dir`
JIRA: https://jts.seagate.com/browse/EOS-28411
# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
