### PR TITLE
CORTX-33600: Conf.search not working without value

### DIFF
--- a/py-utils/src/utils/kv_store/kv_store_collection.py
+++ b/py-utils/src/utils/kv_store/kv_store_collection.py
@@ -490,7 +490,7 @@ class ConsulKvPayload(KvPayload):
         return keys
 
     @ExponentialBackoff(exception=(ConsulException, HTTPError, RequestException), tries=4)
-    def search(self, parent_key: str, search_key: str, search_val: str) -> list:
+    def search(self, parent_key: str, search_key: str, search_val: str = '') -> list:
         """
         Searches the given dictionary for the key and value.
 
@@ -502,8 +502,11 @@ class ConsulKvPayload(KvPayload):
         for key in keys:
             key_suffix = key.split(self._delim)[-1]
             if key_suffix == search_key:
-                value = self.get(key) if parent_key else ''
-                if value == search_val:
+                if search_val:
+                    value = self.get(key) if parent_key else ''
+                    if value == search_val:
+                        key_list.append(key)
+                else:
                     key_list.append(key)
         return key_list
 

--- a/py-utils/test/kv_store/test_consul_kv_store.py
+++ b/py-utils/test/kv_store/test_consul_kv_store.py
@@ -102,6 +102,12 @@ class TestStore(unittest.TestCase):
         TestStore.loaded_consul[0].delete(['test>child_key>leaf_key'])
         self.assertEqual(['test>child_key>leaf_key'], out)
 
+    def test_consul_store_h_search_without_val(self):
+        """Test consul search without search_val."""
+        TestStore.loaded_consul[0].set(['test>child_key>leaf_key'],['value'])
+        out = TestStore.loaded_consul[0].search('test', 'leaf_key')
+        TestStore.loaded_consul[0].delete(['test>child_key>leaf_key'])
+        self.assertEqual(['test>child_key>leaf_key'], out)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Signed-off-by: Rahul Tripathi <rahul.tripathi@seagate.com>

# Problem Statement
- Conf.Search is not working with search_val for consul backend

# Design
-  modified code to work without search val as well

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]: Y
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]: Y
- Confirm that Test Cases are added for new features added [Y/N]: NA
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: Y
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  K8s dployment will happen for this PR

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: N
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]: NA
- [ ] New package/s added to setup.py?: NA
- [ ] Jira is updated: Y
- [ ] Check if the description is clear and explained. : Y
- [ ] Check Acceptance Criterion is defined. : Y
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [x] KVStore
- [ ] ConfCli
- [x] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page: NA
