### PR TITLE
CORTX-29022: Derive JsonMessageKvStore from DictKvStore 

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -318,7 +318,8 @@ class DictKvStore(KvStore):
         try:
             self.data = json.loads(self._store_path)
         except JSONDecodeError as jerr:
-            raise KvError(errno.EINVAL, "Invalid dict format %s", jerr.__str__())
+            raise KvError(errno.EINVAL, "Invalid %s format %s",
+                self.name, jerr.__str__())
         return KvPayload(self.data, self._delim, recurse=recurse)
 
     def dump(self, data) -> None:
@@ -326,27 +327,10 @@ class DictKvStore(KvStore):
         self._store_path = data.get_data()
 
 
-class JsonMessageKvStore(JsonKvStore):
+class JsonMessageKvStore(DictKvStore):
     """ Represents and In Memory JSON Message """
 
     name = "jsonmessage"
-
-    def __init__(self, store_loc, store_path, delim='>'):
-        """
-        Represents the Json Without FIle
-        :param json_str: Json String to be processed :type: str
-        """
-        JsonKvStore.__init__(self, store_loc, store_path, delim)
-
-    def load(self) -> KvPayload:
-        """ Load json to python Dictionary Object. Returns Dict """
-        import json
-        return KvPayload(json.loads(self._store_path), self._delim)
-
-    def dump(self, data: dict) -> None:
-        """ Sets data after converting to json """
-        import json
-        self._store_path = json.dumps(data.get_data())
 
 
 class PropertiesKvStore(KvStore):

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -78,6 +78,22 @@ class TestConfStore(unittest.TestCase):
         dict_json = Format.dump(dict_data,"json")
         Conf.load('dict', "dict:"+dict_json)
 
+    def test_json_message_kv_store(self):
+        """Tests jsonmessage basic operation."""
+        index = 'json_message_kv_store_index'
+        Conf.load(index, 'jsonmessage:{"key1":"val1"}')
+        self.assertEqual(Conf.get(index, 'key1'), 'val1')
+        Conf.set(index, 'key2', 'val2')
+        self.assertEqual(Conf.get_keys(index),['key1', 'key2'])
+        Conf.set(index, 'key2>key3>key4', 'val4')
+        Conf.delete(index, 'key2>key3>key4')
+        self.assertEqual(Conf.get(index, 'key2>key3>key4'), None)
+        # TODO: Add delete cases when confStore branch is merged
+        # and force option is available
+
+
+
+
     def test_conf_store_load_and_get(self):
         """Test by loading the give config file to in-memory"""
         load_config('sspl_local', 'json:///tmp/file1.json')
@@ -544,6 +560,7 @@ class TestConfStore(unittest.TestCase):
         expected = [{}, {}, {}, {}, {}, {}, 'v14']
         out = Conf.get('dict', 'k14')
         self.assertListEqual(expected, out)
+
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- redundant code in classes JsonMessageKvStore & DictKvStore

# Design
- Derived JsonMessageKvStore from DictKvStore  to avoid redundancy of code
# Coding 
-  derived JsonMessageStore from DictKvStore
# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: N
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Y

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: N
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page: NOT REQUIRED
