### PR TITLE
CORTX-29052: fix: num_keys are missing for list/array type values in cluster.conf

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -61,9 +61,7 @@ class ConfCache:
         self._dirty = True
 
     def add_num_keys(self):
-        """
-        Add "num_xxx" keys for all the list items in ine KV Store
-        """
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         self._data.add_num_keys()
         self._dirty = True
 

--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -60,6 +60,13 @@ class ConfCache:
         self._data.set(key, val)
         self._dirty = True
 
+    def add_num_keys(self):
+        """
+        Add "num_xxx" keys for all the list items in ine KV Store
+        """
+        self._data.add_num_keys()
+        self._dirty = True
+
     def search(self, parent_key: str, search_key: str, search_val: str) -> list:
         """
         Search for given key and value under a node

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -42,6 +42,12 @@ class ConfCli:
         Conf.load(index, url)
 
     @staticmethod
+    def add_num_keys(args):
+        """ Add num keys """
+        Conf.add_num_keys(ConfCli._index)
+        Conf.save(ConfCli._index)
+
+    @staticmethod
     def set(args):
         """ Set Key Value """
         kv_delim = '=' if args.kv_delim == None else args.kv_delim
@@ -291,6 +297,17 @@ class SearchCmd:
        s_parser.add_argument('search_key', help="search key")
        s_parser.add_argument('search_val', help="search val")
        s_parser.set_defaults(func=ConfCli.search)
+
+
+class AddNumKeysCmd:
+    @staticmethod
+    def add_args(sub_parser) -> None:
+        s_parser = sub_parser.add_parser('addnumkeys', help=
+            "Adds num keys for the list items" \
+            "Example Command:\n"
+            "# conf yaml:///tmp/test.conf addnumkeys\n\n")
+        s_parser.set_defaults(func=ConfCli.add_num_keys)
+        
 
 def main():
     # Setup Parser

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -43,7 +43,7 @@ class ConfCli:
 
     @staticmethod
     def add_num_keys(args):
-        """ Add num keys """
+        """Add "num_xxx" keys for all the list items in ine KV Store"""
         Conf.add_num_keys(ConfCli._index)
         Conf.save(ConfCli._index)
 

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -43,7 +43,7 @@ class ConfCli:
 
     @staticmethod
     def add_num_keys(args):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf.add_num_keys(ConfCli._index)
         Conf.save(ConfCli._index)
 
@@ -307,7 +307,7 @@ class AddNumKeysCmd:
             "Example Command:\n"
             "# conf yaml:///tmp/test.conf addnumkeys\n\n")
         s_parser.set_defaults(func=ConfCli.add_num_keys)
-        
+
 
 def main():
     # Setup Parser

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -281,7 +281,10 @@ class Conf:
     @staticmethod
     def delete(index: str, key: str):
         """ Deletes a given key from the config """
-        return Conf._conf.delete(index, key)
+        is_deleted = Conf._conf.delete(index, key)
+        if is_deleted:
+            Conf.save(index)
+        return is_deleted
 
     @staticmethod
     def copy(src_index: str, dst_index: str, key_list: list = None,
@@ -341,6 +344,7 @@ class Conf:
         Add "num_xxx" keys for all the list items in ine KV Store
         """
         Conf._conf.add_num_keys(index)
+        Conf.save(index)
 
 
 class MappedConf:
@@ -401,6 +405,4 @@ class MappedConf:
 
     def delete(self, key: str):
         """Delete key from CORTX confstore."""
-        is_deleted = Conf.delete(self._conf_idx, key)
-        if is_deleted:
-            Conf.save(self._conf_idx)
+        return Conf.delete(self._conf_idx, key)

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -179,6 +179,10 @@ class ConfStore:
         """
         return self._cache[index].search(parent_key, search_key, search_val)
 
+    def add_num_keys(self, index: str):
+        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        self._cache[index].add_num_keys()
+
     def copy(self, src_index: str, dst_index: str, key_list: list = None,
         recurse: bool = True):
         """
@@ -315,6 +319,7 @@ class Conf:
         """
         return Conf._conf.get_keys(index, **filters)
 
+    @staticmethod
     def search(index: str, parent_key: str, search_key: str,
         search_val: str = None) -> list:
         """
