### PR TITLE
CORTX-30863: added unittest for mapped conf api add_num_keys

### DIFF
--- a/py-utils/test/conf_store/test_conf_store_mapped_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_mapped_conf.py
@@ -41,12 +41,11 @@ def delete_file(file):
         print(e)
 
 class TestMappedConf(unittest.TestCase):
-    
     """Test MappedConf."""
 
     def test_mapped_conf_add_num_keys(self):
         """Test if add_num_keys adds num_xx keys for xx list in the given config."""
-        data = { 
+        data = {
             'a' : '1',
             'b' : ['2', {'3': ['5', '6']}, '4']
         }
@@ -57,7 +56,7 @@ class TestMappedConf(unittest.TestCase):
         cortx_conf.add_num_keys()
         test_index = 'test_index1'
         Conf.load(test_index, conf_url)
-        # Test before saving 
+        # Test before saving
         self.assertIsNone(Conf.get(test_index, 'num_b'), "num_b key is added without even saving to conf")
         self.assertIsNone(Conf.get(test_index, 'b>num_3'), "num_b key is added without even saving to conf")
         # Test after saving

--- a/py-utils/test/conf_store/test_conf_store_mapped_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_mapped_conf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import os
+import unittest
+import yaml
+
+from cortx.utils.conf_store import MappedConf, Conf
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+def create_file(file, data=""):
+    """Creates temporary file."""
+    try:
+        with open(file, 'w+') as temp_file:
+            temp_file.write(data)
+    except OSError as e:
+        print(e)
+
+def delete_file(file):
+    """Deletes temporary files."""
+    try:
+        if os.path.exists(file):
+            os.remove(file)
+    except OSError as e:
+        print(e)
+
+class TestMappedConf(unittest.TestCase):
+    """Test MappedConf."""
+
+    def test_mapped_conf_add_num_keys(self):
+        """Test if add_num_keys adds num_xx keys for xx list in the given config."""
+        data = { 
+            'a' : '1',
+            'b' : ['2', {'3': ['5', '6']}, '4']
+        }
+        sample_file = f"{dir_path}/sample_conf.yaml"
+        create_file(sample_file, yaml.dump(data))
+        conf_url = f"yaml:///{sample_file}"
+        cortx_conf = MappedConf(conf_url)
+        cortx_conf.add_num_keys()
+        test_index = 'test_index1'
+        Conf.load(test_index, conf_url)
+        # Test before saving 
+        self.assertIsNone(Conf.get(test_index, 'num_b'), "num_b key is added without even saving to conf")
+        self.assertIsNone(Conf.get(test_index, 'b>num_3'), "num_b key is added without even saving to conf")
+        # Test after saving
+        test_index = 'test_index2'
+        conf_id = cortx_conf._conf_idx
+        Conf.save(conf_id)
+        Conf.load(test_index, conf_url)
+        self.assertEqual(Conf.get(test_index, 'num_b'), 3)
+        self.assertEqual(Conf.get(test_index, 'b[1]>num_3'), 2)
+        delete_file(sample_file)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py-utils/test/conf_store/test_conf_store_mapped_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_mapped_conf.py
@@ -46,8 +46,8 @@ class TestMappedConf(unittest.TestCase):
     def test_mapped_conf_add_num_keys(self):
         """Test if add_num_keys adds num_xx keys for xx list in the given config."""
         data = {
-            'a' : '1',
-            'b' : ['2', {'3': ['5', '6']}, '4']
+            'a': '1',
+            'b': ['2', {'3': ['5', '6']}, '4']
         }
         sample_file = f"{dir_path}/sample_conf.yaml"
         create_file(sample_file, yaml.dump(data))
@@ -58,7 +58,7 @@ class TestMappedConf(unittest.TestCase):
         Conf.load(test_index, conf_url)
         # Test before saving
         self.assertIsNone(Conf.get(test_index, 'num_b'), "num_b key is added without even saving to conf")
-        self.assertIsNone(Conf.get(test_index, 'b>num_3'), "num_b key is added without even saving to conf")
+        self.assertIsNone(Conf.get(test_index, 'b[1]>num_3'), "num_b key is added without even saving to conf")
         # Test after saving
         test_index = 'test_index2'
         conf_id = cortx_conf._conf_idx

--- a/py-utils/test/conf_store/test_conf_store_mapped_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_mapped_conf.py
@@ -41,6 +41,7 @@ def delete_file(file):
         print(e)
 
 class TestMappedConf(unittest.TestCase):
+    
     """Test MappedConf."""
 
     def test_mapped_conf_add_num_keys(self):


### PR DESCRIPTION
Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
- Fix the problem where any operation like add_num_keys, or set, or delete is in memory operation and should not reflected until explicit save

# Design
-  adding unit test cases to cover the problem statement scenario
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [x] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [x] Changes done to WIKI / Confluence page
