### PR TITLE
CORTX-32413: remove node types from cortx const.py

### DIFF
--- a/py-utils/src/utils/cortx/const.py
+++ b/py-utils/src/utils/cortx/const.py
@@ -34,12 +34,6 @@ class Const(Enum):
     SERVICE_CSM_AGENT      = 'agent'
     SERVICE_MOTR_CLIENT    = 'motr_client'
 
-    # Node Types
-    NODE_TYPE_DATA         = 'data_node'
-    NODE_TYPE_HA           = 'ha_node'
-    NODE_TYPE_SERVER       = 'server_node'
-    NODE_TYPE_CONTROL      = 'control_node'
-
     # Deprecated services
     COMPONENT_S3           = 's3'
     COMPONENT_CCLIENT      = 'cclient'


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- Remove node_types from cortx const.py

# Design
-  node type values are prone to change with respect to multiple data pods and changes in various pods, hence we need to remove the hard dependency from these constants and recognize data pods based on storage key.

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
