### PR TITLE
CORTX-29608: Disable set api for non string type values in confstore

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -55,9 +55,9 @@ class ConfCache:
         """ Returns the value corresponding to the key """
         return self._data.get(key, **filters)
 
-    def set(self, key: str, val):
+    def set(self, key: str, val, force):
         """ Sets the value into the DB for the given key """
-        self._data.set(key, val)
+        self._data.set(key, val, force)
         self._dirty = True
 
     def add_num_keys(self):

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -50,6 +50,7 @@ class ConfCli:
     @staticmethod
     def set(args):
         """ Set Key Value """
+        force = args.force
         kv_delim = '=' if args.kv_delim == None else args.kv_delim
         if len(kv_delim) > 1 or kv_delim not in [':', '>', '.', '|', '/', '=']:
             raise ConfError(errno.EINVAL, "invalid delim %s", kv_delim)
@@ -59,7 +60,7 @@ class ConfCli:
                 key, val = kv.split(kv_delim, 1)
             except:
                raise ConfError(errno.EINVAL, "Invalid KV pair %s", kv)
-            Conf.set(ConfCli._index, key, val)
+            Conf.set(ConfCli._index, key, val, force)
         Conf.save(ConfCli._index)
 
     @staticmethod
@@ -129,9 +130,10 @@ class ConfCli:
     def delete(args):
         """ Deletes given set of keys from the config """
         key_list = args.args[0].split(';')
+        force = args.force
         is_deleted = []
         for key in key_list:
-            status = Conf.delete(ConfCli._index, key, args.force)
+            status = Conf.delete(ConfCli._index, key, force)
             is_deleted.append(status)
         if any(is_deleted):
             Conf.save(ConfCli._index)
@@ -211,6 +213,8 @@ class SetCmd:
         s_parser.set_defaults(func=ConfCli.set)
         s_parser.add_argument('-d', dest='kv_delim',
             help="Delimiter for k=v (default is '=')")
+        s_parser.add_argument('--force', default=False, help=\
+            "force option to set non string values")
         s_parser.add_argument('args', nargs='+', default=[], help='args')
 
 

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -127,7 +127,7 @@ class ConfStore:
         val = self._cache[index].get(key, **filters)
         return default_val if val is None else val
 
-    def set(self, index: str, key: str, val):
+    def set(self, index: str, key: str, val, force: bool = False):
         """
         Sets the value into the DB for the given index, key
 
@@ -142,7 +142,7 @@ class ConfStore:
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index)
 
-        self._cache[index].set(key, val)
+        self._cache[index].set(key, val, force)
 
     def get_keys(self, index: str, **filters) -> list:
         """
@@ -269,9 +269,9 @@ class Conf:
         Conf._conf.save(index)
 
     @staticmethod
-    def set(index: str, key: str, val):
+    def set(index: str, key: str, val, force: bool = False):
         """ Sets config value for the given key """
-        Conf._conf.set(index, key, val)
+        Conf._conf.set(index, key, val, force)
 
     @staticmethod
     def get(index: str, key: str, default_val: str = None, **filters):
@@ -367,10 +367,10 @@ class MappedConf:
                     f' in confstore. {e}')
         Conf.save(self._conf_idx)
 
-    def set(self, key: str, val: str):
+    def set(self, key: str, val: str, force: bool = False):
         """Save key-value in CORTX confstore."""
         try:
