### PR TITLE
CORTX-29025 : Disable deletion of non leaf keys

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -74,12 +74,12 @@ class ConfCache:
         """
         return self._data.search(parent_key, search_key, search_val)
 
-    def delete(self, key: str):
+    def delete(self, key: str, force: bool = False):
         """
         Delete a given key from the config.
         Return Value:
         return boolean True for success else False
         """
-        result = self._data.delete(key)
+        result = self._data.delete(key, force)
         self._dirty = True
         return result

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -164,12 +164,12 @@ class ConfStore:
                                  index)
         return self._cache[index].get_data()
 
-    def delete(self, index: str, key: str):
+    def delete(self, index: str, key: str, force: bool = False):
         """ Delets a given key from the config """
         if index not in self._cache.keys():
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index)
-        return self._cache[index].delete(key)
+        return self._cache[index].delete(key, force)
 
     def search(self, index: str, parent_key: str, search_key: str,
         search_val: str = None) -> list:
@@ -279,9 +279,9 @@ class Conf:
         return Conf._conf.get(index, key, default_val, **filters)
 
     @staticmethod
-    def delete(index: str, key: str):
+    def delete(index: str, key: str, force: bool = False):
         """ Deletes a given key from the config """
-        is_deleted = Conf._conf.delete(index, key)
+        is_deleted = Conf._conf.delete(index, key, force)
         if is_deleted:
             Conf.save(index)
         return is_deleted
@@ -401,6 +401,6 @@ class MappedConf:
         """Returns value for the given key."""
         return Conf.get(self._conf_idx, key, default_val)
 
-    def delete(self, key: str):
+    def delete(self, key: str, force: bool = False):
         """Delete key from CORTX confstore."""
-        return Conf.delete(self._conf_idx, key)
+        return Conf.delete(self._conf_idx, key, force)

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from cortx.utils.schema.payload import Json
 from cortx.utils.conf_store import Conf
 from cortx.utils.schema.format import Format
+from cortx.utils.kv_store.error import KvError
 
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -468,6 +469,31 @@ class TestConfStore(unittest.TestCase):
         Conf.add_num_keys('src_index')
         self.assertEqual(5, Conf.get('src_index', 'num_test_val'))
         self.assertEqual(3, Conf.get('src_index', 'test_nested>2>num_1'))
+
+    def test_delete(self):
+        Conf.load('test_file_1', 'yaml:///tmp/test_file_1.yaml')
+        Conf.set('test_file_1', 'a>b>c>d', 'value1')
+        Conf.set('test_file_1', 'a1>b>c>d[0]', 11)
+        Conf.set('test_file_1', 'a1>b>c>d[1]', 22)
+
+        # Deleting non leaf keys raise KvError
+        with self.assertRaises(KvError):
+            Conf.delete('test_file_1', 'a1>b>c>d')
+        with self.assertRaises(KvError):
+            Conf.delete('test_file_1', 'a>b>c')
+        with self.assertRaises(KvError):
+            Conf.delete('test_file_1', 'a')
+
+        # Delete leaf node
+        self.assertEqual(True, Conf.delete('test_file_1', 'a>b>c>d'))
+        # Deleting empty intermediate key
+        self.assertEqual(True, Conf.delete('test_file_1', 'a>b>c'))
+        # Delete non-leaf key with force:
+        self.assertEqual(True, Conf.delete('test_file_1', 'a>b', True))
+        # Delete top key with force:
+        self.assertEqual(True, Conf.delete('test_file_1', 'a', True))
+        # Delete indexed key
+        self.assertEqual(True,  Conf.delete('test_file_1', 'a1>b>c>d[0]'))
 
     # DictKVstore tests
     def test_001_conf_dictkvstore_get_all_keys(self):


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Disable deletion of non-leaf key until force parameter is passed
# Design
-  recurrsive deletion of keys are restricted until `force=True` is passed to `Conf.delete(index, key, force)`
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