@@ -329,6 +334,13 @@ class Conf:
         Returns list of keys that matched the creteria (i.e. has given value)
         """
         return Conf._conf.search(index, parent_key, search_key, search_val)
+
+    @staticmethod
+    def add_num_keys(index):
+        """
+        Add "num_xxx" keys for all the list items in ine KV Store
+        """
+        Conf._conf.add_num_keys(index)
 
 
 class MappedConf:
@@ -378,6 +390,10 @@ class MappedConf:
     def search(self, parent_key, search_key, value):
         """Search for given key under parent key in CORTX confstore."""
         return Conf.search(self._conf_idx, parent_key, search_key, value)
+
+    def add_num_keys(self):
+        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        Conf.add_num_keys(self._conf_idx)
 
     def get(self, key: str, default_val: str = None) -> str:
         """Returns value for the given key."""

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -180,7 +180,7 @@ class ConfStore:
         return self._cache[index].search(parent_key, search_key, search_val)
 
     def add_num_keys(self, index: str):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         self._cache[index].add_num_keys()
 
     def copy(self, src_index: str, dst_index: str, key_list: list = None,
@@ -340,9 +340,7 @@ class Conf:
 
     @staticmethod
     def add_num_keys(index):
-        """
-        Add "num_xxx" keys for all the list items in ine KV Store
-        """
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf._conf.add_num_keys(index)
         Conf.save(index)
 
@@ -396,7 +394,7 @@ class MappedConf:
         return Conf.search(self._conf_idx, parent_key, search_key, value)
 
     def add_num_keys(self):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf.add_num_keys(self._conf_idx)
 
     def get(self, key: str, default_val: str = None) -> str:

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -84,6 +84,18 @@ class KvPayload:
                         "%s%s%s" % (key_prefix, self._delim, key)))
         return keys
 
+    def add_num_keys(self):
+        self._add_num_keys(self._data)
+
+    def _add_num_keys(self, data):
+        num_keys = {}
+        for k, v in data.items():
+            if type(v) == list:
+                num_keys[f'num_{k}'] = len(v)
+            elif type(v) == dict:
+                self._add_num_keys(v)
+        data.update(num_keys)
+
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:
         """
         Obtains list of keys stored in the payload

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -97,14 +97,12 @@ class KvPayload:
                 elif isinstance(v, list):
                     num_keys[f'num_{k}'] = len(v)
                     self._add_num_keys(v)
-            data.update(num_keys)
+            if len(num_keys) > 0:
+                data.update(num_keys)
 
         if isinstance(data, list):
             for v in data:
                 if isinstance(v, dict):
-                    self._add_num_keys(v)
-                elif isinstance(v, list):
-                    num_keys[f'num_{v}'] = len(v)
                     self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -88,6 +88,7 @@ class KvPayload:
         self._add_num_keys(self._data)
 
     def _add_num_keys(self, data):
+        """Add "num_xxx" keys for all the list items in ine KV Store"""
         num_keys = {}
         for k, v in data.items():
             if type(v) == list:

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -90,12 +90,22 @@ class KvPayload:
     def _add_num_keys(self, data):
         """Add "num_xxx" keys for all the list items in ine KV Store"""
         num_keys = {}
-        for k, v in data.items():
-            if type(v) == list:
-                num_keys[f'num_{k}'] = len(v)
-            elif type(v) == dict:
-                self._add_num_keys(v)
-        data.update(num_keys)
+        if isinstance(data, dict):
+            for k, v in data.items():
+                if isinstance(v, dict):
+                    self._add_num_keys(v)
+                elif isinstance(v, list):
+                    num_keys[f'num_{k}'] = len(v)
+                    self._add_num_keys(v)
+            data.update(num_keys)
+        
+        if isinstance(data, list):
+            for v in data:
+                if isinstance(v, dict):
+                    self._add_num_keys(v)
+                elif isinstance(v, list):
+                    num_keys[f'num_{v}'] = len(v)
+                    self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:
         """

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -102,8 +102,7 @@ class KvPayload:
 
         if isinstance(data, list):
             for v in data:
-                if isinstance(v, dict):
-                    self._add_num_keys(v)
+                self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:
         """

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -88,7 +88,7 @@ class KvPayload:
         self._add_num_keys(self._data)
 
     def _add_num_keys(self, data):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         num_keys = {}
         if isinstance(data, dict):
             for k, v in data.items():

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -60,7 +60,7 @@ class KvStore:
         return payload.search(parent_key, search_key, search_val)
 
     def add_num_keys(self):
-        """writes "num_xxx" keys for all the list items in ine KV Store."""
+        """Writes "num_xxx" keys for all the list items in ine KV Store."""
         payload = self.load()
         payload.add_num_keys()
         self.dump(payload)

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -60,7 +60,7 @@ class KvStore:
         return payload.search(parent_key, search_key, search_val)
 
     def add_num_keys(self):
-        """writes "num_xxx" keys for all the list items in ine KV Store"""
+        """writes "num_xxx" keys for all the list items in ine KV Store."""
         payload = self.load()
         payload.add_num_keys()
         self.dump(payload)

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -60,6 +60,7 @@ class KvStore:
         return payload.search(parent_key, search_key, search_val)
 
     def add_num_keys(self):
