### PR TITLE
CORTX-23443:  adding retry decorator in consul confstore in main

### DIFF
--- a/py-utils/src/utils/common/__init__.py
+++ b/py-utils/src/utils/common/__init__.py
@@ -18,7 +18,8 @@
 from cortx.utils.common.errors import SetupError
 from cortx.utils.common.errors import UtilsError
 from cortx.utils.common.common import CortxConf
+from cortx.utils.common.common import ExponentialBackoff
 from cortx.utils.common.dbconf import DbConf
 
 # adds all above defined packages in import *
-__all__ = ('SetupError', 'UtilsError', 'CortxConf', 'DbConf')
+__all__ = ('SetupError', 'UtilsError', 'CortxConf', 'ExponentialBackoff', 'DbConf')

--- a/py-utils/src/utils/common/common.py
+++ b/py-utils/src/utils/common/common.py
@@ -1,9 +1,53 @@
 import os
 import errno
+import time
+from functools import wraps
 
 from cortx.utils.conf_store import Conf
 from cortx.utils.conf_store.error import ConfError
 
+class ExponentialBackoff:
+    """
+    ExponentialBackoff decorator class can decorate a function/method to set a retry logic
+    to its call.It Retries the *calling of decorated function*, using a capped exponential
+    backoff.
+    Example:
+    @ExponentialBackoff(ValueError)
+    def foo(x, y=10):
+        ...
+    or
+    @ExponentialBackoff(Exception, tries=2, delay=10, backoff=2, cap=2)
+    def bar():
+        ...
+    Args:
+        exception (Exception or tuple(Exception)):  it can be a single exception
+                                                    or a tuple of exceptions.
+        tries (int): 10     number of times to try before failing.
+        delay (int): 1      initiall delay (in seconds) between retries.
+        backoff (int): 2    backoff multiplier.
+        cap (int): 120      cap for maximum delay (in seconds) between retries
+    """
+    def __init__(self, exception, tries=10, delay=1, backoff=2, cap=120):
+        """Constructor method."""
+        self._exception = exception
+        self._tries = tries
+        self._delay = delay
+        self._backoff = backoff
+        self._cap = cap
+
+    def __call__(self, func):
+        @wraps(func)
+        def wrap(*args, **kwargs):
+            cap, max_tries, max_delay = self._cap, self._tries, self._delay
+            while max_tries > 1:
+                try:
+                    return func(*args, **kwargs)
+                except self._exception:
+                    time.sleep(min(cap, max_delay))
+                    max_tries -= 1
+                    max_delay *= self._backoff
+            return func (*args, **kwargs)
+        return wrap
 
 class CortxConf:
     _index = 'config_file'

--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -18,13 +18,16 @@
 import errno
 import os
 from typing import Union
-from consul import Consul
+from consul import Consul, ConsulException
+from requests.exceptions import RequestException
+from urllib.error import HTTPError
 from configparser import ConfigParser, NoOptionError, NoSectionError
 
 from cortx.utils.kv_store.error import KvError
 from cortx.utils.kv_store.kv_store import KvStore
 from cortx.utils.kv_store.kv_payload import KvPayload
 from cortx.utils.process import SimpleProcess
+from cortx.utils.common import ExponentialBackoff
 
 
 class JsonKvStore(KvStore):
@@ -420,6 +423,7 @@ class ConsulKvPayload(KvPayload):
             if not self._store_path.endswith('/'): self._store_path = self._store_path + '/'
         self._keys = self.get_keys()
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def get(self, key: str, *args, **kwargs) -> str:
         """ Get value for consul key. """
         if not key in self._keys:
@@ -435,14 +439,17 @@ class ConsulKvPayload(KvPayload):
             raise KvError(errno.EINVAL, \
                 "Invalid response from consul: %d:%s", index, data)
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def _set(self, key: str, val: str, *args, **kwargs) -> Union[bool, None]:
         """ Set the value to the key in consul kv. """
         return self._consul.kv.put(self._store_path + key, str(val))
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def _delete(self, key: str, *args, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """
         return self._consul.kv.delete(self._store_path + key)
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def get_data(self, format_type: str = None, *args, **kwargs):
         """ Return a dict of kv pair. """
         self._data = {}
@@ -454,6 +461,7 @@ class ConsulKvPayload(KvPayload):
             return self._data
         return Format.dump(self._data, format_type)
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def get_keys(self, starts_with: str = '', *args, **kwargs) -> list:
         """ Return a list of all the keys present. """
         keys=[]
@@ -474,6 +482,7 @@ class ConsulKvPayload(KvPayload):
                 keys.extend(key_list)
         return keys
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def search(self, parent_key: str, search_key: str, search_val: str) -> list:
         """
         Searches the given dictionary for the key and value.
@@ -511,6 +520,7 @@ class ConsulKVStore(KvStore):
                 "Failed to eshtablish a new connection to consul endpoint: %s.\n %s", \
                 store_loc, e)
 
+    @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def load(self, **kwargs) -> ConsulKvPayload:
         """ Return ConsulKvPayload object. """
         return self._payload


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- Since confstore branch is discarded, raised a separate PR for retry mechanism in consul.

# Design
-  These changes are pre approved changes from confstore branch, now raised the same changes against main branch.
relevant PRs: https://github.com/Seagate/cortx-utils/pull/776, https://github.com/Seagate/cortx-utils/pull/753

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
