### PR TITLE
CORTX-29731: system_health even-id getting floating value

### DIFF
--- a/py-utils/src/utils/event_framework/event.py
+++ b/py-utils/src/utils/event_framework/event.py
@@ -44,11 +44,11 @@ class Event(KvPayload):
         """Initialize event object with header and payload attributes."""
         super().__init__()
         # Set Header
-        _now = str(time.time())
+        _now = time.time()
         _uuid = str(uuid.uuid4().hex)
         super().set(f'header>{EventAttr.VERSION}', VERSION)
-        super().set(f'header>{EventAttr.TIMESTAMP}', _now)
-        super().set(f'header>{EventAttr.EVENT_ID}', _now + _uuid)
+        super().set(f'header>{EventAttr.TIMESTAMP}', str(_now))
+        super().set(f'header>{EventAttr.EVENT_ID}', str(int(_now)) + _uuid)
         # Set payload if required
         for key in payload.get_keys():
             super().set(f'payload>{key}', payload.get(key))

--- a/py-utils/src/utils/event_framework/event.py
+++ b/py-utils/src/utils/event_framework/event.py
@@ -44,11 +44,12 @@ class Event(KvPayload):
         """Initialize event object with header and payload attributes."""
         super().__init__()
         # Set Header
-        _now = time.time()
+        _now = str(time.time())
         _uuid = str(uuid.uuid4().hex)
+        _event_id = _now.split('.')[0] + _uuid
         super().set(f'header>{EventAttr.VERSION}', VERSION)
-        super().set(f'header>{EventAttr.TIMESTAMP}', str(_now))
-        super().set(f'header>{EventAttr.EVENT_ID}', str(int(_now)) + _uuid)
+        super().set(f'header>{EventAttr.TIMESTAMP}', _now)
+        super().set(f'header>{EventAttr.EVENT_ID}', _event_id)
         # Set payload if required
         for key in payload.get_keys():
             super().set(f'payload>{key}', payload.get(key))

--- a/py-utils/test/event_framework/test_health_event.py
+++ b/py-utils/test/event_framework/test_health_event.py
@@ -18,6 +18,7 @@
 
 import unittest
 from cortx.utils.event_framework.health import HealthEvent, HealthAttr
+from cortx.utils.event_framework.event import EventAttr
 
 class TestHealthEvent(unittest.TestCase):
     """Test health event message schema handling."""
@@ -59,5 +60,9 @@ class TestHealthEvent(unittest.TestCase):
         # Other attributes remain empty strings if not set
         self.assertEqual(he.get(f'payload>{HealthAttr.RESOURCE_ID}'), '')
 
+    def test_health_event_id(self):
+        """Check event id is not floating value."""
+        he = HealthEvent()
+        self.assertFalse('.' in he.get(f'header>{EventAttr.EVENT_ID}'))
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: gauri-bhosale <gauri.bhosale@seagate.com>

# Problem Statement
-  https://jts.seagate.com/browse/CORTX-29731

# Design
- event_id should contain timestamp but not should contain floating value 
- so need to convert into integer before string conversion

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]:  Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]: Y
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]: Y
- Confirm that Test Cases are added for new features added [Y/N]:  Y 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  Y

# Review Checklist 
####  Before posting the PR please ensure:
- [X] PR is self reviewed
- [X] Jira is updated
- [X] Check if the description is clear and explained. 
- [X] Check Acceptance Criterion is defined. 
- [X] All the tests performed should be mentioned before Resolving a JIRA. 
- [X] Verification needs to be done before marked as Closed/Verified.

# Documentation
- [X] Changes done to WIKI / Confluence page

Testing result :
sh-4.4# pytest test_health_event.py
======================================= test session starts ========================================
platform linux -- Python 3.6.8, pytest-7.0.1, pluggy-1.0.0
rootdir: /etc/cortx
collected 3 items

test_health_event.py ...                                                                     [100%]

======================================== 3 passed in 0.02s =========================================
sh-4.4#

Sample local test :
[root@ssc-vm-g3-rhev4-2813 event_framework1]# python3 health.py
if returnkeysss
{"header": {"version": "1.0", "timestamp": "1651219774.4916775", "event_id": "16512197748aef6b536ea641f39371519fe45fabbe"}, "payload": {"source": "", "cluster_id": "", "site_id": "", "rack_id": "", "storageset_id": "", "node_id": "", "resource_type": "", "resource_status": "", "specific_info": ""}}
if returnkeysss
if returnkeysss
{"header": {"version": "1.0", "timestamp": "1651219774.494863", "event_id": "1651219774fee9e4c295114e5b8a16dcd59937eff9"}, "payload": {"source": "s1", "cluster_id": "1234", "site_id": "1", "rack_id": "1", "storageset_id": "1", "node_id": "3", "resource_type": "node", "resource_status": "ok", "specific_info": {"a": "a1", "b": true}}}
[root@ssc-vm-g3-rhev4-2813 event_framework1]#
