### PR TITLE
CORTX-29612: Use empty string as blank values instead of none

### DIFF
--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -191,7 +191,7 @@ class KvPayload:
                 data[k[0]] = []
             # if index is more than list size, extend the list
             for i in range(len(data[k[0]]), index + 1):
-                data[k[0]].append({})
+                data[k[0]].append('')
             # if this is leaf node of the key
             if len(k) == 1:
                 data[k[0]][index] = val
@@ -347,7 +347,7 @@ class KvPayload:
                 if index == len(data[k[0]]) - 1:
                     del data[k[0]][index]
                 else:
-                    data[k[0]][index] = None
+                    data[k[0]][index] = ''
                 return True
             else:
                 return self._delete(k[1], data[k[0]][index], force)

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -267,7 +267,7 @@ class TestConfStore(unittest.TestCase):
         result_data = Conf.get('set_local_8', 'bridge>lte_type')
         # Expected list should match the result_data list output
         expected_result = [
-            {'name': '3g'}, {'name': '4g'}, 'sample2', {}, {}, 'sample5']
+            {'name': '3g'}, {'name': '4g'}, 'sample2', '', '', 'sample5']
         self.assertListEqual(result_data, expected_result)
 
     def test_conf_store_set_nested_keys(self):
@@ -581,7 +581,7 @@ class TestConfStore(unittest.TestCase):
     def test_012_conf_dictkvstore_set_value_to_indexed_key(self):
         """Test conf store set value to indexed key."""
         Conf.set('dict', 'k14[6]', 'v14')
-        expected = [{}, {}, {}, {}, {}, {}, 'v14']
+        expected = ['', '', '', '', '', '', 'v14']
         out = Conf.get('dict', 'k14')
         self.assertListEqual(expected, out)
 

--- a/py-utils/test/kv_store/test_kv_store.py
+++ b/py-utils/test/kv_store/test_kv_store.py
@@ -468,7 +468,7 @@ class TestStore(unittest.TestCase):
             'bridge>name_list[3]'], ['1', '2', '3', '4'])
         TestStore.loaded_json[0].delete(['bridge>name_list[1]'])
         result_list = TestStore.loaded_json[0].get(['bridge>name_list[1]'])
-        self.assertIsNone(result_list[0])
+        self.assertEqual(result_list[0], '')
 
     def test_no_left_shift_end_list_kvstore(self):
         """


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>
JIRA: https://jts.seagate.com/browse/CORTX-29612

# Problem Statement
- None is being used as blank value which is not a recognized blank value outside python environment(json, ini, yaml) 

# Design
-  Use empty string `' '` as blank values instead of `None`

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: No
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [x] Changes done to WIKI / Confluence page: will be done when feature is released to public
