### PR TITLE
EOS-28599: remove query parameters from the path before signing the request

### DIFF
--- a/py-utils/src/utils/rgwadmin/client.py
+++ b/py-utils/src/utils/rgwadmin/client.py
@@ -69,7 +69,7 @@ class RGWAdminClient(HTTPClient):
         for key in sorted(required_headers):
             val = headers.get(key, "")
             string_to_sign += f"{val}\n"
-        string_to_sign += path
+        string_to_sign += path.split('?')[0]
         string_to_sign_bytes = string_to_sign.encode("UTF-8")
         secret_access_key_bytes = self._secret_access_key.encode("UTF-8")
         secret_key_hmac = hmac.new(secret_access_key_bytes, string_to_sign_bytes, sha1).digest()


### PR DESCRIPTION
# Problem Statement
- RGWAdminClient fails to sign create_key request properly.

# Design
-  Remove query parameters from the path before signing the request
- E.g. from the path like '/admin/user?key' remove '?key' 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [ ] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
