### PR TITLE
CORTX-32122: remove sudo usage

### DIFF
--- a/c-utils/scripts/build.sh
+++ b/c-utils/scripts/build.sh
@@ -156,7 +156,7 @@ cortx_utils_rpm_install() {
         echo "$rpm"
     done
 
-    sudo yum install -y ${myrpms[@]}
+    yum install -y ${myrpms[@]}
     local rc=$?
 
     echo "Done ($rc)."
@@ -164,7 +164,7 @@ cortx_utils_rpm_install() {
 }
 
 cortx_utils_rpm_uninstall() {
-    sudo yum remove -y "${PROJECT_NAME_BASE}-utils*"
+    yum remove -y "${PROJECT_NAME_BASE}-utils*"
 }
 
 cortx_utils_reinstall() {

--- a/py-utils/test/ssh_connection/test_ssh_connection.py
+++ b/py-utils/test/ssh_connection/test_ssh_connection.py
@@ -38,7 +38,7 @@ class TestSSHChannel(unittest.TestCase):
         cls.__user = "utiltester"
         cls.__passwd = "P@ssw0rd"
         e_pass = crypt.crypt(cls.__passwd, "22")
-        os.system(f"sudo useradd -M -p {e_pass} {cls.__user}")
+        os.system(f"useradd -M -p {e_pass} {cls.__user}")
 
         # Let ssh connection be alive across all tests
         cls.session = SSHChannel(cls.hostname, cls.__user, cls.__passwd, sftp_enabled=True)
@@ -103,7 +103,7 @@ class TestSSHChannel(unittest.TestCase):
     def tearDownClass(cls):
         """Cleanup the setup."""
         cls.session.disconnect()
-        os.system(f"sudo userdel {cls.__user}")
+        os.system(f"userdel {cls.__user}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: rohit-k-dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- use of sudo is discouraged

# Design
-  removed use of sudo from codebase
# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
