### PR TITLE
CORTX-33673: Improvement for lock-unlock interface with lock end time…

### DIFF
--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -282,7 +282,7 @@ class ConfStore:
         self.lock_owner = self.default_owner
         self.lock_key = const.LOCK_KEY
         allowed_keys = { 'lock_key', 'lock_owner', 'duration' }
-        _ = [self.__setattr__(key, kwargs.get(key)) for key in allowed_keys]
+        _ = [self.__setattr__(key, val) for key, val in kwargs.items() if key in allowed_keys]
 
         rc = False
         if not self.test_lock(index, lock_owner=self.lock_owner, lock_key=self.lock_key):
@@ -302,7 +302,7 @@ class ConfStore:
         self.lock_owner = self.default_owner
         self.lock_key = const.LOCK_KEY
         allowed_keys = { 'lock_key', 'lock_owner', 'force' }
-        _ = [self.__setattr__(key, kwargs.get(key)) for key in allowed_keys]
+        _ = [self.__setattr__(key, val) for key, val in kwargs.items() if key in allowed_keys]
 
         rc = False
         if self._get_lock_owner(index, self.lock_key) == self.lock_owner or self.force:
@@ -319,7 +319,7 @@ class ConfStore:
         self.lock_key = const.LOCK_KEY
         self.lock_owner = self.default_owner
         allowed_keys = { 'lock_key' , 'lock_owner'}
-        _ = [self.__setattr__(key, kwargs.get(key)) for key in allowed_keys]
+        _ = [self.__setattr__(key, val) for key, val in kwargs.items() if key in allowed_keys]
 
         if self._get_lock_owner(index, self.lock_key) in [None, "", self.lock_owner]:
             return False

--- a/py-utils/src/utils/conf_store/conf_store.py
+++ b/py-utils/src/utils/conf_store/conf_store.py
@@ -297,9 +297,9 @@ class ConfStore:
             if key == 'duration' and not isinstance(val, int):
                 raise ConfError(errno.EINVAL, "Invalid value %s for parameter %s", val, key)
 
-        owner = self._lock_owner if 'owner' not in kwargs.keys() else kwargs['owner']
-        domain = self._lock_domain if 'domain' not in kwargs.keys() else kwargs['domain']
-        duration = self._lock_duration if 'duration' not in kwargs.keys() else kwargs['duration']
+        owner = self._lock_owner if 'owner' not in kwargs else kwargs['owner']
+        domain = self._lock_domain if 'domain' not in kwargs else kwargs['domain']
+        duration = self._lock_duration if 'duration' not in kwargs else kwargs['duration']
 
         rc = False
         if self.test_lock(index, owner=owner, domain=domain):
@@ -339,8 +339,8 @@ class ConfStore:
             if key == 'force' and not isinstance(val, bool):
                 raise ConfError(errno.EINVAL, "Invalid value %s for parameter %s", val, key)
 
-        owner = self._lock_owner if 'owner' not in kwargs.keys() else kwargs['owner']
-        domain = self._lock_domain if 'domain' not in kwargs.keys() else kwargs['domain']
+        owner = self._lock_owner if 'owner' not in kwargs else kwargs['owner']
+        domain = self._lock_domain if 'domain' not in kwargs else kwargs['domain']
 
         rc = False
         if self.get(index, const.LOCK_OWNER_KEY_PREFIX % domain) == owner or force:
@@ -369,8 +369,8 @@ class ConfStore:
             if key not in allowed_keys:
                 raise ConfError(errno.EINVAL, "Invalid parameter %s", key)
 
-        owner = self._lock_owner if 'owner' not in kwargs.keys() else kwargs['owner']
-        domain = self._lock_domain if 'domain' not in kwargs.keys() else kwargs['domain']
+        owner = self._lock_owner if 'owner' not in kwargs else kwargs['owner']
+        domain = self._lock_domain if 'domain' not in kwargs else kwargs['domain']
 
         _current_owner= self.get(index, const.LOCK_OWNER_KEY_PREFIX % domain)
         if _current_owner in [None, "", owner]:

