### PR TITLE
[WIP] CORTX-31132: added conf.compare in confstore for comparing two indexes

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -125,6 +125,16 @@ class ConfCli:
         Conf.merge(dest_index, src_index, keys)
         Conf.save(dest_index)
 
+
+    @staticmethod
+    def compare(args):
+        """Compares two conf urls and return 3 lists: new_keys, deleted_keys, updated_keys."""
+        index1 = ConfCli._index
+        index2 = 'index2'
+        ConfCli.load(args.second_url, index2)
+        return Conf.compare(index1, index2)
+
+
     @staticmethod
     def delete(args):
         """ Deletes given set of keys from the config """
@@ -281,6 +291,20 @@ class MergeCmd:
         s_parser.set_defaults(func=ConfCli.merge)
         s_parser.add_argument('-k', dest='keys',  nargs='+', default=[], \
             help='Only specified keys will be merged.')
+
+
+class CompareCmd:
+    """ Get Compare Cmd Structure """
+
+    @staticmethod
+    def add_args(sub_parser) -> None:
+        s_parser = sub_parser.add_parser('compare', help=
+            "Compares two given urls\n."
+            "Where it returns new_keys, deleted_keys and updated_keys lists by comparing url2 with url1\n"
+            "Example command:\n"
+            "# conf yaml:///tmp/url1.conf compare yaml:///tmp/url2.conf\n\n")
+        s_parser.add_argument('second_url', help='second url for compare')
+        s_parser.set_defaults(func=ConfCli.compare)
 
 
 class SearchCmd:

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -208,6 +208,31 @@ class ConfStore:
         for key in key_list:
             self._cache[dst_index].set(key, self._cache[src_index].get(key))
 
