### PR TITLE
CORTX-34050: support bundle: rgw log directory not present in server pod logs.

### DIFF
--- a/py-utils/src/utils/support_framework/log_filters.py
+++ b/py-utils/src/utils/support_framework/log_filters.py
@@ -184,7 +184,8 @@ class FilterLog:
         start_time, end_time = FilterLog._parse_duration(duration)
         for file in os.listdir(src_dir):
             op_file = os.path.join(dest_dir, 'tmp_' + file)
-            if file.startswith(file_name_reg_ex):
+            # TODO: Handle time based log collection for rotated files('.gz') files
+            if file.startswith(file_name_reg_ex) and not file.endswith('.gz'):
                 in_file = os.path.join(src_dir, file)
                 with open(in_file, 'r') as fd_in, open(op_file, 'a') as fd_out:
                     line = fd_in.readline()


### PR DESCRIPTION
Problem: 
Support bundle creation is failing in limit_time filter for rotated log (.gz) files.

Solution:
For now to unblock the sanity skip rotated files while applying limit_time filter during log collection.

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>

# Problem Statement
- Problem statement 

# Design
-  For Bug describe the fix here. 
-  For Feature, Post the link to the solution page on the confluence CORTX Foundation Library 

# Coding 
-  Coding conventions are followed and code is consistent [Y/N]: 
-  Confirm All CODACY errors are resolved [Y/N]: 

# Testing
- Are test cases updated along with code changes due to Enhancements/Bugs [Y/N]:
- Confirm that new test cases are added to regression and sanity plan files and relevant feature plan files [Y/N]:
- Confirm that Test Cases are added for new features added [Y/N]: 
- Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability [Y/N]: 
- Confirm Testing was performed with installed RPM/K8s deployment [Y/N]:  

# Review Checklist 
####  Before posting the PR please ensure:
- [ ] PR is self reviewed
- [ ] Is there a change in filename/package/module or signature [Y/N]: 
- [ ] If yes for above point, Is a notification sent to all other cortx components [Y/N]
- [ ] New package/s added to setup.py?
- [ ] Jira is updated
- [ ] Check if the description is clear and explained. 
- [ ] Check Acceptance Criterion is defined. 
- [ ] All the tests performed should be mentioned before Resolving a JIRA. 
- [ ] Verification needs to be done before marked as Closed/Verified.

# KVstore/Confstore feature (changes/fixes) checklist
#### Confirm changes are made for:
- [ ] ConfStore
- [ ] KVStore
- [ ] ConfCli
- [ ] Test cases added for all above 3
- [ ] changes done in all the KVpayloads (ConsulKvPayload, IniKvPayload, KvPayload)

# Documentation
- [ ] Changes done to WIKI / Confluence page
