### PR TITLE
CORTX-29208 : Consul backend test cases reaching out to consul endpoints mentioned in cluster.conf

### DIFF
--- a/py-utils/src/test_framework/const.py
+++ b/py-utils/src/test_framework/const.py
@@ -14,10 +14,13 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 CLUSTER_CONF_TESTS = [
+    'conf_store.test_conf_store_conf',
     'iem_framework.test_iem_cli',
+    'iem_framework.test_iem',
+    'kv_store.test_consul_kv_store',
+    'kv_store.test_kv_store',
     'message_bus.test_kvpayload_message',
     'message_bus.test_message_bus',
     'support_bundle.test_support_bundle',
     'support_bundle.test_support_bundle_cli',
-    'iem_framework.test_iem',
     ]

--- a/py-utils/test/conf_store/config.yaml
+++ b/py-utils/test/conf_store/config.yaml
@@ -1,2 +1,2 @@
 conf_url_list:
-  consul_test_index: 'consul://'
+  consul_endpoints: 'cortx>external>consul>endpoints[1]'

--- a/py-utils/test/kv_store/config.yaml
+++ b/py-utils/test/kv_store/config.yaml
@@ -1,0 +1,2 @@
+conf_url_list:
+  consul_endpoints: 'cortx>external>consul>endpoints[1]'

--- a/py-utils/test/kv_store/test_consul_kv_store.py
+++ b/py-utils/test/kv_store/test_consul_kv_store.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # CORTX Python common library.
-# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021, 2022 Seagate Technology LLC and/or its Affiliates
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -17,7 +17,15 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import unittest
+import os
+import errno
+import yaml
 from cortx.utils.kv_store import KvStoreFactory
+from cortx.utils.kv_store.error import KvError
+from cortx.utils.conf_store import Conf
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+url_config_file = os.path.join(dir_path, 'config.yaml')
 
 def test_current_file(file_path):
     kv_store = KvStoreFactory.get_instance(file_path)
@@ -26,7 +34,27 @@ def test_current_file(file_path):
 
 class TestStore(unittest.TestCase):
 
-    loaded_consul = test_current_file('consul://')
+    _cluster_conf_path = ''
+    loaded_consul = ''
+
+    @classmethod
+    def setUpClass(cls, \
+        cluster_conf_path: str = 'yaml:///etc/cortx/cluster.conf'):
+        """Setup test class."""
+        if TestStore._cluster_conf_path:
+            cls.cluster_conf_path = TestStore._cluster_conf_path
+        else:
+            cls.cluster_conf_path = cluster_conf_path
+        with open(url_config_file) as fd:
+            urls = yaml.safe_load(fd)['conf_url_list']
+            endpoint_key = urls['consul_endpoints']
+        Conf.load('config', cls.cluster_conf_path, skip_reload=True)
+        endpoint_url = Conf.get('config', endpoint_key)
+        if endpoint_url is not None and 'http' in endpoint_url:
+            url = endpoint_url.replace('http', 'consul')
+        else:
+            raise KvError(errno.EINVAL, "Invalid consul endpoint key %s", endpoint_key)
+        TestStore.loaded_consul = test_current_file(url)
 
     def test_consul_a_set_get_kv(self):
         """ Test consul kv set and get a KV. """
@@ -74,5 +102,9 @@ class TestStore(unittest.TestCase):
         TestStore.loaded_consul[0].delete(['test>child_key>leaf_key'])
         self.assertEqual(['test>child_key>leaf_key'], out)
 
+
 if __name__ == '__main__':
+    import sys
+    if len(sys.argv) >= 2:
+        TestStore._cluster_conf_path = sys.argv.pop()
     unittest.main()

--- a/py-utils/test/setup.py
+++ b/py-utils/test/setup.py
@@ -73,6 +73,7 @@ setup(
             "ha_dm/test_schema/*.json",
             "iem_framework/*.json",
             "kv_store/*.json",
+            "kv_store/*.yaml",
             "message_bus/*.conf",
             "support_bundle/*.yaml",
         ]


### PR DESCRIPTION
Signed-off-by: VidyaKabber <vidya.kabber@seagate.com>

# Problem Statement
- Consul backend test cases is running on localhost in K8's environment

# Design
- Jira Ticket : [CORTX-29208](https://jts.seagate.com/browse/CORTX-29208)
- 
# Coding 
-  Coding conventions are followed and code is consistent [Y]: 
-  Confirm All CODACY errors are resolved [Y]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ]Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
