### PR TITLE
CORTX-29642: fixed get_keys. Keys were not getting del from get_keys

### DIFF
--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -119,8 +119,6 @@ class KvPayload:
                     when True, returns keys including array index
                     e.g. In case of "xxx[0],xxx[1]", only "xxx" is returned
         """
-        if all([len(filters.items()) == 0, not starts_with]):
-            return self._keys
         keys = []
         if recurse:
             self._get_keys(keys, self._data, None, **filters)

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -136,6 +136,15 @@ class TestConfStore(unittest.TestCase):
         result_data = Conf.get_keys('get_keys_local')
         self.assertTrue(True if 'bridge>name' in result_data else False)
 
+    def test_get_keys_delete(self):
+        """Test get_keys after deletion of a key."""
+        load_config('get_keys_delete', 'json:///tmp/file1.json')
+        Conf.set('get_keys_delete', 'bridge>delete>key', 'del_val')
+        pre_key_list = Conf.get_keys('get_keys_delete')
+        Conf.delete('get_keys_delete', 'bridge>delete>key')
+        post_key_list = Conf.get_keys('get_keys_delete')
+        self.assertTrue( pre_key_list != post_key_list )
+
     def test_conf_store_delete(self):
         """
         Test by removing the key, value to given index and reading it back.


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- After deletetion of keys from conf, Conf.get_keys() still returns the deleted keys.

# Design
-  Fixed the get_keys logic

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [ ] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