+        """writes "num_xxx" keys for all the list items in ine KV Store"""
         payload = self.load()
         payload.add_num_keys()
         self.dump(payload)

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -59,6 +59,11 @@ class KvStore:
         payload = self.load()
         return payload.search(parent_key, search_key, search_val)
 
+    def add_num_keys(self):
+        payload = self.load()
+        payload.add_num_keys()
+        self.dump(payload)
+
     def get_data(self, format_type: str = None) -> str:
         payload = self.load()
         return payload.get_data(format_type)

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -444,9 +444,9 @@ class TestConfStore(unittest.TestCase):
             'cortx>software>common>test_key2'))
         self.assertEqual('kafka', Conf.get('dest_index', \
             'cortx>software>common>message_bus_type'))
-    
+
     def test_conf_store_add_num_keys(self):
-        """Test Confstore Add Num keys to KV store"""
+        """Test Confstore Add Num keys to KV store."""
         Conf.set('src_index', 'test_val[0]', '1')
         Conf.set('src_index', 'test_val[1]', '2')
         Conf.set('src_index', 'test_val[2]', '3')

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -444,6 +444,18 @@ class TestConfStore(unittest.TestCase):
             'cortx>software>common>test_key2'))
         self.assertEqual('kafka', Conf.get('dest_index', \
             'cortx>software>common>message_bus_type'))
+    
+    def test_conf_store_add_num_keys(self):
+        """Test Confstore Add Num keys to KV store"""
+        expected = 5
+        Conf.set('src_index', 'test_val[0]', '1')
+        Conf.set('src_index', 'test_val[1]', '2')
+        Conf.set('src_index', 'test_val[2]', '3')
+        Conf.set('src_index', 'test_val[3]', '4')
+        Conf.set('src_index', 'test_val[4]', '5')
+        Conf.save('src_index')
+        Conf.add_num_keys('src_index')
+        self.assertEqual(expected, Conf.get('src_index', 'num_test_val'))
 
     # DictKVstore tests
     def test_001_conf_dictkvstore_get_all_keys(self):

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -447,15 +447,20 @@ class TestConfStore(unittest.TestCase):
     
     def test_conf_store_add_num_keys(self):
         """Test Confstore Add Num keys to KV store"""
-        expected = 5
         Conf.set('src_index', 'test_val[0]', '1')
         Conf.set('src_index', 'test_val[1]', '2')
         Conf.set('src_index', 'test_val[2]', '3')
         Conf.set('src_index', 'test_val[3]', '4')
         Conf.set('src_index', 'test_val[4]', '5')
+        Conf.set('src_index', 'test_nested', '2')
+        Conf.set('src_index', 'test_nested>2', '1')
+        Conf.set('src_index', 'test_nested>2>1[0]', '1')
+        Conf.set('src_index', 'test_nested>2>1[1]', '2')
+        Conf.set('src_index', 'test_nested>2>1[2]', '3')
         Conf.save('src_index')
         Conf.add_num_keys('src_index')
-        self.assertEqual(expected, Conf.get('src_index', 'num_test_val'))
+        self.assertEqual(5, Conf.get('src_index', 'num_test_val'))
+        self.assertEqual(3, Conf.get('src_index', 'test_nested>2>num_1'))
 
     # DictKVstore tests
     def test_001_conf_dictkvstore_get_all_keys(self):

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -453,7 +453,7 @@ class TestConfStore(unittest.TestCase):
         Conf.set('src_index', 'test_val[3]', '4')
         Conf.set('src_index', 'test_val[4]', '5')
         Conf.set('src_index', 'test_nested', '2')
-        Conf.set('src_index', 'test_nested>2', '1')
+        Conf.set('src_index', 'test_nested>2[0]', '1')
         Conf.set('src_index', 'test_nested>2>1[0]', '1')
         Conf.set('src_index', 'test_nested>2>1[1]', '2')
         Conf.set('src_index', 'test_nested>2>1[2]', '3')


### PR DESCRIPTION
# Problem Statement
- Missing num_data & num_metadata keys in cluster.conf
      cvg:
      - devices:
          data:
          - /dev/sdd
          - /dev/sde
          metadata:
          - /dev/sdc
        name: cvg-01
        type: ios
Expected num keys for data & metadata (wherever applicable)

      cvg:
      - devices:
          data:
          num_data: 2
          - /dev/sdd
          - /dev/sde
          metadata:
          num_metadata: 1
          - /dev/sdc
        name: cvg-01
        type: ios

# Design
-  https://jts.seagate.com/browse/CORTX-29052

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