--- a/py-utils/src/utils/const.py
+++ b/py-utils/src/utils/const.py
@@ -90,8 +90,8 @@ COMPONENT_NAME_MAP = {'CORTX': 'CORTX', 'cortx-motr': 'motr', 'cortx-rgw': 'rgw'
 VERSION_UPGRADE = "UPGRADE"
 
 # Confstore lock keys
-LOCK_END_TIME_PREFIX = "lock>%s>end_time"
-LOCK_OWNER_PREFIX = "lock>%s>owner"
+LOCK_END_TIME_KEY_PREFIX = "lock>%s>end_time"
+LOCK_OWNER_KEY_PREFIX = "lock>%s>owner"
 DEFAULT_LOCK_DURATION = 10
 DEFAULT_RETRY_DELAY = 1
 DEFAULT_LOCK_DOMAIN = "default"

--- a/py-utils/src/utils/const.py
+++ b/py-utils/src/utils/const.py
@@ -91,7 +91,7 @@ VERSION_UPGRADE = "UPGRADE"
 
 # Confstore lock keys
 LOCK_KEY = "cortx>gconf>lock"
-LOCK_TIME_KEY = "%s>time"
+LOCK_END_TIME_KEY = "%s>end_time"
 LOCK_OWNER_KEY = "%s>owner"
-DEFAULT_LOCK_TIMEOUT = 0
+DEFAULT_LOCK_DURATION = 10
 DEFAULT_RETRY_DELAY = 1

--- a/py-utils/src/utils/const.py
+++ b/py-utils/src/utils/const.py
@@ -90,8 +90,8 @@ COMPONENT_NAME_MAP = {'CORTX': 'CORTX', 'cortx-motr': 'motr', 'cortx-rgw': 'rgw'
 VERSION_UPGRADE = "UPGRADE"
 
 # Confstore lock keys
-LOCK_KEY = "cortx>gconf>lock"
-LOCK_END_TIME_KEY = "%s>end_time"
-LOCK_OWNER_KEY = "%s>owner"
+LOCK_END_TIME_PREFIX = "lock>%s>end_time"
+LOCK_OWNER_PREFIX = "lock>%s>owner"
 DEFAULT_LOCK_DURATION = 10
 DEFAULT_RETRY_DELAY = 1
+DEFAULT_LOCK_DOMAIN = "default"

--- a/py-utils/test/conf_store/conf_store_multiple_lock_threads_test.py
+++ b/py-utils/test/conf_store/conf_store_multiple_lock_threads_test.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from multiprocessing import Process
 import random
 from datetime import datetime
@@ -10,11 +8,11 @@ from cortx.utils.conf_store import Conf
 class TestConfStoreLock(object):
     """Test Confstore lock."""
     lock_status = []
-    def __init__(self, URL="consul://ssc-vm-g3-rhev4-3306.colo.seagate.com/conf10"):
+    def __init__(self, URL="consul://cortx-consul-server:8500/test_lock"):
         self.url = URL
         self.duration = 20
 
-    def test_lock_race(self, thread_count:int=2, repeat=1):
+    def test_lock_race(self, thread_count:int = 2, repeat = 1):
         """Test race condition with lock."""
         _index = None
         _conf_index = TestConfStoreLock._generate_index()
@@ -28,7 +26,7 @@ class TestConfStoreLock(object):
         for _proc in _process_store:
             _proc.start()
 
-    def test_multiple_lock_unlock(self, thread_count:int=2, repeat=1):
+    def test_multiple_lock_unlock(self, thread_count:int = 2, repeat = 1):
         """Test race condition with lock."""
         _index = None
         _conf_index = TestConfStoreLock._generate_index()
@@ -38,11 +36,11 @@ class TestConfStoreLock(object):
             Conf.load(_index, self.url)
             _conf_process = Process(target=self.lock_unlock, args=(_index, repeat), kwargs={ "owner": _index, "duration":self.duration})
             _process_store.append(_conf_process)
-        
+
         for _proc in _process_store:
             _proc.start()
             _proc.join()
-    
+
     def test_multiple_lock_reset_lock(self, thread_count:int = 2, repeat = 1):
         """Test race condition with lock."""
         _index = None
@@ -53,7 +51,7 @@ class TestConfStoreLock(object):
             Conf.load(_index, self.url)
             _conf_process = Process(target=self.lock_reset_lock, args=(_index, repeat), kwargs={ "owner": _index })
             _process_store.append(_conf_process)
-        
+
         for _proc in _process_store:
             _proc.start()
             _proc.join()
@@ -108,7 +106,7 @@ class TestConfStoreLock(object):
             self.do_lock(index, 1, **kwargs)
             sleep(1)
             self.do_unlock(index, 1)
-    
+
     def lock_reset_lock(self, index, repeat, **kwargs):
         for rep in range(0, repeat):
             print(f"Rep {index} {rep+1}")
@@ -125,7 +123,7 @@ class TestConfStoreLock(object):
             self.do_unlock(index,1)
             sleep(1)
             self._test_lock(index, 1)
-    
+
     def _test_lock(self, index, repeat):
         for rep in range(0, repeat):
             print(f"Test Lock Rep {index} {rep+1}")

--- a/py-utils/test/conf_store/test_conf_store_multiple_lock_threads.py
+++ b/py-utils/test/conf_store/test_conf_store_multiple_lock_threads.py
@@ -24,7 +24,7 @@ class TestConfStoreLock(object):
             Conf.load(_index, self.url)
             _conf_process = Process(target=self.do_lock, args=(_index, repeat, 2), kwargs={ "owner": _index, "duration":self.duration})
             _process_store.append(_conf_process)
-        
+
         for _proc in _process_store:
             _proc.start()
 
@@ -43,7 +43,7 @@ class TestConfStoreLock(object):
             _proc.start()
             _proc.join()
     
-    def test_multiple_lock_reset_lock(self, thread_count:int=2, repeat=1):
+    def test_multiple_lock_reset_lock(self, thread_count:int = 2, repeat = 1):
         """Test race condition with lock."""
         _index = None
         _conf_index = TestConfStoreLock._generate_index()
@@ -58,7 +58,7 @@ class TestConfStoreLock(object):
             _proc.start()
             _proc.join()
 
-    def test_multiple_lock_and_test_lock(self, thread_count=2, repeat=1):
+    def test_multiple_lock_and_test_lock(self, thread_count = 2, repeat=1):
         """Test race condition with lock."""
         _index = None
         _conf_index = TestConfStoreLock._generate_index()
@@ -73,7 +73,7 @@ class TestConfStoreLock(object):
             _proc.start()
             _proc.join()
 
-    def test_process_lock_recover(self, thread_count=2, repeat=1):
+    def test_process_lock_recover(self, thread_count = 2, repeat=1):
         """Test race condition with lock."""
         _index = None
         first_index = None
@@ -131,7 +131,7 @@ class TestConfStoreLock(object):
             print(f"Test Lock Rep {index} {rep+1}")
             print(f"{datetime.now()} Test Lock Status for {index}: {Conf.test_lock(index, owner=index)}")
 
-    def do_lock(self, index, repeat=1, sleep_time=0, **kwargs):
+    def do_lock(self, index, repeat = 1, sleep_time = 0, **kwargs):
         """lock config."""
         for rep in range(0, repeat):
             print(f"Lock Rep {index} {rep+1}")
@@ -170,6 +170,7 @@ class TestConfStoreLock(object):
         digits = random.choices(string.digits, k=2)
         letters = random.choices(string.ascii_uppercase, k=9)
         return ''.join(random.sample(digits + letters, 11))
+
 
 if __name__ == '__main__':
     run_count = int(input("Run Count: "))

--- a/py-utils/test/conf_store/test_conf_store_multiple_lock_threads.py
+++ b/py-utils/test/conf_store/test_conf_store_multiple_lock_threads.py
@@ -1,0 +1,188 @@
+import os
+import sys
+from multiprocessing import Process
+import random
+from datetime import datetime
+import string
+from time import sleep
+from cortx.utils.conf_store import Conf
+
+class TestConfStoreLock(object):
+    """Test Confstore lock."""
+    lock_status = []
+    def __init__(self, URL="consul://ssc-vm-g3-rhev4-3306.colo.seagate.com/conf10"):
+        self.url = URL
+        self.duration = 20
+
+    def test_lock_race(self, thread_count:int=2, repeat=1):
+        """Test race condition with lock."""
+        _index = None
+        _conf_index = TestConfStoreLock._generate_index()
+        _process_store = []
+        for num in range(0, thread_count):
+            _index = _conf_index + str(num)
+            Conf.load(_index, self.url)
+            _conf_process = Process(target=self.do_lock, args=(_index, repeat, 2), kwargs={ "owner": _index, "duration":self.duration})
+            _process_store.append(_conf_process)
+        
+        for _proc in _process_store:
+            _proc.start()
+
+    def test_multiple_lock_unlock(self, thread_count:int=2, repeat=1):
+        """Test race condition with lock."""
+        _index = None
+        _conf_index = TestConfStoreLock._generate_index()
+        _process_store = []
+        for num in range(0, thread_count):
+            _index = _conf_index + str(num)
+            Conf.load(_index, self.url)
+            _conf_process = Process(target=self.lock_unlock, args=(_index, repeat), kwargs={ "owner": _index, "duration":self.duration})
+            _process_store.append(_conf_process)
+        
+        for _proc in _process_store:
+            _proc.start()
+            _proc.join()
+    
+    def test_multiple_lock_reset_lock(self, thread_count:int=2, repeat=1):
+        """Test race condition with lock."""
+        _index = None
+        _conf_index = TestConfStoreLock._generate_index()
+        _process_store = []
+        for num in range(0, thread_count):
+            _index = _conf_index + str(num)
+            Conf.load(_index, self.url)
+            _conf_process = Process(target=self.lock_reset_lock, args=(_index, repeat), kwargs={ "owner": _index })
+            _process_store.append(_conf_process)
+        
+        for _proc in _process_store:
+            _proc.start()
+            _proc.join()
+
+    def test_multiple_lock_and_test_lock(self, thread_count=2, repeat=1):
+        """Test race condition with lock."""
+        _index = None
+        _conf_index = TestConfStoreLock._generate_index()
+        _process_store = []
+        for num in range(0, thread_count):
+            _index = _conf_index + str(num)
+            Conf.load(_index, self.url)
+            _conf_process = Process(target=self.lock_and_test_lock, args=(_index, repeat), kwargs={ "owner": _index, "duration":self.duration })
+            _process_store.append(_conf_process)
+
+        for _proc in _process_store:
+            _proc.start()
+            _proc.join()
+
+    def test_process_lock_recover(self, thread_count=2, repeat=1):
+        """Test race condition with lock."""
+        _index = None
+        first_index = None
+        _conf_index = TestConfStoreLock._generate_index()
+        _process_store = []
+        for num in range(0, thread_count):
+            _index = _conf_index + str(num)
+            Conf.load(_index, self.url)
+            if first_index is None:
+                first_index = _index
+                _conf_process = Process(target=self.do_lock, args=(_index, 1, 2), kwargs={ "owner": _index , "duration":self.duration})
+                _conf_process.start()
+                sleep(20)
+                print(f"process terminated {first_index}")
+                _conf_process.terminate()
+                continue
+
+            _conf_process = Process(target=self.do_lock, args=(_index, repeat, 5), kwargs={ "owner": _index, "duration":self.duration})
+            _process_store.append(_conf_process)
+
+        for _proc in _process_store:
+            _proc.start()
+            _proc.join()
+        sleep(10)
+        print(f"Process started again {first_index}")
+        _conf_process = Process(target=self.do_lock, args=(first_index, 1, 2), kwargs={ "owner": first_index, "duration":self.duration})
+        _conf_process.start()
+
+    def lock_unlock(self, index, repeat, **kwargs):
+        for rep in range(0, repeat):
+            print(f"Rep {index} {rep+1}")
+            self.do_lock(index, 1, **kwargs)
+            sleep(1)
+            self.do_unlock(index, 1)
+    
+    def lock_reset_lock(self, index, repeat, **kwargs):
+        for rep in range(0, repeat):
+            print(f"Rep {index} {rep+1}")
+            self.do_lock(index, 1, **kwargs)
+            sleep(1)
+            self._reset_lock(index)
+
+    def lock_and_test_lock(self, index, repeat, **kwargs):
+        for rep in range(0, repeat):
+            print(f"Rep {index} {rep+1}")
+            self.do_lock(index, 1, **kwargs)
+            sleep(1)
+            self._test_lock(index, 1)
+            self.do_unlock(index,1)
+            sleep(1)
+            self._test_lock(index, 1)
+    
+    def _test_lock(self, index, repeat):
+        for rep in range(0, repeat):
+            print(f"Test Lock Rep {index} {rep+1}")
+            print(f"{datetime.now()} Test Lock Status for {index}: {Conf.test_lock(index, owner=index)}")
+
+    def do_lock(self, index, repeat=1, sleep_time=0, **kwargs):
+        """lock config."""
+        for rep in range(0, repeat):
+            print(f"Lock Rep {index} {rep+1}")
+            status = Conf.lock(index, **kwargs)
+            if status and index not in TestConfStoreLock.lock_status:
+                TestConfStoreLock.lock_status.append(index)
+                if len(TestConfStoreLock.lock_status) > 1:
+                    print("Error: More than 2 process have acquired the lock")
+                    print(TestConfStoreLock.lock_status)
+                    exit()
+            print(f"{datetime.now()} Lock Status for {index}: {status} ")
+            sleep(sleep_time)
+
+    def do_unlock(self, index, repeat=1):
+        """Unlock config."""
+        for rep in range(0, repeat):
+            print(f"Unlock Rep {index} {rep+1}")
+            status = Conf.unlock(index, owner=index)
+            if status:
+                TestConfStoreLock.lock_status.remove(index)
+            print(f"{datetime.now()} UnLock Status for {index}: {status} ")
+
+    def _reset_lock(self, _index = None):
+        """Reset lock status."""
+        if _index is None:
+            _index = self._generate_index()
+            Conf.load(_index, self.url)
+        status = Conf.unlock(_index, force=True)
+        if status and _index in TestConfStoreLock.lock_status:
+            TestConfStoreLock.lock_status.remove(_index)
+        print(f"{datetime.now()} Reset status: {status}")
+
+    @staticmethod
+    def _generate_index():
+        """Generate random index."""
+        digits = random.choices(string.digits, k=2)
+        letters = random.choices(string.ascii_uppercase, k=9)
+        return ''.join(random.sample(digits + letters, 11))
+
+if __name__ == '__main__':
+    run_count = int(input("Run Count: "))
+    thread_count = int(input("Thread count: "))
+    rep = int(input("Repeat: "))
+    _test_lock = TestConfStoreLock()
+    _test_lock._reset_lock()
+    for run in range(0, run_count):
+        print(f"Run: {run+1}")
+        # from below Call only one function at a time for testing
+        # different test scenarios
+        _test_lock.test_lock_race(thread_count, rep)
+        # _test_lock.test_multiple_lock_unlock(thread_count, rep)
+        # _test_lock.test_multiple_lock_reset_lock(thread_count, rep)
+        # # _test_lock.test_multiple_lock_and_test_lock(thread_count, rep)
+        # _test_lock.test_process_lock_recover(thread_count, rep)


### PR DESCRIPTION
… implementation

Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- Improve lock unlock interfaces code written in utils by adding the duration of lock to be acquired by a thread.

# Design
Added new parameter in lock as duration which will update for how much time a thread can acquire lock.
if a new thread wants to acquire the lock, test_lock() interface will check if the lock_end time which is calculated by duration is less than current time and if the new thread can acquire the lock or not.


# Test Cases

>>> from cortx.utils.conf_store import Conf
>>> Conf.load('p0', 'consul://ssc-vm-g3-rhev4-3306.colo.seagate.com/conf8')
>>> Conf.load('p1', 'consul://ssc-vm-g3-rhev4-3306.colo.seagate.com/conf8')
>>> Conf.load('p2', 'consul://ssc-vm-g3-rhev4-3306.colo.seagate.com/conf8')

1. test "lock" interface
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True

2. test "test_lock" interface
>>> Conf.test_lock('p1', owner='p1', domain='prov')
False

3. test "unlock" interface
>>> Conf.unlock('p0', owner='p0', domain='prov')
True

4. test "lock" repeat
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.lock('p1', owner='p1', domain='prov', duration=30)
False
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True

5. lock at one thread and test “lock” from a different thread
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.lock('p1', owner='p1', domain='prov', duration=30)
False

6. lock at one thread and test “unlock” from a different thread
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.unlock('p1', owner='p1', domain='prov')
False

7. test “unlock” repeat
>>> Conf.unlock('p1', owner='p1', domain='prov')
False
>>> Conf.unlock('p1', owner='p1', domain='prov')
False
>>> Conf.unlock('p1', owner='p1', domain='prov')
False

8. lock with two different domains
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.lock('p0', owner='p0', domain='hare', duration=30)
True

9. lock from one thread and test “unlock with force=true”  from another thread
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True
>>> Conf.unlock('p1', owner='p1', domain='prov', force=True)
True

10. unlock from one thread and test “lock”  from another
>>> Conf.unlock('p1', owner='p1', domain='prov', force=True)
True
>>> Conf.lock('p0', owner='p0', domain='prov', duration=30)
True


# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [x] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
