### PR TITLE
Handle python36-dbus dependency for cortx-utils/py-utils build and install (CentOS 7.9)

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -1,0 +1,1 @@
+CODE_OF_CONDUCT.md

--- a/py-utils/README.md
+++ b/py-utils/README.md
@@ -23,7 +23,8 @@ A common utils framework which includes common modules across components
 ## Prerequisites for build
 ```bash
 On Centos7,
-sudo yum install -y gcc rpm-build python36 python36-pip python36-devel python36-setuptools openssl-devel libffi-devel python36-dbus
+sudo yum install -y gcc rpm-build python36 python36-pip python36-devel python36-setuptools openssl-devel libffi-devel
+sudo yum localinstall -y https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/p/python36-dbus-1.2.4-4.el7.x86_64.rpm
 
 On Rocky linux,
 sudo yum install -y gcc rpm-build python3 python3-pip python3-devel python3-setuptools openssl-devel libffi-devel python3-dbus
@@ -49,7 +50,8 @@ cd cortx-utils
 ### Install yum packages
 ```bash
 On Centos7,
-sudo yum install -y gcc python36 python36-pip python36-devel python36-setuptools openssl-devel libffi-devel python36-dbus
+sudo yum install -y gcc python36 python36-pip python36-devel python36-setuptools openssl-devel libffi-devel
+sudo yum localinstall -y https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/p/python36-dbus-1.2.4-4.el7.x86_64.rpm
 
 On Rocky linux,
 sudo yum install -y gcc python3 python3-pip python3-devel python3-setuptools openssl-devel libffi-devel python3-dbus


### PR DESCRIPTION
Issue:
	python36-dbus is not available in CentOS 7.9
Solution:
	Get python36-dbus from epel and install it separately

Signed-off-by: Deepak Nayak [deepak.nayak@seagate.com](mailto:deepak.nayak@seagate.com)

-----
[View rendered py-utils/README.md](https://github.com/d-nayak/cortx-utils/blob/main/py-utils/README.md)