### PR TITLE
CORTX-33856: str to dict in topology

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,19 @@
+# Set to true to add reviewers to pull requests
+  addReviewers: true
+
+# Set to true to add assignees to pull requests
+  addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+  reviewers: 
+   - sachinpunadikar
+   - ujjwalpl
+   - cdeshmukh
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+  skipKeywords:
+   - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+  numberOfReviewers: 0

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -30,7 +30,7 @@ class Topology:
                'release': {}
                 }
              },
-            'clusters': [],
+            'cluster': [],
             'nodes': [],
             }
 class QueryConfData:
@@ -109,7 +109,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+        _config['cluster'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -54,12 +54,12 @@ class QueryConfData:
         """Return data in dict format."""
         try:
             Conf.load(QueryConfData._query_idx, kv_url)
-        except:
+        except Exception:
             Log.debug(f"confstore {QueryConfData._query_idx} is already loaded")
         _data_keys = Conf.get_keys(QueryConfData._query_idx)
         try:
             Conf.load(QueryConfData._data_idx, QueryConfData._local_conf)
-        except:
+        except Exception:
             Log.debug(f"confstore {QueryConfData._query_idx} is already loaded")
         Conf.copy(QueryConfData._query_idx, QueryConfData._data_idx, _data_keys)
         Conf.save(QueryConfData._data_idx)

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -114,7 +114,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+            _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -49,10 +49,15 @@ class QueryConfData:
 
     def _get_data(self, kv_url: str):
         """Return data in dict format."""
-        Conf.load(QueryConfData._query_idx, kv_url)
+        try:
+            Conf.load(QueryConfData._query_idx, kv_url)
+        except:
+            pass
         _data_keys = Conf.get_keys(QueryConfData._query_idx)
-
-        Conf.load(QueryConfData._data_idx, QueryConfData._local_conf)
+        try:
+            Conf.load(QueryConfData._data_idx, QueryConfData._local_conf)
+        except:
+            pass
         Conf.copy(QueryConfData._query_idx, QueryConfData._data_idx, _data_keys)
         Conf.save(QueryConfData._data_idx)
         for key in Conf.get_keys(QueryConfData._data_idx):

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -19,6 +19,8 @@ import os
 import json
 import errno
 from collections import defaultdict
+
+from cortx.utils.log import Log
 from cortx.utils.conf_store import Conf
 from cortx.utils.conf_store import ConfStore
 from cortx.utils.query_deployment.error import QueryDeploymentError
@@ -53,12 +55,12 @@ class QueryConfData:
         try:
             Conf.load(QueryConfData._query_idx, kv_url)
         except:
-            pass
+            Log.debug(f"confstore {QueryConfData._query_idx} is already loaded")
         _data_keys = Conf.get_keys(QueryConfData._query_idx)
         try:
             Conf.load(QueryConfData._data_idx, QueryConfData._local_conf)
         except:
-            pass
+            Log.debug(f"confstore {QueryConfData._query_idx} is already loaded")
         Conf.copy(QueryConfData._query_idx, QueryConfData._data_idx, _data_keys)
         Conf.save(QueryConfData._data_idx)
         for key in Conf.get_keys(QueryConfData._data_idx):

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -95,8 +95,8 @@ class QueryDeployment:
         _config["cortx"]["common"]["release"] = data['cortx']['common']['release']
 
         # To fetch cluster_info
+        cluster_info = nested_dict()
         for cluster_key, cluster_val in data['cluster'].items():
-            cluster_info = nested_dict()
             storage_set_info = nested_dict()
             storage_set_list=[]
             cluster_info['security'] = data['cortx']['common']['security']
@@ -109,7 +109,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+            _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -25,13 +25,13 @@ from cortx.utils.query_deployment.error import QueryDeploymentError
 
 class Topology:
     topology = {
-           "cortx": {
-            "common": {
-               "release": {}
+           'cortx': {
+            'common': {
+               'release': {}
                 }
              },
-            "cluster": [],
-            "nodes": [],
+            'clusters': [],
+            'nodes': [],
             }
 class QueryConfData:
     """Query Configuration Data."""
@@ -109,7 +109,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['cluster'].append((json.dumps(cluster_info)))
+        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():
@@ -121,7 +121,7 @@ class QueryDeployment:
                     nodes_info['version'] = data['node'][nodes_key]['provisioning']['version']
                 else:
                     nodes_info[key] = val
-            _config["nodes"].append(json.dumps(nodes_info))
+            _config["nodes"].append(json.loads(json.dumps(nodes_info)))
         if os.path.exists(QueryConfData._local_file):
             os.remove(QueryConfData._local_file)
         return _config

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -109,7 +109,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-            _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -24,7 +24,8 @@ from cortx.utils.conf_store import ConfStore
 from cortx.utils.query_deployment.error import QueryDeploymentError
 
 class Topology:
-    topology = {
+    def __init__(self):
+        self.topology = {
            'cortx': {
             'common': {
                'release': {}
@@ -94,7 +95,8 @@ class QueryDeployment:
     def _get_cortx_topology(data: dict) -> dict:
         """ Map gconf fields to topology """
         nested_dict = lambda: defaultdict(nested_dict)
-        _config = Topology.topology
+        topology_obj = Topology()
+        _config = topology_obj.topology
 
         # To fetch common_info
         _config["cortx"]["common"]["release"] = data['cortx']['common']['release']
@@ -129,4 +131,5 @@ class QueryDeployment:
             _config["nodes"].append(json.loads(json.dumps(nodes_info)))
         if os.path.exists(QueryConfData._local_file):
             os.remove(QueryConfData._local_file)
+        del topology_obj
         return _config

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -30,7 +30,7 @@ class Topology:
                'release': {}
                 }
              },
-            'clusters': [],
+            'cluster': [],
             'nodes': [],
             }
 class QueryConfData:
@@ -114,7 +114,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+        _config['cluster'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -30,7 +30,7 @@ class Topology:
                'release': {}
                 }
              },
-            'cluster': [],
+            'clusters': [],
             'nodes': [],
             }
 class QueryConfData:
@@ -114,7 +114,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['cluster'].append((json.loads(json.dumps(cluster_info))))
+        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -114,7 +114,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-            _config['clusters'].append((json.loads(json.dumps(cluster_info))))
+        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():

--- a/py-utils/src/utils/query_deployment/query_deployment.py
+++ b/py-utils/src/utils/query_deployment/query_deployment.py
@@ -30,7 +30,7 @@ class Topology:
                'release': {}
                 }
              },
-            'cluster': [],
+            'clusters': [],
             'nodes': [],
             }
 class QueryConfData:
@@ -109,7 +109,7 @@ class QueryDeployment:
                 cluster_info['storage_set'] = storage_set_list
             else:
                 cluster_info[cluster_key] = cluster_val
-        _config['cluster'].append((json.loads(json.dumps(cluster_info))))
+        _config['clusters'].append((json.loads(json.dumps(cluster_info))))
 
         # To fetch Nodes Info
         for nodes_key in data['node'].keys():


### PR DESCRIPTION
Signed-off-by: Lakshita Jain <lakshita.jain@seagate.com>

# Problem Statement
- The data in clusters field of output topology of query deployment is in string format need to change it into dictionary.

# Design
-  convert json.dumps value to dict by doing json.loads
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [x] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [x] Jira is updated
- [x] Check if the description is clear and explained. 
- [x] Check Acceptance Criterion is defined. 
- [x] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [x] Changes done to WIKI / Confluence page
