### PR TITLE
CORTX-29181: Update message_server port if value is None

### DIFF
--- a/py-utils/src/utils/utils_server/utils_server.py
+++ b/py-utils/src/utils/utils_server/utils_server.py
@@ -92,6 +92,6 @@ if __name__ == '__main__':
     message_bus_backend = cluster_conf.get('cortx>utils>message_bus_backend')
     message_server_endpoints = cluster_conf.get(
         f'cortx>external>{message_bus_backend}>endpoints')
-    message_server_port = cluster_conf.get('cortx>utils>message_server_port')
+    message_server_port = cluster_conf.get('cortx>utils>message_server_port', 28300)
     cluster_id = cluster_conf.get('cluster>id')
     MessageServer(message_server_endpoints, message_server_port, cluster_id)


### PR DESCRIPTION
Signed-off-by: Selvakumar <selva.k.nambi@seagate.com>

# Problem Statement
- Message Server runs on 8080 by default since port value is returned as None

# Design
-  ConfStore should set value as 28300(assigned for message_server) if Conf.get returns None

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
