### PR TITLE
CORTX-31530: Observed cortx-ha-k8s-monitor restart after ~115 hours o…

### DIFF
--- a/py-utils/src/utils/event_framework/health.py
+++ b/py-utils/src/utils/event_framework/health.py
@@ -15,6 +15,9 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+"""Module which creates the health event with required key value"""
+
+
 from cortx.utils.kv_store.kv_payload import KvPayload
 from cortx.utils.event_framework.event import Attr, Event
 
@@ -53,13 +56,15 @@ class HealthEvent(Event):
             payload.set(str(key), '')
         for key, val in kwargs.items():
             payload.set(key, val)
-        payload.set('specific_info', '')
+        payload.set('specific_info', {})
         super().__init__(payload)
 
     def set(self, key, val):
+        """Sets up the payload"""
         super().set_payload_attr(key, val)
 
     def set_specific_attr(self, key: str, val: str):
+        """Sets up the specific info for payload"""
         super().set_payload_attr(f'specific_info>{key}', val)
 
     def set_specific_info(self, spec_info: dict):


### PR DESCRIPTION
…f IO's.

HA k8s monitor service restart was observed because at some point of time
it failed at parsing the alert message because of some type mismatch. The
basic health event gets created using utils HealthEvent class. This event's
payload attribute "specific_info" has default value as 'str'. So, if
'set_specifc_info' gets called, then only, this value will change to 'dict'.
Otherwise it will remain as 'str' and the parsing will fail. So, This should be
dictionary as its purpose is to carry additional information in key value
format.

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
https://github.com/Seagate/cortx-utils/pull/new/CORTX-31530

# Design
Make default value of "specific_info" of payload as dictionary

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