-            Conf.set(self._conf_idx, key, val)
+            Conf.set(self._conf_idx, key, val, force)
             Conf.save(self._conf_idx)
         except (AssertionError, ConfError) as e:
             raise ConfError(errno.EINVAL,

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -184,7 +184,7 @@ class ConfStore:
         self._cache[index].add_num_keys()
 
     def copy(self, src_index: str, dst_index: str, key_list: list = None,
-        recurse: bool = True):
+        recurse: bool = True, force: bool = False):
         """
         Copies one config domain to the other and saves
 
@@ -206,9 +206,10 @@ class ConfStore:
             else:
                 key_list = self._cache[src_index].get_keys(key_index=False)
         for key in key_list:
-            self._cache[dst_index].set(key, self._cache[src_index].get(key))
+            self._cache[dst_index].set(key, self._cache[src_index].get(key), force)
 
-    def merge(self, dest_index: str, src_index: str, keys: list = None):
+    def merge(self, dest_index: str, src_index: str, keys: list = None, \
+        force: bool = False):
         """
         Merges the content of src_index and dest_index file
 
@@ -233,12 +234,12 @@ class ConfStore:
                 if not self._cache[src_index].get(key):
                     raise ConfError(errno.ENOENT, "%s is not present in %s", \
                         key, src_index)
-        self._merge(dest_index, src_index, keys)
+        self._merge(dest_index, src_index, keys, force)
 
-    def _merge(self, dest_index, src_index, keys):
+    def _merge(self, dest_index, src_index, keys, force):
         for key in keys:
             if key not in self._cache[dest_index].get_keys():
-                self._cache[dest_index].set(key, self._cache[src_index].get(key))
+                self._cache[dest_index].set(key, self._cache[src_index].get(key), force)
 
 
 class Conf:
@@ -290,8 +291,8 @@ class Conf:
         Conf._conf.copy(src_index, dst_index, key_list, recurse)
 
     @staticmethod
-    def merge(dest_index: str, src_index: str, keys: list = None):
-        Conf._conf.merge(dest_index, src_index, keys)
+    def merge(dest_index: str, src_index: str, keys: list = None, force: bool = False):
+        Conf._conf.merge(dest_index, src_index, keys, force)
 
     class ClassProperty(property):
         """ Subclass property for classmethod properties """
@@ -351,7 +352,7 @@ class MappedConf:
         self._conf_url = conf_url
         Conf.load(self._conf_idx, self._conf_url, skip_reload=True)
 
-    def set_kvs(self, kvs: list):
+    def set_kvs(self, kvs: list, force: bool = False):
         """
         Parameters:
         kvs - List of KV tuple, e.g. [('k1','v1'),('k2','v2')]
@@ -360,7 +361,7 @@ class MappedConf:
 
         for key, val in kvs:
             try:
-                Conf.set(self._conf_idx, key, val)
+                Conf.set(self._conf_idx, key, val, force)
             except (AssertionError, ConfError) as e:
                 raise ConfError(errno.EINVAL,
                     f'Error occurred while adding key {key} and value {val}'

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -209,7 +209,7 @@ class KvPayload:
                 self._set(k[1], val, data[k[0]][index], force)
             return
 
-        # Leaf node check 
+        # Leaf node check
         if len(k) == 1:
             # if this is leaf node of the key
             data[k[0]] = val

--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -435,9 +435,9 @@ class ConsulKvPayload(KvPayload):
             raise KvError(errno.EINVAL, \
                 "Invalid response from consul: %d:%s", index, data)
 
-    def _set(self, key: str, val: str, *args, force: bool = False, **kwargs) -> Union[bool, None]:
+    def _set(self, key: str, val: str, force: bool = False, *args, **kwargs) -> Union[bool, None]:
         """ Set the value to the key in consul kv. """
-        if not isinstance(val, (int, str, byte)):
+        if not isinstance(val, (int, str, bytes)):
             if force:
                 return self._consul.kv.put(self._store_path + key, str(val))
             else:
@@ -445,7 +445,7 @@ class ConsulKvPayload(KvPayload):
                 type. Value should be a 'str' type", val)
         return self._consul.kv.put(self._store_path + key, val)
 
-    def _delete(self, key: str, data: dict, *args, force: bool = False, **kwargs) -> Union[bool, None]:
+    def _delete(self, key: str, data: dict, force: bool = False, *args, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """
         return self._consul.kv.delete(key = self._store_path + key, recurse = force)
 

