### PR TITLE
Cortx 32734 conflock

### DIFF
--- a/py-utils/src/utils/conf_store/conf_cache.py
+++ b/py-utils/src/utils/conf_store/conf_cache.py
@@ -83,3 +83,9 @@ class ConfCache:
         result = self._data.delete(key, force)
         self._dirty = True
         return result
+
+    def lock(self):
+        return self._data.lock()
+
+    def unlock(self):
+        return self._data.unlock()

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -268,6 +268,17 @@ class ConfStore:
             if key not in self._cache[dest_index].get_keys():
                 self._cache[dest_index].set(key, self._cache[src_index].get(key))
 
+    def lock(self, index:str):
+        if index not in self._cache.keys():
+            raise ConfError(errno.EINVAL, "config index %s is not loaded",
+                index)
+        return self._cache[index].lock()
+    
+    def unlock(self, index:str):
+        if index not in self._cache.keys():
+            raise ConfError(errno.EINVAL, "config index %s is not loaded",
+                index)
+        return self._cache[index].unlock()
 
 class Conf:
     """Singleton class instance based on conf_store."""
@@ -375,6 +386,13 @@ class Conf:
         """Add "num_xxx" keys for all the list items in ine KV Store."""
         Conf._conf.add_num_keys(index)
 
+    @staticmethod
+    def lock(index):
+        return Conf._conf.lock(index)
+
+    @staticmethod
+    def unlock(index):
+        return Conf._conf.unlock(index)
 
 class MappedConf:
     """CORTX Config Store with fixed target."""

--- a/py-utils/src/utils/const.py
+++ b/py-utils/src/utils/const.py
@@ -88,3 +88,7 @@ COMPONENT_NAME_MAP = {'CORTX': 'CORTX', 'cortx-motr': 'motr', 'cortx-rgw': 'rgw'
                     'cortx-hare': 'hare', 'cortx-py-utils': 'utils', 'cortx-csm_agent': 'csm',
                     'cortx-ha': 'ha', 'cortx-prvsnr': 'prvsnr'}
 VERSION_UPGRADE = "UPGRADE"
+# Distributed Lock related keys
+SERVICE = "conf-service"
+LEAD_KEY = "gconf>leader"
+ACQUIRED_TIME_KEY = "gconf>acquisition_time"

--- a/py-utils/src/utils/kv_store/kv_store.py
+++ b/py-utils/src/utils/kv_store/kv_store.py
@@ -116,6 +116,9 @@ class KvStore:
         raise KvError(errno.ENOSYS, "%s:dump() not implemented",
                       type(self).__name__)
 
+    def lock(self, payload, delim='>'):
+        payload = self.load()
+        return payload.lock()
 
 class KvStoreFactory:
 


### PR DESCRIPTION
# Problem Statement
- Implement an interface to soft lock and unlock a config from Confstore, to avoid concurrent access and redundant effort from multiple config service instances.

# Design
-  
-  [For Feature, Post the link to the solution page on the confluence CORTX Foundation Library ](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/1074626828/HLD+Distributed+Locks+using+Conf+Store)

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [x] ConfStore
- [x] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