+    def compare(self, index1: str, index2: str):
+        """
+        Compares two configs and returns difference
+
+        Parameters:
+        index1 : Conf Index 1 
+        index2 : Conf Index 2
+
+        Return Value:
+        Returns three lists : New keys, deleted keys, Updated keys
+        """
+        if index1 not in self._cache.keys():
+            raise ConfError(errno.EINVAL, "config index %s is not loaded",
+                index1)
+        if index2 not in self._cache.keys():
+            raise ConfError(errno.EINVAL, "config index %s is not loaded",
+                index2)
+        
+        key_list1 = self._cache[index1].get_keys()
+        key_list2 = self._cache[index2].get_keys()
+        deleted_keys = list(set(key_list1).difference(key_list2))
+        new_keys = list(set(key_list2).difference(key_list1))
+        updated_keys = list(filter(lambda key: key not in deleted_keys and self._cache[index1].get(key) != self._cache[index2].get(key), key_list1))
+        return new_keys, deleted_keys, updated_keys
+
     def merge(self, dest_index: str, src_index: str, keys: list = None):
         """
         Merges the content of src_index and dest_index file
@@ -292,6 +317,10 @@ class Conf:
     @staticmethod
     def merge(dest_index: str, src_index: str, keys: list = None):
         Conf._conf.merge(dest_index, src_index, keys)
+    
+    @staticmethod
+    def compare(index1: str, index2: str):
+        return Conf._conf.compare(index1, index2)
 
     class ClassProperty(property):
         """ Subclass property for classmethod properties """

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -213,7 +213,7 @@ class ConfStore:
         Compares two configs and returns difference
 
         Parameters:
-        index1 : Conf Index 1 
+        index1 : Conf Index 1
         index2 : Conf Index 2
 
         Return Value:
@@ -225,7 +225,7 @@ class ConfStore:
         if index2 not in self._cache.keys():
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index2)
-        
+
         key_list1 = self._cache[index1].get_keys()
         key_list2 = self._cache[index2].get_keys()
         deleted_keys = list(set(key_list1).difference(key_list2))

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -317,7 +317,7 @@ class Conf:
     @staticmethod
     def merge(dest_index: str, src_index: str, keys: list = None):
         Conf._conf.merge(dest_index, src_index, keys)
-    
+
     @staticmethod
     def compare(index1: str, index2: str):
         return Conf._conf.compare(index1, index2)

--- a/py-utils/test/conf_store/test_conf_cli.py
+++ b/py-utils/test/conf_store/test_conf_cli.py
@@ -315,6 +315,16 @@ class TestConfCli(unittest.TestCase):
         result_data = cmd_proc.run()
         self.assertEqual(result_data[2], 0)
 
+    def test_conf_cli_compare(self):
+        cmd = "conf json:///tmp/file1.json compare json:///tmp/file2.json"
+        cmd_proc = SimpleProcess(cmd)
+        result_data = cmd_proc.run()
+        print(result_data)
+        print(result_data[0])
+        print(result_data[1])
+        self.assertEqual(result_data[2], 0)
+
+
     @classmethod
     def tearDownClass(cls):
         delete_files()

--- a/py-utils/test/conf_store/test_conf_store.py
+++ b/py-utils/test/conf_store/test_conf_store.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from cortx.utils.schema.payload import Json
 from cortx.utils.conf_store import Conf
 from cortx.utils.schema.format import Format
+from cortx.utils.conf_store.error import ConfError
 
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -134,6 +135,23 @@ class TestConfStore(unittest.TestCase):
         load_config('get_keys_local', 'json:///tmp/file1.json')
         result_data = Conf.get_keys('get_keys_local')
         self.assertTrue(True if 'bridge>name' in result_data else False)
+
+    def test_conf_store_compare(self):
+        """Test comparing given two index and return new/deleted/updated keys."""
+        load_config('conf1', 'json:///tmp/file1.json')
+        load_config('conf2', 'json:///tmp/file2.json')
+        Conf.delete('conf2', 'bridge>name')
+        Conf.set('conf2', 'bridge>protocol', 'http')
+        Conf.set('conf2', 'bridge>port', '51288')
+        expected_new_keys = ['bridge>protocol']
+        expected_updated_keys = ['bridge>port']
+        actual_new_keys, actual_deleted_keys, actual_updated_keys = Conf.compare('conf1', 'conf2')
+        self.assertEqual(actual_new_keys, expected_new_keys)
+        self.assertEqual(actual_updated_keys, expected_updated_keys)
+        self.assertTrue(True if 'bridge>name' in actual_deleted_keys else False)
+        self.assertNotEqual(actual_new_keys, None)
+        with self.assertRaises(ConfError):
+            actual_new_keys, actual_deleted_keys, actual_updated_keys = Conf.compare('conf1', 'conf4')
 
     def test_conf_store_delete(self):
         """


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
Add Conf. compare utility in confstore for comparing two kVstores and return new/deleted/updated keys .
Also add Conf compare CLI support for the same.

# Design
Using Confstore Compare, If Two Indexes are passed, this function should return the difference between two indexes in a way that it would return three lists: new keys, deleted keys, and updated keys.
Example conf.compare:
>>> from cortx.utils.conf_store import Conf, MappedConf
>>> Conf.load('index1',"yaml:///etc/cortx/cluster.conf")
>>> Conf.load('index2',"yaml:///tmp/tmp.conf")
>>>
>>> new_keys, updated_keys, deleted_keys = Conf.compare('index1','index2')
>>> print(new_keys)
['node>8efd697708a8f7e428d3fd520c180795>provisioning>status', 'node>8efd697708a8f7e428d3fd520c180795>components[0]>version', 'node>8efd697708a8f7e428d3fd520c180795>components[1]>version', 'node>8efd697708a8f7e428d3fd520c180795>provisioning>version', 'node>8efd697708a8f7e428d3fd520c180795>provisioning>phase']
>>> print(updated_keys)
[]
>>> print(deleted_keys)
['cortx>common>service>secret', 'cortx>external>consul>secret', 'cortx>external>kafka>secret']

Outuot of conf compare CLI:
`[root@ssc-vm-g3-rhev4-3062 ~]# conf yaml:///root/tmp.conf compare yaml:///root/tmp1.conf
(['cortx>rgw>protocol'], ['cortx>rgw>port'], ['cortx>rgw>name'])
`
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]: Y
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: Y
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  Y

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [x] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [x] ConfStore
- [ ] KVStore
- [x] ConfCli
- [x] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [x] Changes done to WIKI / Confluence page
