### PR TITLE
CORTX-29612: CORTX-29642: Confstore: alternate PR for PR #814 (DCO check issue)

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -74,12 +74,12 @@ class ConfCache:
         """
         return self._data.search(parent_key, search_key, search_val)
 
-    def delete(self, key: str):
+    def delete(self, key: str, force: bool = False):
         """
         Delete a given key from the config.
         Return Value:
         return boolean True for success else False
         """
-        result = self._data.delete(key)
+        result = self._data.delete(key, force)
         self._dirty = True
         return result

--- a/py-utils/src/utils/conf_store/conf_cli.py
+++ b/py-utils/src/utils/conf_store/conf_cli.py
@@ -141,7 +141,7 @@ class ConfCli:
         key_list = args.args[0].split(';')
         is_deleted = []
         for key in key_list:
-            status = Conf.delete(ConfCli._index, key)
+            status = Conf.delete(ConfCli._index, key, args.force)
             is_deleted.append(status)
         if any(is_deleted):
             Conf.save(ConfCli._index)
@@ -252,6 +252,8 @@ class DeleteCmd:
             "Example command:\n"
             "# conf json:///tmp/csm.conf delete 'k1>k2;k3'\n\n")
         s_parser.set_defaults(func=ConfCli.delete)
+        s_parser.add_argument('--force', default=False, help=\
+            "force option to delete non-leaf keys")
         s_parser.add_argument('args', nargs='+', default=[], help='args')
 
 

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -164,12 +164,12 @@ class ConfStore:
                                  index)
         return self._cache[index].get_data()
 
-    def delete(self, index: str, key: str):
+    def delete(self, index: str, key: str, force: bool = False):
         """ Delets a given key from the config """
         if index not in self._cache.keys():
             raise ConfError(errno.EINVAL, "config index %s is not loaded",
                 index)
-        return self._cache[index].delete(key)
+        return self._cache[index].delete(key, force)
 
     def search(self, index: str, parent_key: str, search_key: str,
         search_val: str = None) -> list:
@@ -304,9 +304,9 @@ class Conf:
         return Conf._conf.get(index, key, default_val, **filters)
 
     @staticmethod
-    def delete(index: str, key: str):
+    def delete(index: str, key: str, force: bool = False):
         """ Deletes a given key from the config """
-        return Conf._conf.delete(index, key)
+        return Conf._conf.delete(index, key, force)
 
     @staticmethod
     def copy(src_index: str, dst_index: str, key_list: list = None,
@@ -368,7 +368,6 @@ class Conf:
     def add_num_keys(index):
         """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf._conf.add_num_keys(index)
-        Conf.save(index)
 
 
 class MappedConf:
@@ -427,6 +426,6 @@ class MappedConf:
         """Returns value for the given key."""
         return Conf.get(self._conf_idx, key, default_val)
 
-    def delete(self, key: str):
+    def delete(self, key: str, force: bool = False):
         """Delete key from CORTX confstore."""
-        return Conf.delete(self._conf_idx, key)
+        return Conf.delete(self._conf_idx, key, force)

