### PR TITLE
CORTX-29256: Patch for force delete in ini and consul 

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -252,7 +252,7 @@ class IniKvPayload(KvPayload):
         except (NoOptionError, NoSectionError):
             return None
 
-    def delete(self, key):
+    def delete(self, key, *args):
         k = key.split(self._delim)
         if len(k) <= 1 or len(k) > 2:
             raise KvError(errno.EINVAL, "Invalid key %s for INI format", key)
@@ -455,9 +455,9 @@ class ConsulKvPayload(KvPayload):
         """ Set the value to the key in consul kv. """
         return self._consul.kv.put(self._store_path + key, str(val))
 
-    def _delete(self, key: str, *args, **kwargs) -> Union[bool, None]:
+    def _delete(self, key: str, data: dict, force: bool = False, *args, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """
-        return self._consul.kv.delete(self._store_path + key)
+        return self._consul.kv.delete(key = self._store_path + key, recurse = force)
 
     def get_data(self, format_type: str = None, *args, **kwargs):
         """ Return a dict of kv pair. """


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Ini test failed in the delete operation

# Design
-  ini doesn't allows multilevel keys hence delete operation is implemented separately, added a force key which is never used as a key can only be leaf node in ini format and having multi-level key will any way throw error as it is not a valid key for ini
-  Consul supports recurrsive deletion of keys if a key is not leaf key `consul.kv.delete(key, recurse=None, cas=None, token=None, dc=None)`, so passed force to recurse enables force deletion of non leaf keys in consul

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
