### PR TITLE
EOS-27916: added dependency check for different os in build.sh

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -95,8 +95,12 @@ fi
 exit \$rc " >> utils-pre-install
 /bin/chmod +x utils-pre-install
 
+# add python3-dbus for rocky linux and python36-dbus for centos as rpm dependency
+OS_ID=$(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release|tr -d '"')
+[[ $OS_ID = rocky ]] && python_dbus="python3-dbus" || python_dbus="python36-dbus"
+
 # Create the rpm
-/bin/python3.6 setup.py bdist_rpm --requires python36,python36-dbus \
+/bin/python3.6 setup.py bdist_rpm --requires python36,$python_dbus \
 --release="$REL" --pre-install utils-pre-install \
 --post-install utils-post-install --post-uninstall utils-post-uninstall
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- python36-bdus is not availabel in rocky linux ,instead it utilises python3-dbus

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
