### PR TITLE
CORTX-29052_num_array_rgw fix: support to add num_array keys for nest…

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -180,7 +180,7 @@ class ConfStore:
         return self._cache[index].search(parent_key, search_key, search_val)
 
     def add_num_keys(self, index: str):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         self._cache[index].add_num_keys()
 
     def copy(self, src_index: str, dst_index: str, key_list: list = None,
@@ -340,9 +340,7 @@ class Conf:
 
     @staticmethod
     def add_num_keys(index):
-        """
-        Add "num_xxx" keys for all the list items in ine KV Store
-        """
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf._conf.add_num_keys(index)
         Conf.save(index)
 
@@ -396,7 +394,7 @@ class MappedConf:
         return Conf.search(self._conf_idx, parent_key, search_key, value)
 
     def add_num_keys(self):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf.add_num_keys(self._conf_idx)
 
     def get(self, key: str, default_val: str = None) -> str:

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -90,12 +90,22 @@ class KvPayload:
     def _add_num_keys(self, data):
         """Add "num_xxx" keys for all the list items in ine KV Store"""
         num_keys = {}
-        for k, v in data.items():
-            if type(v) == list:
-                num_keys[f'num_{k}'] = len(v)
-            elif type(v) == dict:
-                self._add_num_keys(v)
-        data.update(num_keys)
+        if isinstance(data, dict):
+            for k, v in data.items():
+                if isinstance(v, dict):
+                    self._add_num_keys(v)
+                elif isinstance(v, list):
+                    num_keys[f'num_{k}'] = len(v)
+                    self._add_num_keys(v)
+            data.update(num_keys)
+
+        if isinstance(data, list):
+            for v in data:
+                if isinstance(v, dict):
+                    self._add_num_keys(v)
+                elif isinstance(v, list):
+                    num_keys[f'num_{v}'] = len(v)
+                    self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:
         """

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -97,14 +97,12 @@ class KvPayload:
                 elif isinstance(v, list):
                     num_keys[f'num_{k}'] = len(v)
                     self._add_num_keys(v)
-            data.update(num_keys)
+            if len(num_keys) > 0:
+                data.update(num_keys)
 
         if isinstance(data, list):
             for v in data:
                 if isinstance(v, dict):
-                    self._add_num_keys(v)
-                elif isinstance(v, list):
-                    num_keys[f'num_{v}'] = len(v)
                     self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -88,7 +88,7 @@ class KvPayload:
         self._add_num_keys(self._data)
 
     def _add_num_keys(self, data):
-        """Add "num_xxx" keys for all the list items in ine KV Store"""
+        """Add "num_xxx" keys for all the list items in ine KV Store."""
         num_keys = {}
         if isinstance(data, dict):
             for k, v in data.items():
@@ -102,8 +102,7 @@ class KvPayload:
 
         if isinstance(data, list):
             for v in data:
-                if isinstance(v, dict):
-                    self._add_num_keys(v)
+                self._add_num_keys(v)
 
     def get_keys(self, starts_with: str = '', recurse: bool = True, **filters) -> list:
         """

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -60,7 +60,7 @@ class KvStore:
         return payload.search(parent_key, search_key, search_val)
 
     def add_num_keys(self):
-        """writes "num_xxx" keys for all the list items in ine KV Store"""
+        """Writes "num_xxx" keys for all the list items in ine KV Store."""
         payload = self.load()
         payload.add_num_keys()
         self.dump(payload)

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -444,9 +444,9 @@ class TestConfStore(unittest.TestCase):
             'cortx>software>common>test_key2'))
         self.assertEqual('kafka', Conf.get('dest_index', \
             'cortx>software>common>message_bus_type'))
-    
+
     def test_conf_store_add_num_keys(self):
-        """Test Confstore Add Num keys to KV store"""
+        """Test Confstore Add Num keys to KV store."""
         Conf.set('src_index', 'test_val[0]', '1')
         Conf.set('src_index', 'test_val[1]', '2')
         Conf.set('src_index', 'test_val[2]', '3')

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -447,15 +447,20 @@ class TestConfStore(unittest.TestCase):
     
     def test_conf_store_add_num_keys(self):
         """Test Confstore Add Num keys to KV store"""
-        expected = 5
         Conf.set('src_index', 'test_val[0]', '1')
         Conf.set('src_index', 'test_val[1]', '2')
         Conf.set('src_index', 'test_val[2]', '3')
         Conf.set('src_index', 'test_val[3]', '4')
         Conf.set('src_index', 'test_val[4]', '5')
+        Conf.set('src_index', 'test_nested', '2')
+        Conf.set('src_index', 'test_nested>2', '1')
+        Conf.set('src_index', 'test_nested>2>1[0]', '1')
+        Conf.set('src_index', 'test_nested>2>1[1]', '2')
+        Conf.set('src_index', 'test_nested>2>1[2]', '3')
         Conf.save('src_index')
         Conf.add_num_keys('src_index')
-        self.assertEqual(expected, Conf.get('src_index', 'num_test_val'))
+        self.assertEqual(5, Conf.get('src_index', 'num_test_val'))
+        self.assertEqual(3, Conf.get('src_index', 'test_nested>2>num_1'))
 
     # DictKVstore tests
     def test_001_conf_dictkvstore_get_all_keys(self):

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -453,7 +453,7 @@ class TestConfStore(unittest.TestCase):
         Conf.set('src_index', 'test_val[3]', '4')
         Conf.set('src_index', 'test_val[4]', '5')
         Conf.set('src_index', 'test_nested', '2')
-        Conf.set('src_index', 'test_nested>2', '1')
+        Conf.set('src_index', 'test_nested>2[0]', '1')
         Conf.set('src_index', 'test_nested>2>1[0]', '1')
         Conf.set('src_index', 'test_nested>2>1[1]', '2')
         Conf.set('src_index', 'test_nested>2>1[2]', '3')


### PR DESCRIPTION
…ed array in KVStore

Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
- Missing num_data & num_metadata keys in cluster.conf
cvg:
- devices:
data:
- /dev/sdd
- /dev/sde
metadata:
- /dev/sdc
name: cvg-01
type: ios
Expected num keys for data & metadata (wherever applicable)

cvg:
- devices:
    data:
    num_data: 2
    - /dev/sdd
    - /dev/sde
    metadata:
    num_metadata: 1
    - /dev/sdc
  name: cvg-01
  type: ios

# Design
- https://jts.seagate.com/browse/CORTX-29052

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
