### PR TITLE
CORTX-29339: remove redundant pip packages check from post_install phase

### DIFF
--- a/py-utils/src/setup/utils.py
+++ b/py-utils/src/setup/utils.py
@@ -71,23 +71,6 @@ class Utils:
     @staticmethod
     def post_install(config_path: str):
         """ Performs post install operations """
-        # Check required python packages
-        # TODO: Remove this python package check as RPM installation
-        # doing the same.
-        with open(f"{Utils.utils_path}/conf/python_requirements.txt") as file:
-            req_pack = []
-            for package in file.readlines():
-                pack = package.strip().split('==')
-                req_pack.append(f"{pack[0]} ({pack[1]})")
-        try:
-            with open(f"{Utils.utils_path}/conf/python_requirements.ext.txt") as extfile :
-                for package in extfile.readlines():
-                    pack = package.strip().split('==')
-                    req_pack.append(f"{pack[0]} ({pack[1]})")
-        except Exception:
-             Log.info("Not found: "+f"{Utils.utils_path}/conf/python_requirements.ext.txt")
-
-        PkgV().validate(v_type='pip3s', args=req_pack)
         default_sb_path = '/var/log/cortx/support_bundle'
         os.makedirs(default_sb_path, exist_ok=True)
 


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- Rpm installation already checks for required pip packages

# Design
- Removed pip packages validation in the post_install phase
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]:  Not required
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Not required
- [x] Confirm Testing was performed with installed RPM [Y/N]:  Not required

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [x] Is there a change in filename/package/module or signature [Y/N]: N
- [x] If yes for above point, Is a notification sent to all other cortx components [Y/N]: N
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified: N

# Documentation
- [x] Changes done to WIKI / Confluence page: NO change in confluence page required
