### PR TITLE
CORTX-29225: Add force option to conf_cli

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -131,7 +131,7 @@ class ConfCli:
         key_list = args.args[0].split(';')
         is_deleted = []
         for key in key_list:
-            status = Conf.delete(ConfCli._index, key)
+            status = Conf.delete(ConfCli._index, key, args.force)
             is_deleted.append(status)
         if any(is_deleted):
             Conf.save(ConfCli._index)
@@ -242,6 +242,8 @@ class DeleteCmd:
             "Example command:\n"
             "# conf json:///tmp/csm.conf delete 'k1>k2;k3'\n\n")
         s_parser.set_defaults(func=ConfCli.delete)
+        s_parser.add_argument('--force', default=False, help=\
+            "force option to delete non-leaf keys")
         s_parser.add_argument('args', nargs='+', default=[], help='args')
 
 

--- a/py-utils/test/conf_store/test_conf_cli.py
+++ b/py-utils/test/conf_store/test_conf_cli.py
@@ -132,6 +132,16 @@ class TestConfCli(unittest.TestCase):
         self.assertTrue(True if result_data[2] == 0 and
             result_data[0]==b'[null]\n' else False, result_data[1])
 
+    def test_conf_cli_delete_non_leafKey(self):
+        # fail for deleting non leaf key without force
+        invalid_delete_cmd = "conf json:///tmp/file1.json delete 'bridge'"
+        invalid_delete_return_code = SimpleProcess(invalid_delete_cmd).run()[-1]
+        self.assertNotEqual(0, invalid_delete_return_code)
+        # passes for deleting non leaf key with force
+        valid_delete_cmd = invalid_delete_cmd + "--force True"
+        valid_delete_return_code = SimpleProcess(valid_delete_cmd).run()[-1]
+        self.assertEqual(0, valid_delete_return_code)
+
     def test_conf_cli_by_format_data(self):
         """ Test by converting data into toml format """
         exp_result = b'- lte_type:\n  - name: 3g\n  - name: 4g\n  ' \


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Add force option to delete non-leaf key and its child key-value pairs
- JIRA: https://jts.seagate.com/browse/CORTX-29225

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [ ] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: Y
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page