--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -232,7 +232,7 @@ class IniKvPayload(KvPayload):
             for key in [option for option in self._data[section]]:
                 keys.append(f"{section}{self._delim}{key}")
 
-    def set(self, key, val):
+    def set(self, key, val, *args):
         k = key.split(self._delim)
         if len(k) <= 1 or len(k) > 2:
             raise KvError(errno.EINVAL, "Invalid key %s for INI format", key)
@@ -435,11 +435,17 @@ class ConsulKvPayload(KvPayload):
             raise KvError(errno.EINVAL, \
                 "Invalid response from consul: %d:%s", index, data)
 
-    def _set(self, key: str, val: str, *args, **kwargs) -> Union[bool, None]:
+    def _set(self, key: str, val: str, *args, force: bool = False, **kwargs) -> Union[bool, None]:
         """ Set the value to the key in consul kv. """
-        return self._consul.kv.put(self._store_path + key, str(val))
+        if not isinstance(val, (int, str, byte)):
+            if force:
+                return self._consul.kv.put(self._store_path + key, str(val)) \
+            else:
+                raise KvError(errno.EINVAL, "Invalid value: %s \
+                type. Value should be a 'str' type", val)
+        return self._consul.kv.put(self._store_path + key, val)
 
-    def _delete(self, key: str, data: dict, force: bool = False, *args, **kwargs) -> Union[bool, None]:
+    def _delete(self, key: str, data: dict, *args, force: bool = False, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """
         return self._consul.kv.delete(key = self._store_path + key, recurse = force)
 

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -184,12 +184,11 @@ class TestConfStore(unittest.TestCase):
         Test by setting the key, value to given index and reading it back.
         """
         load_config('set_local1', 'json:///tmp/file1.json')
-        Conf.set('set_local', 'bridge>lte_type[2]>test',
-                       {'name': '5g', 'location': 'NY'})
-        result_data = Conf.get('set_local', 'bridge>lte_type[2]>test>location')
+        Conf.set('set_local', 'bridge>lte_type[2]>test', 'NY')
+        result_data = Conf.get('set_local', 'bridge>lte_type[2]>test')
         self.assertEqual(result_data, 'NY')
 
-    def test_conf_store_set_value_then_dict(self):
+    def test_conf_store_set_value_then_dict_force_true(self):
         """
         Test by setting the key, string value to given index and
         then try to overwrite it with dict.
@@ -198,19 +197,19 @@ class TestConfStore(unittest.TestCase):
         # set string value
         Conf.set('set_local_2', 'bridge>lte_type[2]>test', 'sample')
         Conf.set('set_local_2', 'bridge>lte_type[2]>test>nested_test',
-                       {'name': '5g', 'location': 'NY'})
+                       {'name': '5g', 'location': 'NY'}, force=True)
         result_data = Conf.get('set_local_2',
                                'bridge>lte_type[2]>test>nested_test>location')
         self.assertEqual(result_data, 'NY')
 
-    def test_conf_store_set_dict_then_string(self):
+    def test_conf_store_set_dict_with_force_then_string(self):
         """
         Test by setting the key, dict value to given index and
         then try to overwrite it with a string.
         """
         load_config('set_local_3', 'json:///tmp/file1.json')
         Conf.set('set_local_3', 'bridge>lte_type[2]>test>nested_test',
-                       {'name': '5g', 'location': 'NY'})
+                       {'name': '5g', 'location': 'NY'}, force=True)
         Conf.set('set_local_3', 'bridge>lte_type[2]>test', 'sample')
         result_data = Conf.get('set_local_3', 'bridge>lte_type[2]>test')
         self.assertEqual(result_data, 'sample')
@@ -231,8 +230,7 @@ class TestConfStore(unittest.TestCase):
         """
         load_config('set_local_6', 'json:///tmp/file1.json')
         try:
-            Conf.set('set_local_6', 'bridge>lte_type[2]>..',
-                           {'name': '5g', 'location': 'NY'})
+            Conf.set('set_local_6', 'bridge>lte_type[2]>..', '5g')
         except Exception as err:
             self.assertEqual('Invalid key name ', err.desc)
 
@@ -264,12 +262,12 @@ class TestConfStore(unittest.TestCase):
         """Set a non string value."""
         load_config('mem_dict', 'dict:{}')
         with self.assertRaises(KvError):
-            conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'])
+            Conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'])
 
     def test_conf_set_non_str_value_with_force(self):
         """Set a non string value."""
         load_config('mem_dict', 'dict:{}')
-        conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'], force=True)
+        Conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'], force=True)
         get_val = Conf.get('mem_dict', 'K1>K2>K3[0]')
         self.assertEqual(get_val, '1')
 
@@ -447,7 +445,7 @@ class TestConfStore(unittest.TestCase):
 
     def test_conf_store_merge_01new_file(self):
         self.assertEqual(Conf.get_keys('dest_index'), [])
-        Conf.merge('dest_index', 'src_index')
+        Conf.merge('dest_index', 'src_index', force=True)
         Conf.save('dest_index')
         self.assertEqual(Conf.get_keys('dest_index'),
             Conf.get_keys('src_index'))

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -52,7 +52,7 @@ def setup_and_generate_sample_files():
 
 def load_config(index, backend_url):
     """Instantiate and Load Config into constore"""
-    Conf.load(index, backend_url)
+    Conf.load(index, backend_url, fail_reload=False)
     return Conf
 
 
@@ -225,16 +225,6 @@ class TestConfStore(unittest.TestCase):
         except Exception as err:
             self.assertEqual('Invalid key index for the key lte_type', err.desc)
 
-    def test_conf_store_get_null_index(self):
-        """
-        Test by getting the null index key.
-        """
-        load_config('set_local_5', 'json:///tmp/file1.json')
-        try:
-            Conf.get('set_local_5', 'bridge>lte_type[]')
-        except Exception as err:
-            self.assertEqual('Invalid key index for the key lte_type', err.desc)
-
     def test_conf_store_set_with_wrong_key(self):
         """
         Test by setting the value to invalid wrong key.
@@ -243,16 +233,6 @@ class TestConfStore(unittest.TestCase):
         try:
             Conf.set('set_local_6', 'bridge>lte_type[2]>..',
                            {'name': '5g', 'location': 'NY'})
-        except Exception as err:
-            self.assertEqual('Invalid key name ', err.desc)
-
-    def test_conf_store_get_with_wrong_key(self):
-        """
-        Test by getting the invalid wrong key
-        """
-        load_config('set_local_7', 'json:///tmp/file1.json')
-        try:
-            Conf.get('set_local_7', 'bridge>lte_type[2]>..>location')
         except Exception as err:
             self.assertEqual('Invalid key name ', err.desc)
 
@@ -280,6 +260,26 @@ class TestConfStore(unittest.TestCase):
         result_data = Conf.get('set_local_9', 'bridge>nstd>k1>k2>k3>k4>5>6>7')
         self.assertEqual(result_data, 'okay')
 
+    def test_conf_set_non_str_value_without_force(self):
+        """Set a non string value."""
+        load_config('mem_dict', 'dict:{}')
+        with self.assertRaises(KvError):
+            conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'])
+
+    def test_conf_set_non_str_value_with_force(self):
+        """Set a non string value."""
+        load_config('mem_dict', 'dict:{}')
+        conf.set('mem_dict', 'K1>K2>K3', ['1','2','3'], force=True)
+        get_val = Conf.get('mem_dict', 'K1>K2>K3[0]')
+        self.assertEqual(get_val, '1')
+
+    def test_conf_set_byte_array_without_force(self):
+        """Set a non string value."""
+        load_config('mem_dict', 'dict:{}')
+        Conf.set('mem_dict', 'K1>K2>K3', b'qaz12')
+        val = Conf.get('mem_dict', 'K1>K2>K3')
+        self.assertEqual(val, b'qaz12')
+
     def test_conf_store_delete_with_index(self):
         """ Test by removing the key, value from the given index. """
         load_config('delete_local_index', 'json:///tmp/file1.json')
@@ -306,6 +306,26 @@ class TestConfStore(unittest.TestCase):
         Conf.set('at_local', 'bridge>proxy@type', 'cloud')
         result_data = Conf.get('at_local', 'bridge>proxy@type')
         self.assertEqual(result_data, 'cloud')
+
+    def test_conf_store_get_with_wrong_key(self):
+        """
+        Test by getting the invalid wrong key
+        """
+        load_config('set_local_7', 'json:///tmp/file1.json')
+        try:
+            Conf.get('set_local_7', 'bridge>lte_type[2]>..>location')
+        except Exception as err:
+            self.assertEqual('Invalid key name ', err.desc)
+
+    def test_conf_store_get_null_index(self):
+        """
+        Test by getting the null index key.
+        """
+        load_config('set_local_5', 'json:///tmp/file1.json')
+        try:
+            Conf.get('set_local_5', 'bridge>lte_type[]')
+        except Exception as err:
+            self.assertEqual('Invalid key index for the key lte_type', err.desc)
 
     # Properties test
     def test_conf_store_by_load_and_get(self):
@@ -355,6 +375,18 @@ class TestConfStore(unittest.TestCase):
             'bridge>manufacturer', 'bridge>model', 'bridge>pin', 'bridge>port',
             'bridge>lte_type>name', 'node_count']
         self.assertListEqual(key_lst, expected_list)
+
+    def test_conf_get_keys_after_set_byte_array(self):
+        """Test get_keys before n after setting a byte array."""
+        load_config('mem_dict', 'dict:{}')
+        Conf.set('mem_dict', 'K1>K2>K3', 'Val3')
+        Conf.set('mem_dict', 'K1>K2>K4', 'Val4')
+        pre_get_keys = Conf.get_keys('mem_dict')
+        Conf.set('mem_dict', 'K1>K2>K5', b'qaz12')
+        post_get_keys = Conf.get_keys('mem_dict')
+        #add added key to pre_get_keys
+        pre_get_keys.append('K1>K2>K5')
+        self.assertEqual(pre_get_keys, post_get_keys)
 
     def test_conf_store_get_machine_id_none(self):
         """ Test get_machine_id None value """

--- a/py-utils/test/conf_store/test_conf_store_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_conf.py
@@ -22,6 +22,7 @@ import os
 import errno
 from cortx.utils.conf_store import Conf
 from cortx.utils.conf_store.error import ConfError
+from cortx.utils.kv_store.error import KvError
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 url_config_file = os.path.join(dir_path, 'config.yaml')
@@ -104,6 +105,13 @@ class TestConfStore(unittest.TestCase):
             val = Conf.get(index, 'K1')
             self.assertEqual(val, None)
 
+    def test_set_list_value(self):
+        """Set list type as value."""
+        for index in TestConfStore.indexes:
+            # Setting a list as value raises KvError!
+            # only str/int/byte array allowed as value of a K:V pair
+            with self.assertRaises(KvError):
+                Conf.set(index, 'K1', ['V1', 'V2'])
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- non str values should not be allowed to set in conf/kv store. #Supporting byte strings

# Design
-  checking for type of input value provided by user. #Supporting byte strings

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing 
- [x] Confirm that Test Cases are added (for both the cases, fix and feature) [Y/N]: 
- [x] Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- [x] Confirm Testing was performed with installed RPM [Y/N]:  

# Review Checklist 
  Before posting the PR please ensure
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified 

# Documentation
- [ ] Changes done to WIKI / Confluence page