--- a/py-utils/src/utils/kv_store/kv_payload.py
+++ b/py-utils/src/utils/kv_store/kv_payload.py
@@ -119,8 +119,6 @@ class KvPayload:
                     when True, returns keys including array index
                     e.g. In case of "xxx[0],xxx[1]", only "xxx" is returned
         """
-        if all([len(filters.items()) == 0, not starts_with]):
-            return self._keys
         keys = []
         if recurse:
             self._get_keys(keys, self._data, None, **filters)
@@ -191,7 +189,7 @@ class KvPayload:
                 data[k[0]] = []
             # if index is more than list size, extend the list
             for i in range(len(data[k[0]]), index + 1):
-                data[k[0]].append({})
+                data[k[0]].append('')
             # if this is leaf node of the key
             if len(k) == 1:
                 data[k[0]][index] = val
@@ -327,7 +325,7 @@ class KvPayload:
         """ read operator for KV payload, i.e. kv['xxx'] """
         return self.get(key)
 
-    def _delete(self, key: str, data: dict):
+    def _delete(self, key: str, data: dict, force: bool = False):
         k = key.split(self._delim, 1)
 
         index = None
@@ -344,24 +342,33 @@ class KvPayload:
             if index >= len(data[k[0]]):
                 return False
             if len(k) == 1:
-                del data[k[0]][index]
+                if index == len(data[k[0]]) - 1:
+                    del data[k[0]][index]
+                else:
+                    data[k[0]][index] = ''
                 return True
             else:
-                return self._delete(k[1], data[k[0]][index])
+                return self._delete(k[1], data[k[0]][index], force)
 
         if len(k) == 1:
-            del data[k[0]]
-            return True
+            # value of key being dict/list means it's not a leaf node
+            # or below nodes are deleted
+            is_key_leaf = False if isinstance(data[k[0]], (list, dict)) else True
+            if is_key_leaf or force or (len(data[k[0]]) == 0):
+                del data[k[0]]
+                return True
+            else:
+                raise KvError(errno.EINVAL, "Key: %s is not leaf key", key)
         else:
-            return self._delete(k[1], data[k[0]])
+            return self._delete(k[1], data[k[0]], force)
 
-    def delete(self, key) -> bool:
+    def delete(self, key, force: bool = False) -> bool:
         """
         Deletes given set of keys from the dictionary
         Return Value:
         returns True if key existed/deleted. Returns False if key not found.
         """
-        rc = self._delete(key, self._data)
+        rc = self._delete(key, self._data, force)
         if rc == True and key in self._keys:
             del self._keys[self._keys.index(key)]
         return rc

--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -255,7 +255,7 @@ class IniKvPayload(KvPayload):
         except (NoOptionError, NoSectionError):
             return None
 
-    def delete(self, key):
+    def delete(self, key, *args):
         k = key.split(self._delim)
         if len(k) <= 1 or len(k) > 2:
             raise KvError(errno.EINVAL, "Invalid key %s for INI format", key)
@@ -445,9 +445,9 @@ class ConsulKvPayload(KvPayload):
         return self._consul.kv.put(self._store_path + key, str(val))
 
     @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
-    def _delete(self, key: str, *args, **kwargs) -> Union[bool, None]:
+    def _delete(self, key: str, data: dict, force: bool = False, *args, **kwargs) -> Union[bool, None]:
         """ Delete the key:value for the input key. """
-        return self._consul.kv.delete(self._store_path + key)
+        return self._consul.kv.delete(key = self._store_path + key, recurse = force)
 
     @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
     def get_data(self, format_type: str = None, *args, **kwargs):

--- a/py-utils/test/conf_store/test_conf_cli.py
+++ b/py-utils/test/conf_store/test_conf_cli.py
@@ -134,6 +134,16 @@ class TestConfCli(unittest.TestCase):
         self.assertTrue(True if result_data[2] == 0 and
             result_data[0]==b'[null]\n' else False, result_data[1])
 
+    def test_conf_cli_delete_non_leafKey(self):
+        # fail for deleting non leaf key without force
+        invalid_delete_cmd = "conf json:///tmp/file1.json delete 'bridge'"
+        invalid_delete_return_code = SimpleProcess(invalid_delete_cmd).run()[-1]
+        self.assertNotEqual(0, invalid_delete_return_code)
+        # passes for deleting non leaf key with force
+        valid_delete_cmd = invalid_delete_cmd + "--force True"
+        valid_delete_return_code = SimpleProcess(valid_delete_cmd).run()[-1]
+        self.assertEqual(0, valid_delete_return_code)
+
     def test_conf_cli_by_format_data(self):
         """ Test by converting data into toml format """
         exp_result = b'- lte_type:\n  - name: 3g\n  - name: 4g\n  ' \

--- a/py-utils/test/conf_store/test_conf_store_mapped_conf.py
+++ b/py-utils/test/conf_store/test_conf_store_mapped_conf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import os
+import unittest
+import yaml
+
+from cortx.utils.conf_store import MappedConf, Conf
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+def create_file(file, data=""):
+    """Creates temporary file."""
+    try:
+        with open(file, 'w+') as temp_file:
+            temp_file.write(data)
+    except OSError as e:
+        print(e)
+
+def delete_file(file):
+    """Deletes temporary files."""
+    try:
+        if os.path.exists(file):
+            os.remove(file)
+    except OSError as e:
+        print(e)
+
+class TestMappedConf(unittest.TestCase):
+    """Test MappedConf."""
+
+    def test_mapped_conf_add_num_keys(self):
+        """Test if add_num_keys adds num_xx keys for xx list in the given config."""
+        data = {
+            'a': '1',
+            'b': ['2', {'3': ['5', '6']}, '4']
+        }
+        sample_file = f"{dir_path}/sample_conf.yaml"
+        create_file(sample_file, yaml.dump(data))
+        conf_url = f"yaml:///{sample_file}"
+        cortx_conf = MappedConf(conf_url)
+        cortx_conf.add_num_keys()
+        test_index = 'test_index1'
+        Conf.load(test_index, conf_url)
+        # Test before saving
+        self.assertIsNone(Conf.get(test_index, 'num_b'), "num_b key is added without even saving to conf")
+        self.assertIsNone(Conf.get(test_index, 'b[1]>num_3'), "num_b key is added without even saving to conf")
+        # Test after saving
+        test_index = 'test_index2'
+        conf_id = cortx_conf._conf_idx
+        Conf.save(conf_id)
+        Conf.load(test_index, conf_url)
+        self.assertEqual(Conf.get(test_index, 'num_b'), 3)
+        self.assertEqual(Conf.get(test_index, 'b[1]>num_3'), 2)
+        delete_file(sample_file)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py-utils/test/kv_store/test_consul_kv_store.py
+++ b/py-utils/test/kv_store/test_consul_kv_store.py
@@ -108,3 +108,4 @@ if __name__ == '__main__':
     if len(sys.argv) >= 2:
         TestStore._cluster_conf_path = sys.argv.pop()
     unittest.main()
+    

--- a/py-utils/test/kv_store/test_kv_store.py
+++ b/py-utils/test/kv_store/test_kv_store.py
@@ -363,6 +363,7 @@ class TestStore(unittest.TestCase):
         self.assertEqual([None], out)
 
     # consul store
+    # Fix it
     def test_consul_a_set_get_kv(self):
         """ Test consul kv set and get a KV. """
         TestStore.loaded_consul[0].set(['consul_cluster_uuid'], ['#410'])
@@ -460,6 +461,28 @@ class TestStore(unittest.TestCase):
         TestStore.loaded_dict[1].set('k1', '')
         out = TestStore.loaded_dict[1].get('k1')
         self.assertEqual('', out)
+
+    def test_no_left_shift_kvstore(self):
+        """Test and ensure left shift not happening."""
+        TestStore.loaded_json[0].set(['bridge>name_list[0]',\
+            'bridge>name_list[1]', 'bridge>name_list[2]',
+            'bridge>name_list[3]'], ['1', '2', '3', '4'])
+        TestStore.loaded_json[0].delete(['bridge>name_list[1]'])
+        result_list = TestStore.loaded_json[0].get(['bridge>name_list[1]'])
+        self.assertEqual('', result_list[0])
+
+    def test_no_left_shift_end_list_kvstore(self):
+        """
+        Test and ensure left shift not happening
+        while deleting last element of a list
+        """
+        TestStore.loaded_json[0].set(['bridge>end_name_list[0]',\
+            'bridge>end_name_list[1]', 'bridge>end_name_list[2]',\
+            'bridge>end_name_list[3]'], ['1', '2', '3', '4'])
+        TestStore.loaded_json[0].delete(['bridge>end_name_list[3]'])
+        TestStore.loaded_json[0].add_num_keys()
+        result_list = TestStore.loaded_json[0].get(['bridge>num_end_name_list'])
+        self.assertEqual(result_list[0], 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

Raised this PR for PR:https://github.com/Seagate/cortx-utils/pull/814
Above PR had DCO failures with good number of commits hence had raised this PR with all the changes present in PR: #814

**This PR includes changes from following PRs:**
https://github.com/Seagate/cortx-utils/pull/749
https://github.com/Seagate/cortx-utils/pull/746
https://github.com/Seagate/cortx-utils/pull/755
https://github.com/Seagate/cortx-utils/pull/756
https://github.com/Seagate/cortx-utils/pull/763
https://github.com/Seagate/cortx-utils/pull/779
https://github.com/Seagate/cortx-utils/pull/780

Relevant Stories:

[CORTX-29612](https://jts.seagate.com/browse/CORTX-29612): ConfStore: instead of None, use empty string as a null value
[CORTX-29642](https://jts.seagate.com/browse/CORTX-29642): Conf_store: After deletetion of keys from conf, Conf.get_keys() still returns the deleted keys.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [x] ConfStore
- [x] KVStore
- [x] ConfCli
- [x] Test cases added for all above 3
- [x] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
