### PR TITLE
CORTX-31950: add url to kwargs for S3Client constructor

### DIFF
--- a/py-utils/src/utils/s3/client.py
+++ b/py-utils/src/utils/s3/client.py
@@ -19,6 +19,7 @@ from hashlib import sha1
 import hmac
 from http import HTTPStatus
 from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 from cortx.utils.http import HttpClient, HttpClientException
 from cortx.utils.s3.exceptions import S3ClientException
@@ -33,8 +34,7 @@ class S3Client(HttpClient):
 
     def __init__(
         self, access_key_id: str, secret_access_key: str,
-        host: str = 'localhost', port: int = 8000,
-        tls_enabled: bool = False, ca_bundle: str = '',
+        url: str = '', ca_bundle: str = '',
         timeout: int = 5
     ) -> None:
         """
@@ -45,11 +45,15 @@ class S3Client(HttpClient):
         :param host: hostname of the S3 server.
         :param port: port of the S3 server.
         :param tls_enabled: flag to use https.
+        :param url: whole URL for the client, if set, then host, port and tls_enabled are ignored.
         :param ca_bundle: path to the root CA certificate.
         :param timeout: connection timeout.
         :returns: None.
         """
-
+        parsed_url = urlparse(url)
+        host = parsed_url.hostname
+        port = parsed_url.port
+        tls_enabled = parsed_url.scheme == 'https'
         super(S3Client, self).__init__(host, port, tls_enabled, ca_bundle, timeout)
         self._access_key_id = access_key_id
         self._secret_access_key = secret_access_key


### PR DESCRIPTION
# Problem Statement
- [CORTX-31950](https://jts.seagate.com/browse/CORTX-31950): CSM-S3 communication should be on https.

# Design
-  Per Pranay's request make S3 client capable of handling URL provided as is instead of constructing from host, port and tls_enabled arguments.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
