### PR TITLE
CORTX-33162: removed hard coded site_packages path

### DIFF
--- a/py-utils/utils-post-install
+++ b/py-utils/utils-post-install
@@ -15,31 +15,31 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 ## Replace <INSTALL_PATH> with cortx installation path. example: /opt/seagate
+CORTX_SITE_PACKAGE=`python3 -c "import cortx as _; print(_.__path__)"|awk -F\' '{print $2}'`
 install_path=<INSTALL_PATH>
 cortx_path=$install_path/cortx/
 utils_path=$cortx_path/utils
-
 # Create /etc/cortx. This will be used for storing message_bus.conf file.
 /bin/mkdir -p /etc/cortx
 
 # Copy the setup_cli.py as utils_setup.
 /bin/mkdir -p $utils_path/bin/
-/bin/ln -sf /usr/lib/python3.6/site-packages/cortx/setup/utils_setup.py $utils_path/bin/utils_setup
+/bin/ln -sf $CORTX_SITE_PACKAGE/setup/utils_setup.py $utils_path/bin/utils_setup
 /bin/chmod +x $utils_path/bin//utils_setup
 
 # Copy the message_bus_server.py as message_bus_server.
-/bin/ln -sf /usr/lib/python3.6/site-packages/cortx/utils/utils_server/utils_server.py $utils_path/bin/utils_server
+/bin/ln -sf $CORTX_SITE_PACKAGE/utils/utils_server/utils_server.py $utils_path/bin/utils_server
 /bin/chmod +x $utils_path/bin/utils_server
 
 # Copy the cortx_support_bundle.py as cortx_support_bundle
-/bin/ln -sf /usr/lib/python3.6/site-packages/cortx/support/cortx_support_bundle.py $utils_path/bin/cortx_support_bundle
+/bin/ln -sf $CORTX_SITE_PACKAGE/support/cortx_support_bundle.py $utils_path/bin/cortx_support_bundle
 /bin/chmod +x $utils_path/bin/cortx_support_bundle
 
 # Copy cortx.conf file to /etc/cortx.
 [ -f "/etc/cortx/cortx.conf" ] || cp -n $utils_path/conf/cortx.conf.sample /etc/cortx/cortx.conf
 
 # Copy support/utils_support_bundle.py to $utils_path/bin.
-/bin/ln -sf /usr/lib/python3.6/site-packages/cortx/support/utils_support_bundle.py $utils_path/bin/utils_support_bundle
+/bin/ln -sf $CORTX_SITE_PACKAGE/support/utils_support_bundle.py $utils_path/bin/utils_support_bundle
 /bin/chmod +x $utils_path/bin/utils_support_bundle
 
 # Replace cortx path to support_bundle.yaml.


### PR DESCRIPTION
Signed-off-by: rohit-k-dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- `utils-post-install` script has hardcoded site_packages path

# Design
- added snipper to fetch the cortx package install path at runtime

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: Y
-  Confirm All CODACY errors are resolved [Y/N]: Y

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]: N
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]:  N
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: N
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  Y

# Review Checklist 
####  Before posting the PR please ensure:
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
